### PR TITLE
ENG-132177 - Selection Control Tweaks

### DIFF
--- a/src/components/mx-switch/mx-switch.tsx
+++ b/src/components/mx-switch/mx-switch.tsx
@@ -14,9 +14,15 @@ export class MxSwitch {
     return (
       <Host class="mx-switch">
         <label class="relative inline-flex flex-nowrap align-center items-center cursor-pointer text-sm w-36 h-14">
-          <input class="absolute h-0 w-0 opacity-0" type="checkbox" name={this.name} checked={this.checked} />
+          <input
+            class="absolute h-0 w-0 opacity-0"
+            role="switch"
+            type="checkbox"
+            name={this.name}
+            checked={this.checked}
+          />
           <span class="slider round"></span>
-          <div class="ml-48 inline-block whitespace-nowrap" data-testid="labelName">
+          <div class="pl-48 inline-block whitespace-nowrap" data-testid="labelName">
             {this.labelName}
           </div>
         </label>

--- a/src/tailwind/mx-checkbox/index.scss
+++ b/src/tailwind/mx-checkbox/index.scss
@@ -3,6 +3,7 @@
     position: relative;
     z-index: 1;
     border: 2px solid #5a5a5a;
+    border-radius: 2px;
 
     &::before {
       content: '';
@@ -40,6 +41,16 @@
       &::before {
         background: rgba(0, 0, 0, 0.12);
       }
+    }
+  }
+
+  :focus-within:focus-visible {
+    & + span::before {
+      display: block;
+      background: rgba(0, 0, 0, 0.12);
+    }
+    &:checked ~ span::before {
+      background: rgba(4, 87, 175, 0.32);
     }
   }
 

--- a/src/tailwind/mx-radio/index.scss
+++ b/src/tailwind/mx-radio/index.scss
@@ -5,6 +5,7 @@
     border: 2px solid #5a5a5a;
 
     &::before {
+      display: none;
       content: '';
       position: absolute;
       top: -12.5px;
@@ -29,6 +30,7 @@
 
     &:hover {
       &::before {
+        display: block;
         background: rgba(0, 0, 0, 0.04);
       }
     }
@@ -37,6 +39,16 @@
       &::before {
         background: rgba(0, 0, 0, 0.12);
       }
+    }
+  }
+
+  :focus-within:focus-visible {
+    & + span::before {
+      display: block;
+      background: rgba(0, 0, 0, 0.12);
+    }
+    &:checked ~ span::before {
+      background: rgba(4, 87, 175, 0.32);
     }
   }
 
@@ -53,6 +65,7 @@
 
     &:active {
       &::before {
+        display: block;
         background: rgba(4, 87, 175, 0.32);
       }
     }

--- a/src/tailwind/mx-switch/index.scss
+++ b/src/tailwind/mx-switch/index.scss
@@ -11,6 +11,7 @@
     transition: 0.4s;
 
     &:before {
+      @apply shadow-1;
       position: absolute;
       content: '';
       height: 20px;
@@ -18,23 +19,28 @@
       left: -1px;
       bottom: -3px;
       background-color: white;
-      box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.04), 0px 2px 2px rgba(0, 0, 0, 0.02), 0px 1px 3px rgba(0, 0, 0, 0.06);
       -webkit-transition: 0.4s;
       transition: 0.4s;
     }
 
-    &:hover {
-      &::after {
-        content: '';
-        position: absolute;
-        top: -12.5px;
-        left: -12.5px;
-        width: 40px;
-        height: 40px;
-        border-radius: 100%;
-        z-index: 0;
-        background: rgba(0, 0, 0, 0.04);
-      }
+    &::after {
+      display: none;
+      content: '';
+      position: absolute;
+      top: -13px;
+      left: -11.5px;
+      width: 40px;
+      height: 40px;
+      border-radius: 100%;
+      z-index: 0;
+    }
+    &:hover::after {
+      display: block;
+      background: rgba(0, 0, 0, 0.04);
+    }
+    &:active::after {
+      display: block;
+      background: rgba(0, 0, 0, 0.12);
     }
   }
 
@@ -42,8 +48,15 @@
     background-color: #abc6e2;
   }
 
-  input:focus + .slider {
-    box-shadow: 0 0 1px #abc6e2;
+  :focus-within:focus-visible + .slider::after {
+    display: block;
+    background: rgba(0, 0, 0, 0.12);
+  }
+
+  input:checked + .slider:active::after,
+  :focus-within:focus-visible:checked + .slider::after {
+    display: block;
+    background: rgba(4, 87, 175, 0.32);
   }
 
   input:checked + .slider:before {

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -4,6 +4,7 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
 
 ## Checkboxes
 
+<!-- #region checkboxes -->
 <div class="mds">
   <div class="my-12 grid grid-flow-row grid-cols-2 gap-4">
     <div><mx-checkbox name="foo" label-name="Premier" checked="true" /></div>
@@ -12,17 +13,9 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
     <div><mx-checkbox name="foo" label-name="Warlock" /></div>
   </div>
 </div>
+<!-- #endregion checkboxes -->
 
-```html
-<div class="mds">
-  <div class="my-12 grid grid-flow-row grid-cols-2 gap-4">
-    <div><mx-checkbox name="foo" label-name="Premier" checked="true" /></div>
-    <div><mx-checkbox name="foo" label-name="W Collection" /></div>
-    <div><mx-checkbox name="foo" label-name="Equestrian" /></div>
-    <div><mx-checkbox name="foo" label-name="Warlock" /></div>
-  </div>
-</div>
-```
+<<< @/vuepress/components/selection-controls.md#checkboxes
 
 ### Properties
 
@@ -35,6 +28,7 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
 
 ## Radio Buttons
 
+<!-- #region radio-buttons -->
 <div class="mds">
   <div class="my-12 grid grid-flow-row grid-cols-2 gap-4">
     <div><mx-radio name="foo" label-name="Premier" /></div>
@@ -43,17 +37,9 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
     <div><mx-radio name="foo" label-name="Warlock" /></div>
   </div>
 </div>
+<!-- #endregion radio-buttons -->
 
-```html
-<div class="mds">
-  <div class="my-12 grid grid-flow-row grid-cols-2 gap-4">
-    <div><mx-radio name="foo" label-name="Premier" /></div>
-    <div><mx-radio name="foo" label-name="W Collection" /></div>
-    <div><mx-radio name="foo" label-name="Equestrian" /></div>
-    <div><mx-radio name="foo" label-name="Warlock" /></div>
-  </div>
-</div>
-```
+<<< @/vuepress/components/selection-controls.md#radio-buttons
 
 ### Properties
 
@@ -66,6 +52,7 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
 
 ## Switches
 
+<!-- #region switches -->
 <div class="mds">
   <div class="my-12 grid grid-flow-row grid-cols-2 gap-4">
     <div><mx-switch name="foo" label-name="Premier" /></div>
@@ -74,17 +61,9 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
     <div><mx-switch name="foo" label-name="Warlock" /></div>
   </div>
 </div>
+<!-- #endregion switches -->
 
-```html
-<div class="mds">
-  <div class="my-12 grid grid-flow-row grid-cols-2 gap-4">
-    <div><mx-switch name="foo" label-name="Premier" /></div>
-    <div><mx-switch name="foo" label-name="W Collection" /></div>
-    <div><mx-switch name="foo" label-name="Equestrian" /></div>
-    <div><mx-switch name="foo" label-name="Warlock" /></div>
-  </div>
-</div>
-```
+<<< @/vuepress/components/selection-controls.md#switches
 
 ### Properties
 


### PR DESCRIPTION
Switches:
- Added missing focus and active states
- Added `switch` ARIA role
- Fixed small dead zone in label by using padding instead of margin for the label text
- Replaced box-shadow with shadow utility class
- Tweaked the centering of the overlay circle (the `.slider::after` pseudoelement)

Checkboxes:
- Added missing focus state
- Added a tiny bit of `border-radius` to match the look in the Figma design

Radio Buttons:
- Added missing focus state

The added focus styles should just show up when tabbing with the keyboard.

While I was making changes to these, I also went ahead and updated the `selection-controls.md` to import the code snippets.