### PR TITLE
ENG-132962 - Implement Badge component

### DIFF
--- a/src/components/mx-badge/mx-badge.tsx
+++ b/src/components/mx-badge/mx-badge.tsx
@@ -1,0 +1,91 @@
+import { Component, Host, h, Prop, Element } from '@stencil/core';
+
+@Component({
+  tag: 'mx-badge',
+  shadow: false,
+})
+export class MxBadge {
+  childElement: HTMLElement;
+  slotWrapper: HTMLSpanElement;
+
+  @Element() private element: HTMLElement;
+
+  /** The value to display inside the badge */
+  @Prop() value: any;
+  /** Make the corners a little more square (best for standalone text) */
+  @Prop() squared: boolean = false;
+  /** Display as a small dot (no value) */
+  @Prop() dot: boolean = false;
+  /** Additional classes to add to the badge itself */
+  @Prop() badgeClass: string;
+  /** Class name of icon */
+  @Prop() icon: string;
+  /** Place anchored badge further inward */
+  @Prop() tight: boolean = false;
+  /** Place badge even further inward (suitable for icon buttons) */
+  @Prop() snug: boolean = false;
+  /** Anchor the badge to the bottom of the wrapped content */
+  @Prop() bottom: boolean = false;
+  /** Anchor the badge to the left of the wrapped content */
+  @Prop() left: boolean = false;
+
+  get isStandalone() {
+    return !this.element.firstElementChild;
+  }
+
+  get isIconOnly() {
+    return this.icon && this.value === undefined;
+  }
+
+  get badgeClassNames() {
+    let str = 'badge inline-flex items-center justify-center text-sm font-semibold pointer-events-none';
+
+    // Border-Radius
+    if (this.dot || this.isIconOnly) {
+      str += ' rounded-full';
+    } else if (this.squared) {
+      str += ' rounded';
+    } else {
+      str += ' rounded-xl';
+    }
+
+    // Width & Height
+    if (this.dot) {
+      str += ' w-12 h-12';
+    } else if (this.isStandalone) {
+      str += ' h-24';
+      str += this.isIconOnly ? ' w-24' : ' px-8';
+    } else {
+      str += ' h-20';
+      str += this.isIconOnly ? ' w-20' : ' px-6';
+    }
+
+    // Position Anchored Badge
+    if (!this.isStandalone) {
+      const offset = this.tight ? '4' : this.snug ? '10' : '0';
+      str += ' absolute transform';
+      if (this.bottom) {
+        str += ` bottom-${offset} translate-y-1/2`;
+        str += this.left ? ' origin-bottom-left' : ' origin-bottom-right';
+      } else {
+        str += ` top-${offset} -translate-y-1/2`;
+        str += this.left ? ' origin-top-left' : ' origin-top-right';
+      }
+      str += this.left ? ` left-${offset} -translate-x-1/2` : ` right-${offset} translate-x-1/2`;
+    }
+
+    return [str, this.badgeClass].join(' ');
+  }
+
+  render() {
+    return (
+      <Host class="mx-badge inline-flex relative">
+        <slot></slot>
+        <span class={this.badgeClassNames}>
+          {this.icon && <i class={this.icon + (this.isIconOnly ? '' : ' mr-4')}></i>}
+          {this.value}
+        </span>
+      </Host>
+    );
+  }
+}

--- a/src/components/mx-badge/mx-badge.tsx
+++ b/src/components/mx-badge/mx-badge.tsx
@@ -19,10 +19,8 @@ export class MxBadge {
   @Prop() badgeClass: string;
   /** Class name of icon */
   @Prop() icon: string;
-  /** Place anchored badge further inward */
-  @Prop() tight: boolean = false;
-  /** Place badge even further inward (suitable for icon buttons) */
-  @Prop() snug: boolean = false;
+  /** Offset badge inward by this many pixels (e.g. 10 for icon buttons) */
+  @Prop() offset: number = 0;
   /** Anchor the badge to the bottom of the wrapped content */
   @Prop() bottom: boolean = false;
   /** Anchor the badge to the left of the wrapped content */
@@ -61,16 +59,15 @@ export class MxBadge {
 
     // Position Anchored Badge
     if (!this.isStandalone) {
-      const offset = this.tight ? '4' : this.snug ? '10' : '0';
       str += ' absolute transform';
       if (this.bottom) {
-        str += ` bottom-${offset} translate-y-1/2`;
+        str += ` bottom-${this.offset} translate-y-1/2`;
         str += this.left ? ' origin-bottom-left' : ' origin-bottom-right';
       } else {
-        str += ` top-${offset} -translate-y-1/2`;
+        str += ` top-${this.offset} -translate-y-1/2`;
         str += this.left ? ' origin-top-left' : ' origin-top-right';
       }
-      str += this.left ? ` left-${offset} -translate-x-1/2` : ` right-${offset} translate-x-1/2`;
+      str += this.left ? ` left-${this.offset} -translate-x-1/2` : ` right-${this.offset} translate-x-1/2`;
     }
 
     return [str, this.badgeClass].join(' ');

--- a/src/components/mx-badge/mx-badge.tsx
+++ b/src/components/mx-badge/mx-badge.tsx
@@ -6,7 +6,6 @@ import { Component, Host, h, Prop, Element } from '@stencil/core';
 })
 export class MxBadge {
   childElement: HTMLElement;
-  slotWrapper: HTMLSpanElement;
 
   @Element() private element: HTMLElement;
 

--- a/src/components/mx-badge/readme.md
+++ b/src/components/mx-badge/readme.md
@@ -7,17 +7,16 @@
 
 ## Properties
 
-| Property     | Attribute     | Description                                                      | Type      | Default     |
-| ------------ | ------------- | ---------------------------------------------------------------- | --------- | ----------- |
-| `badgeClass` | `badge-class` | Additional classes to add to the badge itself                    | `string`  | `undefined` |
-| `bottom`     | `bottom`      | Anchor the badge to the bottom of the wrapped content            | `boolean` | `false`     |
-| `dot`        | `dot`         | Display as a small dot (no value)                                | `boolean` | `false`     |
-| `icon`       | `icon`        | Class name of icon                                               | `string`  | `undefined` |
-| `left`       | `left`        | Anchor the badge to the left of the wrapped content              | `boolean` | `false`     |
-| `snug`       | `snug`        | Place badge even further inward (suitable for icon buttons)      | `boolean` | `undefined` |
-| `squared`    | `squared`     | Make the corners a little more square (best for standalone text) | `boolean` | `undefined` |
-| `tight`      | `tight`       | Place badge further inward (suitable for rounded buttons)        | `boolean` | `undefined` |
-| `value`      | `value`       | The value to display inside the badge                            | `any`     | `undefined` |
+| Property     | Attribute     | Description                                                        | Type      | Default     |
+| ------------ | ------------- | ------------------------------------------------------------------ | --------- | ----------- |
+| `badgeClass` | `badge-class` | Additional classes to add to the badge itself                      | `string`  | `undefined` |
+| `bottom`     | `bottom`      | Anchor the badge to the bottom of the wrapped content              | `boolean` | `false`     |
+| `dot`        | `dot`         | Display as a small dot (no value)                                  | `boolean` | `false`     |
+| `icon`       | `icon`        | Class name of icon                                                 | `string`  | `undefined` |
+| `left`       | `left`        | Anchor the badge to the left of the wrapped content                | `boolean` | `false`     |
+| `offset`     | `offset`      | Offset badge inward by this many pixels (e.g. 10 for icon buttons) | `number`  | `0`         |
+| `squared`    | `squared`     | Make the corners a little more square (best for standalone text)   | `boolean` | `false`     |
+| `value`      | `value`       | The value to display inside the badge                              | `any`     | `undefined` |
 
 
 ----------------------------------------------

--- a/src/components/mx-badge/readme.md
+++ b/src/components/mx-badge/readme.md
@@ -1,0 +1,25 @@
+# mx-badge
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property     | Attribute     | Description                                                      | Type      | Default     |
+| ------------ | ------------- | ---------------------------------------------------------------- | --------- | ----------- |
+| `badgeClass` | `badge-class` | Additional classes to add to the badge itself                    | `string`  | `undefined` |
+| `bottom`     | `bottom`      | Anchor the badge to the bottom of the wrapped content            | `boolean` | `false`     |
+| `dot`        | `dot`         | Display as a small dot (no value)                                | `boolean` | `false`     |
+| `icon`       | `icon`        | Class name of icon                                               | `string`  | `undefined` |
+| `left`       | `left`        | Anchor the badge to the left of the wrapped content              | `boolean` | `false`     |
+| `snug`       | `snug`        | Place badge even further inward (suitable for icon buttons)      | `boolean` | `undefined` |
+| `squared`    | `squared`     | Make the corners a little more square (best for standalone text) | `boolean` | `undefined` |
+| `tight`      | `tight`       | Place badge further inward (suitable for rounded buttons)        | `boolean` | `undefined` |
+| `value`      | `value`       | The value to display inside the badge                            | `any`     | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/mx-badge/test/mx-badge.spec.tsx
+++ b/src/components/mx-badge/test/mx-badge.spec.tsx
@@ -1,18 +1,104 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { MxBadge } from '../mx-badge';
 
-describe('mx-badge', () => {
-  it('renders', async () => {
-    const page = await newSpecPage({
+describe('mx-badge (standalone, icon + value, squared)', () => {
+  let page;
+  let root;
+  let badge;
+  beforeEach(async () => {
+    page = await newSpecPage({
       components: [MxBadge],
-      html: `<mx-badge></mx-badge>`,
+      html: `<mx-badge icon="ph-apple-logo" value="Apple" squared></mx-badge>`,
     });
-    expect(page.root).toEqualHtml(`
-      <mx-badge>
-        <mock:shadow-root>
-          <slot></slot>
-        </mock:shadow-root>
-      </mx-badge>
-    `);
+    root = page.root;
+    badge = root.querySelector('.badge');
+  });
+
+  it('renders a badge', async () => {
+    expect(badge).not.toBeNull();
+  });
+
+  it('displays the icon', async () => {
+    const icon = badge.querySelector('i');
+    expect(icon).not.toBeNull();
+  });
+
+  it('displays the value', async () => {
+    expect(badge.innerText).toBe('Apple');
+  });
+
+  it('has square-ish corners', async () => {
+    expect(badge.getAttribute('class')).toContain('rounded');
+  });
+});
+
+describe('mx-badge (anchored, value)', () => {
+  let page;
+  let root;
+  let badge;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxBadge],
+      html: `<mx-badge value="3"><div></div></mx-badge>`,
+    });
+    root = page.root;
+    badge = root.querySelector('.badge');
+  });
+
+  it('is positioned in the top right corner by default', async () => {
+    expect(badge.getAttribute('class')).toContain('top-0');
+    expect(badge.getAttribute('class')).toContain('right-0');
+  });
+
+  it('has rounded sides by default', async () => {
+    expect(badge.getAttribute('class')).toContain('rounded-xl');
+  });
+});
+
+describe('mx-badge (anchored, icon, bottom left, snug)', () => {
+  let page;
+  let root;
+  let badge;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxBadge],
+      html: `<mx-badge icon="ph-apple-logo" bottom left snug><div></div></mx-badge>`,
+    });
+    root = page.root;
+    badge = root.querySelector('.badge');
+  });
+
+  it('is positioned snugly in the bottom left corner', async () => {
+    expect(badge.getAttribute('class')).toContain('bottom-10');
+    expect(badge.getAttribute('class')).toContain('left-10');
+  });
+
+  it('is fully rounded', async () => {
+    expect(badge.getAttribute('class')).toContain('rounded-full');
+  });
+});
+
+describe('mx-badge (anchored, dot, tight)', () => {
+  let page;
+  let root;
+  let badge;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxBadge],
+      html: `<mx-badge dot tight><div></div></mx-badge>`,
+    });
+    root = page.root;
+    badge = root.querySelector('.badge');
+  });
+
+  it('is positioned tightly in the top right corner', async () => {
+    expect(badge.getAttribute('class')).toContain('top-4');
+    expect(badge.getAttribute('class')).toContain('right-4');
+  });
+
+  it('is a 12px circle', async () => {
+    expect(badge.getAttribute('class')).toContain('rounded-full');
+    expect(badge.getAttribute('class')).toContain('w-12');
+    expect(badge.getAttribute('class')).toContain('h-12');
   });
 });

--- a/src/components/mx-badge/test/mx-badge.spec.tsx
+++ b/src/components/mx-badge/test/mx-badge.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { MxBadge } from '../mx-badge';
+
+describe('mx-badge', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [MxBadge],
+      html: `<mx-badge></mx-badge>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <mx-badge>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </mx-badge>
+    `);
+  });
+});

--- a/vuepress/.vuepress/config.js
+++ b/vuepress/.vuepress/config.js
@@ -134,7 +134,7 @@ module.exports = {
         'filters',
         'opacity',
       ],
-      '/components/': ['inputs', 'buttons', 'selection-controls'],
+      '/components/': ['inputs', 'buttons', 'selection-controls', 'data-display'],
     },
   },
   plugins: [['fulltext-search']],

--- a/vuepress/components/data-display.md
+++ b/vuepress/components/data-display.md
@@ -1,0 +1,51 @@
+# Data Display
+
+## Badges
+
+A Badge can be used as a standalone component, or it can wrap another element in order to place
+itelf in a corner of that element.
+
+<!-- #region badges -->
+<section class="mds">
+  <div class="mt-10">
+    <strong>Standalone Badges</strong>
+    <div class="flex items-center my-5 space-x-20">
+      <mx-badge badge-class="bg-blue-500 text-white" value="Pending" squared />
+      <mx-badge badge-class="bg-red-800 text-white" value="8" />
+      <mx-badge badge-class="bg-yellow-200" value="999+" />
+      <mx-badge badge-class="bg-green-200 text-green-800" icon="ph-star" value="Popular" squared />
+    </div>
+    <strong>Anchored Badges</strong>
+    <div class="flex items-center my-5 space-x-20">
+      <mx-badge badge-class="bg-purple-500 text-white" value="237">
+        <mx-button btn-type="action" icon="ph-bell">Notifications</mx-button>
+      </mx-badge>
+      <mx-badge badge-class="bg-red-500 text-white" icon="ph-x" bottom snug>
+        <mx-button btn-type="icon" icon="ph-video-camera" />
+      </mx-badge>
+      <mx-badge badge-class="bg-yellow-300" dot tight>
+        <mx-button btn-type="action">Announcements</mx-button>
+      </mx-badge>
+      <mx-badge badge-class="bg-gray-700 text-white" value="3" bottom left snug>
+        <mx-button btn-type="icon" icon="ph-shopping-cart" />
+      </mx-badge>
+    </div>
+  </div>
+</section>
+<!-- #endregion badges -->
+
+<<< @/vuepress/components/data-display.md#badges
+
+### Badge Properties
+
+| Property     | Attribute     | Description                                                      | Type      | Default     |
+| ------------ | ------------- | ---------------------------------------------------------------- | --------- | ----------- |
+| `value`      | `value`       | The value to display inside the badge                            | `any`     | `undefined` |
+| `squared`    | `squared`     | Make the corners a little more square (best for standalone text) | `boolean` | `false`     |
+| `dot`        | `dot`         | Display as a small dot (no value)                                | `boolean` | `false`     |
+| `badgeClass` | `badge-class` | Additional classes to add to the badge itself                    | `string`  | `undefined` |
+| `icon`       | `icon`        | Class name of icon                                               | `string`  | `undefined` |
+| `tight`      | `tight`       | Place anchored badge further inward                              | `boolean` | `false`     |
+| `snug`       | `snug`        | Place badge even further inward (suitable for icon buttons)      | `boolean` | `false`     |
+| `bottom`     | `bottom`      | Anchor the badge to the bottom of the wrapped content            | `boolean` | `false`     |
+| `left`       | `left`        | Anchor the badge to the left of the wrapped content              | `boolean` | `false`     |

--- a/vuepress/components/data-display.md
+++ b/vuepress/components/data-display.md
@@ -20,13 +20,13 @@ itelf in a corner of that element.
       <mx-badge badge-class="bg-purple-500 text-white" value="237">
         <mx-button btn-type="action" icon="ph-bell">Notifications</mx-button>
       </mx-badge>
-      <mx-badge badge-class="bg-red-500 text-white" icon="ph-x" bottom snug>
+      <mx-badge badge-class="bg-red-500 text-white" icon="ph-x" bottom offset="10">
         <mx-button btn-type="icon" icon="ph-video-camera" />
       </mx-badge>
-      <mx-badge badge-class="bg-yellow-300" dot tight>
+      <mx-badge badge-class="bg-yellow-300" dot offset="4">
         <mx-button btn-type="action">Announcements</mx-button>
       </mx-badge>
-      <mx-badge badge-class="bg-gray-700 text-white" value="3" bottom left snug>
+      <mx-badge badge-class="bg-gray-700 text-white" value="3" bottom left offset="10">
         <mx-button btn-type="icon" icon="ph-shopping-cart" />
       </mx-badge>
     </div>
@@ -38,14 +38,13 @@ itelf in a corner of that element.
 
 ### Badge Properties
 
-| Property     | Attribute     | Description                                                      | Type      | Default     |
-| ------------ | ------------- | ---------------------------------------------------------------- | --------- | ----------- |
-| `value`      | `value`       | The value to display inside the badge                            | `any`     | `undefined` |
-| `squared`    | `squared`     | Make the corners a little more square (best for standalone text) | `boolean` | `false`     |
-| `dot`        | `dot`         | Display as a small dot (no value)                                | `boolean` | `false`     |
-| `badgeClass` | `badge-class` | Additional classes to add to the badge itself                    | `string`  | `undefined` |
-| `icon`       | `icon`        | Class name of icon                                               | `string`  | `undefined` |
-| `tight`      | `tight`       | Place anchored badge further inward                              | `boolean` | `false`     |
-| `snug`       | `snug`        | Place badge even further inward (suitable for icon buttons)      | `boolean` | `false`     |
-| `bottom`     | `bottom`      | Anchor the badge to the bottom of the wrapped content            | `boolean` | `false`     |
-| `left`       | `left`        | Anchor the badge to the left of the wrapped content              | `boolean` | `false`     |
+| Property     | Attribute     | Description                                                        | Type      | Default     |
+| ------------ | ------------- | ------------------------------------------------------------------ | --------- | ----------- |
+| `value`      | `value`       | The value to display inside the badge                              | `any`     | `undefined` |
+| `squared`    | `squared`     | Make the corners a little more square (best for standalone text)   | `boolean` | `false`     |
+| `dot`        | `dot`         | Display as a small dot (no value)                                  | `boolean` | `false`     |
+| `badgeClass` | `badge-class` | Additional classes to add to the badge itself                      | `string`  | `undefined` |
+| `icon`       | `icon`        | Class name of icon                                                 | `string`  | `undefined` |
+| `offset`     | `offset`      | Offset badge inward by this many pixels (e.g. 10 for icon buttons) | `number`  | `0`         |
+| `bottom`     | `bottom`      | Anchor the badge to the bottom of the wrapped content              | `boolean` | `false`     |
+| `left`       | `left`        | Anchor the badge to the left of the wrapped content                | `boolean` | `false`     |


### PR DESCRIPTION
This adds a new `mx-badge` component.  The badge can either be standalone/inline, or it can be wrapped onto an element to anchor it to a corner of that element.

![image](https://user-images.githubusercontent.com/3342530/119506302-c756b280-bd3b-11eb-838b-d1ea162e6f64.png)

I had to add two props, `tight` and `snug`, to tweak how far the badge is offset from the corner of the wrapped element.  I wish I could determine this automatically for the consumer, but I think trying to do so would make the component super fragile.

Similarly, the `squared` prop is based on the [standalone badges in the Figma file](https://www.figma.com/file/b36oTkOP6vI6uzLnc7Zd3T/Design-System-(Shirley)?node-id=15386%3A6232).  I believe the intent is to to use the more rounded look for numbers and the more squared look for text.

https://moxiworks.atlassian.net/browse/ENG-132962
