### PR TITLE
ENG-129852 - Typography & Tailwind Config Tweaks

### DIFF
--- a/src/tailwind/styles.css
+++ b/src/tailwind/styles.css
@@ -30,7 +30,7 @@
 * Custom CSS
 ***************************/
 .mds {
-  * {
+  *:not(code, code *) {
     font-family: 'Open Sans', sans-serif;
   }
 

--- a/src/tailwind/styles.css
+++ b/src/tailwind/styles.css
@@ -130,7 +130,7 @@
   }
 
   .subtitle1 {
-    @apply text-base tracking-0-5 leading-6 font-semibold;
+    @apply text-base tracking-0-15 leading-6 font-semibold;
   }
 
   .subtitle2 {
@@ -138,15 +138,15 @@
   }
 
   .subtitle3 {
-    @apply text-sm tracking-0-5 leading-5 font-extrabold;
+    @apply text-sm tracking-0-4 leading-5 font-extrabold;
   }
 
   .subtitle4 {
-    @apply text-xs tracking-0-5 leading-4 font-semibold;
+    @apply text-xs tracking-0-4 leading-4 font-semibold;
   }
 
   .subtitle5 {
-    @apply text-xxs tracking-0-5 leading-4 font-bold;
+    @apply text-xxs tracking-0-3 leading-4 font-bold;
   }
 
   .caption1 {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,20 +19,66 @@ module.exports = {
       '16': '0px 16px 24px rgba(0, 0, 0, 0.04), 0px 6px 30px rgba(0, 0, 0, 0.02), 0px 8px 10px rgba(0, 0, 0, 0.06)',
       '24': '0px 24px 38px rgba(0, 0, 0, 0.04), 0px 9px 46px rgba(0, 0, 0, 0.02), 0px 11px 15px rgba(0, 0, 0, 0.06)',
     },
+    fontSize: {
+      // Font size, line-height, and letter-spacing
+      xxs: ['0.625rem', { lineHeight: '1rem', letterSpacing: '0.019rem' }], // 10px / 16px / 0.3px
+      xs: ['0.75rem', { lineHeight: '1rem', letterSpacing: '0.025rem' }], // 12px / 16px / 0.4px
+      sm: ['0.875rem', { lineHeight: '1.25rem', letterSpacing: '0.016rem' }], // 14px / 20px / 0.25px
+      base: ['1rem', { lineHeight: '1.5rem', letterSpacing: '0.009rem' }], // 16px / 24px / 0.15px
+      lg: ['1.125rem', { lineHeight: '1.5rem', letterSpacing: '0.031rem' }], // 18px / 24px / 0.5px
+      xl: ['1.25rem', { lineHeight: '1.5rem', letterSpacing: '0.031rem' }], // 20px / 24px / 0.5px
+    },
+    letterSpacing: {
+      '0': '0rem',
+      '0-1': '0.006rem',
+      '0-15': '0.009rem',
+      '0-25': '0.016rem',
+      '0-3': '0.019rem',
+      '0-4': '0.025',
+      '0-5': '0.031rem',
+      '1-25': '0.078rem',
+      '1-5': '0.094rem',
+    },
+    spacing: {
+      0: '0px',
+      1: '1px',
+      2: '0.125rem',
+      4: '0.25rem',
+      6: '0.375rem',
+      8: '0.5rem',
+      10: '0.625rem',
+      12: '0.75rem',
+      14: '0.875rem',
+      16: '1rem',
+      18: '1.125rem',
+      20: '1.25rem',
+      24: '1.5rem',
+      28: '1.75rem',
+      32: '2rem',
+      36: '2.25rem',
+      40: '2.5rem',
+      44: '2.75rem',
+      48: '3rem',
+      56: '3.5rem',
+      64: '4rem',
+      72: '4.5rem',
+      80: '5rem',
+      96: '6rem',
+      112: '7rem',
+      128: '8rem',
+      144: '9rem',
+      160: '10rem',
+      176: '11rem',
+      192: '12rem',
+      208: '13rem',
+      224: '14rem',
+      240: '15rem',
+      256: '16rem',
+      288: '18rem',
+      320: '20rem',
+      384: '24rem',
+    },
     extend: {
-      letterSpacing: {
-        'neg-1-5': '-0.094rem', // -1.5px
-        'neg-0-5': '-0.031rem', // -0.5px
-        '0': '0rem',
-        '0-1': '0.006rem',
-        '0-15': '0.009rem',
-        '0-25': '0.016rem',
-        '0-3': '0.019rem',
-        '0-4': '0.025',
-        '0-5': '0.031rem',
-        '1-25': '0.078rem',
-        '1-5': '0.094rem',
-      },
       colors: {
         'primary-text-dark': 'var(--mds-primary-text-dark)', // Dark text primary
         'primary-text-light': 'var(--mds-primary-text-light)', // Light text primary
@@ -59,54 +105,6 @@ module.exports = {
 
         '2xl': '1536px',
         // => @media (min-width: 1536px) { ... }
-      },
-      fontSize: {
-        // Font size and line-height
-        xxs: ['0.625rem', '1rem'], // 10px / 16px
-        xs: ['0.75rem', '1rem'], // 12px / 16px
-        sm: ['0.875rem', '1.25rem'], // 14px / 20px
-        base: ['1rem', '1.5rem'], // 16px / 24px
-        lg: ['1.125rem', '1.5rem'], // 18px / 24px
-        xl: ['1.25rem', '1.5rem'], // 20px / 24px
-      },
-      spacing: {
-        0: '0px',
-        1: '1px',
-        2: '0.125rem',
-        4: '0.25rem',
-        6: '0.375rem',
-        8: '0.5rem',
-        10: '0.625rem',
-        12: '0.75rem',
-        14: '0.875rem',
-        16: '1rem',
-        18: '1.125rem',
-        20: '1.25rem',
-        24: '1.5rem',
-        28: '1.75rem',
-        32: '2rem',
-        36: '2.25rem',
-        40: '2.5rem',
-        44: '2.75rem',
-        48: '3rem',
-        56: '3.5rem',
-        64: '4rem',
-        72: '4.5rem',
-        80: '5rem',
-        96: '6rem',
-        112: '7rem',
-        128: '8rem',
-        144: '9rem',
-        160: '10rem',
-        176: '11rem',
-        192: '12rem',
-        208: '13rem',
-        224: '14rem',
-        240: '15rem',
-        256: '16rem',
-        288: '18rem',
-        320: '20rem',
-        384: '24rem',
       },
     },
   },

--- a/vuepress/components/buttons.md
+++ b/vuepress/components/buttons.md
@@ -7,53 +7,53 @@
   <div class="flex flex-row flex-nowrap justify-between mt-10">
     <div style="width: 47%;">
       <strong>Contained</strong>
-      <div class="my-5">
+      <div class="my-20">
         <mx-button>button</mx-button>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-button disabled>Disabled button</mx-button>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-button xl>XL button</mx-button>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-button disabled xl>XL Disabled button</mx-button>
       </div>
-       <div class="my-5">
+       <div class="my-20">
         <mx-button href="https://google.com" target="_blank">Button as Link</mx-button>
       </div>
     </div>
     <div style="width: 47%;">
       <strong>Outline</strong>
-      <div class="my-5">
+      <div class="my-20">
         <mx-button btn-type="outlined">Outlined button</mx-button>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-button btn-type="outlined" disabled>Outlined button</mx-button>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-button btn-type="outlined" xl>XL outlined button</mx-button>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-button btn-type="outlined" disabled xl>XL outlined Disabled</mx-button>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-button btn-type="outlined" href="https://google.com" target="_blank">Button as Link</mx-button>
       </div>
     </div>
   </div>
   <div>
     <strong>Full</strong>
-    <div class="my-5">
+    <div class="my-20">
       <mx-button full>button</mx-button>
     </div>
-    <div class="my-5">
+    <div class="my-20">
       <mx-button xl full>XL button</mx-button>
     </div>
-    <div class="my-5">
+    <div class="my-20">
       <mx-button btn-type="outlined" full>Outlined button</mx-button>
     </div>
-    <div class="my-5">
+    <div class="my-20">
       <mx-button btn-type="outlined" full xl>XL Outlined button</mx-button>
     </div>
   </div>
@@ -66,19 +66,19 @@
 
 <!-- #region action-buttons -->
 <section class="mds">
-  <div class="my-5">
+  <div class="my-20">
     <mx-button btn-type="action">Button</mx-button>
   </div>
-  <div class="my-5">
+  <div class="my-20">
     <mx-button btn-type="action" icon="ph-apple-logo">Button with Icon</mx-button>
   </div>
-  <div class="my-5">
+  <div class="my-20">
     <mx-button btn-type="action" disabled>Disabled</mx-button>
   </div>
-  <div class="my-5">
+  <div class="my-20">
     <mx-button btn-type="action" dropdown>Dropdown</mx-button>
   </div>
-  <div class="my-5">
+  <div class="my-20">
     <mx-button btn-type="action" dropdown disabled>Disabled</mx-button>
   </div>
 </section>
@@ -90,19 +90,19 @@
 
 <!-- #region text-buttons -->
 <section class="mds">
-  <div class="my-5">
+  <div class="my-20">
     <mx-button btn-type="text">button</mx-button>
   </div>
-  <div class="my-5">
+  <div class="my-20">
     <mx-button btn-type="text" icon="ph-apple-logo">button with icon</mx-button>
   </div>
-  <div class="my-5">
+  <div class="my-20">
     <mx-button btn-type="text" disabled>disabled</mx-button>
   </div>
-  <div class="my-5">
+  <div class="my-20">
     <mx-button btn-type="text" icon="ph-apple-logo" dropdown>Icon with Dropdown</mx-button>
   </div>
-  <div class="my-5">
+  <div class="my-20">
     <mx-button btn-type="text" icon="ph-apple-logo" dropdown disabled>Disabled</mx-button>
   </div>
 </section>
@@ -116,7 +116,7 @@
 <section class="mds">
   <div class="mt-5">
     <div>
-      <div class="flex my-5 items-center">
+      <div class="flex my-20 items-center">
         <mx-button btn-type="icon" icon="ph-thumbs-up"></mx-button>
         <mx-button btn-type="icon" icon="ph-heart"></mx-button>
         <mx-button btn-type="icon" icon="ph-x"></mx-button>
@@ -125,7 +125,7 @@
     </div>
     <div>
       <strong>Disabled</strong>
-      <div class="flex my-5 items-center">
+      <div class="flex my-20 items-center">
         <mx-button btn-type="icon" icon="ph-thumbs-up" disabled></mx-button>
         <mx-button btn-type="icon" icon="ph-heart" disabled></mx-button>
         <mx-button btn-type="icon" icon="ph-x" disabled></mx-button>
@@ -164,24 +164,24 @@ appear as a group. They can act as radio buttons when given a <code>value</code>
   <div class="mt-5 grid grid-cols-1 lg:grid-cols-2">
     <div>
       <strong>Single Button</strong>
-      <div class="my-5">
+      <div class="my-20">
         <mx-toggle-button  icon="ph-microphone-slash" :selected="isMuted" @click="isMuted = !isMuted" />
       </div>
     </div>
     <div>
       <strong>Disabled</strong>
-      <div class="my-5">
+      <div class="my-20">
         <mx-toggle-button  icon="ph-heart" disabled />
       </div>
     </div>
     <div>
       <strong>Multiple Buttons</strong>
-      <div class="flex my-5">
+      <div class="flex my-20">
         <mx-toggle-button icon="ph-text-bolder" :selected="hasStyle('bold')" @click="toggleStyle('bold')" />
         <mx-toggle-button icon="ph-text-italic" :selected="hasStyle('italic')" @click="toggleStyle('italic')" />
         <mx-toggle-button icon="ph-text-underline" :selected="hasStyle('underline')" @click="toggleStyle('underline')" />
       </div>
-      <p class="my-5">Selected: <code>{{ JSON.stringify(textStyles) }}</code></p>
+      <p class="my-20">Selected: <code>{{ JSON.stringify(textStyles) }}</code></p>
     </div>
   </div>
   </div>
@@ -210,18 +210,18 @@ emitted via a custom <code>mxInput</code> event.
   <div class="mt-5 grid grid-cols-1 lg:grid-cols-2">
     <div>
       <strong>Enabled</strong>
-      <div class="my-5">
+      <div class="my-20">
         <mx-toggle-button-group :value="textAlign" @mxInput="e => textAlign = e.detail">
           <mx-toggle-button icon="ph-text-align-left" value="left" />
           <mx-toggle-button icon="ph-text-align-center" value="center" />
           <mx-toggle-button icon="ph-text-align-right" value="right" />
         </mx-toggle-button-group>
       </div>
-      <p class="my-5">Selected: <code>{{ JSON.stringify(textAlign) }}</code></p>
+      <p class="my-20">Selected: <code>{{ JSON.stringify(textAlign) }}</code></p>
     </div>
     <div>
       <strong>Disabled</strong>
-      <div class="my-5">
+      <div class="my-20">
         <mx-toggle-button-group :value="textAlign" @mxInput="e => textAlign = e.detail">
           <mx-toggle-button icon="ph-text-align-left" value="left" disabled />
           <mx-toggle-button icon="ph-text-align-center" value="center" disabled />

--- a/vuepress/components/data-display.md
+++ b/vuepress/components/data-display.md
@@ -9,14 +9,14 @@ itelf in a corner of that element.
 <section class="mds">
   <div class="mt-10">
     <strong>Standalone Badges</strong>
-    <div class="flex items-center my-5 space-x-20">
+    <div class="flex items-center my-20 space-x-20">
       <mx-badge badge-class="bg-blue-500 text-white" value="Pending" squared />
       <mx-badge badge-class="bg-red-800 text-white" value="8" />
       <mx-badge badge-class="bg-yellow-200" value="999+" />
       <mx-badge badge-class="bg-green-200 text-green-800" icon="ph-star" value="Popular" squared />
     </div>
     <strong>Anchored Badges</strong>
-    <div class="flex items-center my-5 space-x-20">
+    <div class="flex items-center my-20 space-x-20">
       <mx-badge badge-class="bg-purple-500 text-white" value="237">
         <mx-button btn-type="action" icon="ph-bell">Notifications</mx-button>
       </mx-badge>

--- a/vuepress/components/inputs.md
+++ b/vuepress/components/inputs.md
@@ -9,37 +9,37 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
   <div class="flex flex-row flex-nowrap justify-between">
     <div style="width: 47%;">
       <strong>Regular</strong>
-      <div class="my-5">
+      <div class="my-20">
         <mx-input label="Placeholder"></mx-input>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-input label="Placeholder & Left Icon" left-icon="ph-apple-logo"></mx-input>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-input label="Placeholder & Right Icon" right-icon="ph-apple-logo"></mx-input>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-input label="Placeholder & Assistive Text" assistive-text="Helpful text about input"></mx-input>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-input label="Placeholder & Right Icon" value="Some Error" error></mx-input>
       </div>
     </div>
     <div style="width: 47%;">
       <strong>Dense</strong>
-      <div class="my-5">
+      <div class="my-20">
         <mx-input label="Placeholder" dense></mx-input>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-input label="Placeholder & Left Icon" left-icon="ph-apple-logo" dense></mx-input>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-input label="Placeholder & Right Icon" right-icon="ph-apple-logo" dense></mx-input>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-input label="Placeholder & Assistive Text" assistive-text="Helpful text about input" dense></mx-input>
       </div>
-      <div class="my-5">
+      <div class="my-20">
         <mx-input label="Placeholder & Right Icon" right-icon="ph-apple-logo" value="Some Error" error dense></mx-input>
       </div>
     </div>

--- a/vuepress/css-documentation/typography.md
+++ b/vuepress/css-documentation/typography.md
@@ -4,7 +4,9 @@ Documentation and examples around typography including headings, body text, list
 
 ## Headings
 
-Heading examples for the Moxi Design System.
+The headings in the MoxiWorks Design System comprise the `h1` through `h6` elements. The `h1` can become extra large with an `xl` utility class, and `h3` through `h6` can be given extra weight with an `emphasis` class.
+
+### Examples
 
 <div class="mds">
   <h1 class="xl">This is an Extra Large H1</h1>
@@ -28,13 +30,13 @@ Heading examples for the Moxi Design System.
   <h3 class="emphasis">This is an H3 with emphasis</h3>
 
 ```html
-<h3 class="emphasis">This is an H3</h3>
+<h3 class="emphasis">This is an H3 with emphasis</h3>
 ```
 
-  <h3>This is an H3</h3>
+  <h3>This is an H3 without emphasis</h3>
 
 ```html
-<h3>This is an H3 Without Bold</h3>
+<h3>This is an H3 without emphasis</h3>
 ```
 
   <h4 class="emphasis">This is an H4 with emphasis</h4>
@@ -43,10 +45,10 @@ Heading examples for the Moxi Design System.
 <h4 class="emphasis">This is an H4</h4>
 ```
 
-  <h4>This is an H4</h4>
+  <h4>This is an H4 without emphasis</h4>
 
 ```html
-<h4>This is an H4 Without Bold</h4>
+<h4>This is an H4 without emphasis</h4>
 ```
 
   <h5 class="emphasis">This is an H5 with emphasis</h5>
@@ -55,287 +57,292 @@ Heading examples for the Moxi Design System.
 <h5 class="emphasis">This is an H5 with emphasis</h5>
 ```
 
-  <h5>This is an H5</h5>
+  <h5>This is an H5 without emphasis</h5>
 
 ```html
-<h5>This is an H5 Without Bold</h5>
+<h5>This is an H5 without emphasis</h5>
 ```
 
   <h6 class="emphasis">This is an H6 with emphasis</h6>
 
 ```html
-<h6 class="emphasis">This is an H6</h6>
+<h6 class="emphasis">This is an H6 with emphasis</h6>
 ```
 
-  <h6>This is an H6 Without Bold</h6>
+  <h6>This is an H6 without emphasis</h6>
 
 ```html
-<h6>This is an H6 Without Bold</h6>
+<h6>This is an H6 without emphasis</h6>
 ```
 
 </div>
 
 ## Body Fonts & Font Size
 
-In the moxi design system, the default body font size is 16px. To achieve the base font simply add the `mds` class to your body tag or a containing div you desire the implementation.
+In the Moxi Design System, the default body font size is **16px**. To achieve the base font simply add the `mds` class to your body tag or a containing div you desire the implementation.
 
 ```html
 <body class="mds"></body>
 ```
 
-After the default body class font size, there are three other classes which can be used to adjust if the design spec calls for it.
+After the default body class font size, there are five other classes which can be used to adjust if the design spec calls for it.
 
-| Class      | Description                 |
-| ---------- | --------------------------- |
-| .text-xxs  | 10px or 0.625rem font size  |
-| .text-xs   | 12px or 0.75rem font size.  |
-| .text-sm   | 14px or 0.875rem font size. |
-| .text-base | 16px or 1 rem font size.    |
-| .text-lg   | 18px or 1.125rem font size. |
-| .text-xl   | 24px or 1.25rem font size.  |
+| Class       | Size            | Line-Height    | Letter-Spacing |
+| ----------- | --------------- | -------------- | -------------- |
+| `text-xxs`  | 10px (0.625rem) | 16px (1rem)    | 0.3px          |
+| `text-xs`   | 12px (0.75rem)  | 16px (1rem)    | 0.4px          |
+| `text-sm`   | 14px (0.875rem) | 20px (1.25rem) | 0.25px         |
+| `text-base` | 16px (1rem)     | 24px (1.5rem)  | 0.15px         |
+| `text-lg`   | 18px (1.125rem) | 24px (1.5rem)  | 0.5px          |
+| `text-xl`   | 20px (1.25rem)  | 24px (1.5rem)  | 0.5px          |
+
+### Examples
+
+<!-- #region font-size -->
+<div class="mds">
+  <div class="bg-white p-16 mt-16 border rounded-lg">
+    <p class="my-6 text-xxs">This is xx-small text.</p>
+    <p class="my-6 text-xs">This is x-small text.</p>
+    <p class="my-6 text-sm">This is small text.</p>
+    <p class="my-6 text-base">This is base body text.</p>
+    <p class="my-6 text-lg">This is large text.</p>
+    <p class="my-6 text-xl">This is x-large text.</p>
+  </div>
+</div>
+<!-- #endregion font-size -->
+
+<<<@/vuepress/css-documentation/typography.md#font-size
 
 ## Subtitles
 
 There are currently 5 subtitle variants available via special classes.
 
-| Class      | Description                                             |
-| ---------- | ------------------------------------------------------- |
-| .subtitle1 | 16px, SemiBold, 24px line-height, 0.15px letter spacing |
-| .subtitle2 | 14px, SemiBold, 20px line-height, 0.4px letter spacing  |
-| .subtitle3 | 14px, ExtraBold, 20px line-height, 0.4px letter spacing |
-| .subtitle4 | 12px, SemiBold, 16px line-height, 0.4px letter spacing  |
-| .subtitle5 | 10px, Bold, 16px line-height, 0.3px letter spacing      |
+| Class       | Size            | Weight    | Line-Height    | Letter-Spacing |
+| ----------- | --------------- | --------- | -------------- | -------------- |
+| `subtitle1` | 16px (1rem)     | SemiBold  | 24px (1.5rem)  | 0.15px         |
+| `subtitle2` | 14px (0.875rem) | SemiBold  | 20px (1.25rem) | 0.4px          |
+| `subtitle3` | 14px (0.875rem) | ExtraBold | 20px (1.25rem) | 0.4px          |
+| `subtitle4` | 12px (0.75rem)  | SemiBold  | 16px (1rem)    | 0.4px          |
+| `subtitle5` | 10px (0.625rem) | Bold      | 16px (1rem)    | 0.3px          |
 
 ### Examples
 
+<!-- #region subtitles -->
 <div class="mds">
-  <p class="my-6 subtitle1">Subtitle 1</p>
-  <p class="my-6 subtitle2">Subtitle 2</p>
-  <p class="my-6 subtitle3">Subtitle 3</p>
-  <p class="my-6 subtitle4">Subtitle 4</p>
-  <p class="my-6 subtitle5">Subtitle 5</p>
+  <div class="bg-white p-16 mt-16 border rounded-lg">
+    <p class="my-6 subtitle1">Subtitle 1</p>
+    <p class="my-6 subtitle2">Subtitle 2</p>
+    <p class="my-6 subtitle3">Subtitle 3</p>
+    <p class="my-6 subtitle4">Subtitle 4</p>
+    <p class="my-6 subtitle5">Subtitle 5</p>
+  </div>
 </div>
+<!-- #endregion subtitles -->
 
-```html
-<div class="mds">
-  <p class="my-6 subtitle1">Subtitle 1</p>
-  <p class="my-6 subtitle2">Subtitle 2</p>
-  <p class="my-6 subtitle3">Subtitle 3</p>
-  <p class="my-6 subtitle4">Subtitle 4</p>
-  <p class="my-6 subtitle5">Subtitle 5</p>
-</div>
-```
+<<<@/vuepress/css-documentation/typography.md#subtitles
 
 ## Captions
 
-| Class     | Description                                  |
-| --------- | -------------------------------------------- |
-| .caption1 | 12px, 16px line-height, 0.3px letter spacing |
-| .caption2 | 14px, 16px line-height, 0.3px letter spacing |
+| Class      | Size            | Line-Height | Letter-Spacing |
+| ---------- | --------------- | ----------- | -------------- |
+| `caption1` | 12px (0.75rem)  | 16px (1rem) | 0.3px          |
+| `caption2` | 10px (0.625rem) | 16px (1rem) | 0.3px          |
 
 ### Examples
 
+<!-- #region captions -->
 <div class="mds">
-  <p class="my-6 caption1">Caption 1</p>
-  <p class="my-6 caption2">Caption 2</p>
+  <div class="bg-white p-16 mt-16 border rounded-lg">
+    <p class="my-6 caption1">Caption 1</p>
+    <p class="my-6 caption2">Caption 2</p>
+  </div>
 </div>
+<!-- #endregion captions -->
 
-```html
-<div class="mds">
-  <p class="my-6 caption1">Caption 1</p>
-  <p class="my-6 caption2">Caption 2</p>
-</div>
-```
+<<<@/vuepress/css-documentation/typography.md#captions
 
-## Overline
+## Overlines
 
-| Class      | Description                                                       |
-| ---------- | ----------------------------------------------------------------- |
-| .overline1 | 18px, SemiBold, 24px line-height, 1.5px letter spacing, uppercase |
-| .overline2 | 12px, Regular, 16px line-height, 1.5px letter spacing, uppercase  |
+| Class       | Size            | Weight              | Line-Height   | Letter-Spacing |
+| ----------- | --------------- | ------------------- | ------------- | -------------- |
+| `overline1` | 18px (1.125rem) | SemiBold, Uppercase | 24px (1.5rem) | 1.5px          |
+| `overline2` | 12px (0.75rem)  | Regular, Uppercase  | 16px (1rem)   | 1.5px          |
 
 ### Examples
 
+<!-- #region overlines -->
 <div class="mds">
-  <p class="my-6 overline1">Overline 1</p>
-  <p class="my-6 overline2">Overline 2</p>
+  <div class="bg-white p-16 mt-16 border rounded-lg">
+    <p class="my-6 overline1">Overline 1</p>
+    <p class="my-6 overline2">Overline 2</p>
+  </div>
 </div>
+<!-- #endregion overlines -->
 
-```html
-<div class="mds">
-  <p class="my-6 caption1">Caption 1</p>
-  <p class="my-6 caption2">Caption 2</p>
-</div>
-```
+<<<@/vuepress/css-documentation/typography.md#overlines
 
 ## Font Style
 
-| Class      | Properties          |
-| ---------- | ------------------- |
-| italic     | font-style: italic; |
-| not-italic | font-style: normal; |
+| Class        | Properties            |
+| ------------ | --------------------- |
+| `italic`     | `font-style: italic;` |
+| `not-italic` | `font-style: normal;` |
 
 ## Font Weight
 
-| Class           | Properties        |
-| --------------- | ----------------- |
-| font-thin       | font-weight: 100; |
-| font-extralight | font-weight: 200; |
-| font-light      | font-weight: 300; |
-| font-normal     | font-weight: 400; |
-| font-medium     | font-weight: 500; |
-| font-semibold   | font-weight: 600; |
-| font-bold       | font-weight: 700; |
-| font-extrabold  | font-weight: 800; |
-| font-black      | font-weight: 900; |
+| Class             | Properties          |
+| ----------------- | ------------------- |
+| `font-thin`       | `font-weight: 100;` |
+| `font-extralight` | `font-weight: 200;` |
+| `font-light`      | `font-weight: 300;` |
+| `font-normal`     | `font-weight: 400;` |
+| `font-medium`     | `font-weight: 500;` |
+| `font-semibold`   | `font-weight: 600;` |
+| `font-bold`       | `font-weight: 700;` |
+| `font-extrabold`  | `font-weight: 800;` |
+| `font-black`      | `font-weight: 900;` |
 
 ## Font Variant Numeric
 
-| Class              | Properties                                |
-| ------------------ | ----------------------------------------- |
-| normal-nums        | font-variant-numeric: normal;             |
-| ordinal            | font-variant-numeric: ordinal;            |
-| slashed-zero       | font-variant-numeric: slashed-zero;       |
-| lining-nums        | font-variant-numeric: lining-nums;        |
-| oldstyle-nums      | font-variant-numeric: oldstyle-nums;      |
-| proportional-nums  | font-variant-numeric: proportional-nums;  |
-| tabular-nums       | font-variant-numeric: tabular-nums;       |
-| diagonal-fractions | font-variant-numeric: diagonal-fractions; |
-| stacked-fractions  | font-variant-numeric: stacked-fractions;  |
+| Class                | Properties                                  |
+| -------------------- | ------------------------------------------- |
+| `normal-nums`        | `font-variant-numeric: normal;`             |
+| `ordinal`            | `font-variant-numeric: ordinal;`            |
+| `slashed-zero`       | `font-variant-numeric: slashed-zero;`       |
+| `lining-nums`        | `font-variant-numeric: lining-nums;`        |
+| `oldstyle-nums`      | `font-variant-numeric: oldstyle-nums;`      |
+| `proportional-nums`  | `font-variant-numeric: proportional-nums;`  |
+| `tabular-nums`       | `font-variant-numeric: tabular-nums;`       |
+| `diagonal-fractions` | `font-variant-numeric: diagonal-fractions;` |
+| `stacked-fractions`  | `font-variant-numeric: stacked-fractions;`  |
 
 ## Letter Spacing
 
-| Class            | Properties |
-| ---------------- | ---------- |
-| tracking-neg-1-5 | -0.094rem  |
-| tracking-neg-0-5 | -0.031rem  |
-| tracking-0       | 0rem       |
-| tracking-0-1     | 0.006rem   |
-| tracking-0-15    | 0.009rem   |
-| tracking-0-25    | 0.016rem   |
-| tracking-0-3     | 0.019rem   |
-| tracking-0-4     | 0.025,     |
-| tracking-0-5     | 0.031rem   |
-| tracking-1-25    | 0.078rem   |
-| tracking-1-5     | 0.094rem   |
+| Class           | Properties                  |
+| --------------- | --------------------------- |
+| `tracking-0`    | `letter-spacing: 0rem`;     |
+| `tracking-0-1`  | `letter-spacing: 0.006rem;` |
+| `tracking-0-15` | `letter-spacing: 0.009rem;` |
+| `tracking-0-25` | `letter-spacing: 0.016rem;` |
+| `tracking-0-3`  | `letter-spacing: 0.019rem;` |
+| `tracking-0-4`  | `letter-spacing: 0.025;`    |
+| `tracking-0-5`  | `letter-spacing: 0.031rem;` |
+| `tracking-1-25` | `letter-spacing: 0.078rem;` |
+| `tracking-1-5`  | `letter-spacing: 0.094rem;` |
 
 ## Line Height
 
-| Class           | Properties            |
-| --------------- | --------------------- |
-| leading-3       | line-height: .75rem;  |
-| leading-4       | line-height: 1rem;    |
-| leading-5       | line-height: 1.25rem; |
-| leading-6       | line-height: 1.5rem;  |
-| leading-7       | line-height: 1.75rem; |
-| leading-8       | line-height: 2rem;    |
-| leading-9       | line-height: 2.25rem; |
-| leading-10      | line-height: 2.5rem;  |
-| leading-none    | line-height: 1;       |
-| leading-tight   | line-height: 1.25;    |
-| leading-snug    | line-height: 1.375;   |
-| leading-normal  | line-height: 1.5;     |
-| leading-relaxed | line-height: 1.625;   |
-| leading-loose   | line-height: 2;       |
+| Class             | Properties              |
+| ----------------- | ----------------------- |
+| `leading-3`       | `line-height: .75rem;`  |
+| `leading-4`       | `line-height: 1rem;`    |
+| `leading-5`       | `line-height: 1.25rem;` |
+| `leading-6`       | `line-height: 1.5rem;`  |
+| `leading-7`       | `line-height: 1.75rem;` |
+| `leading-8`       | `line-height: 2rem;`    |
+| `leading-9`       | `line-height: 2.25rem;` |
+| `leading-10`      | `line-height: 2.5rem;`  |
+| `leading-none`    | `line-height: 1;`       |
+| `leading-tight`   | `line-height: 1.25;`    |
+| `leading-snug`    | `line-height: 1.375;`   |
+| `leading-normal`  | `line-height: 1.5;`     |
+| `leading-relaxed` | `line-height: 1.625;`   |
+| `leading-loose`   | `line-height: 2;`       |
 
 ## List Style Type
 
-| Class        | Properties                |
-| ------------ | ------------------------- |
-| list-none    | list-style-type: none;    |
-| list-disc    | list-style-type: disc;    |
-| list-decimal | list-style-type: decimal; |
+| Class          | Properties                  |
+| -------------- | --------------------------- |
+| `list-none`    | `list-style-type: none;`    |
+| `list-disc`    | `list-style-type: disc;`    |
+| `list-decimal` | `list-style-type: decimal;` |
 
 ## List Style Position
 
-| Class        | Properties                    |
-| ------------ | ----------------------------- |
-| list-inside  | list-style-position: inside;  |
-| list-outside | list-style-position: outside; |
+| Class          | Properties                      |
+| -------------- | ------------------------------- |
+| `list-inside`  | `list-style-position: inside;`  |
+| `list-outside` | `list-style-position: outside;` |
 
 ## Text Alignment
 
-| Class        | Properties           |
-| ------------ | -------------------- |
-| text-left    | text-align: left;    |
-| text-center  | text-align: center;  |
-| text-right   | text-align: right;   |
-| text-justify | text-align: justify; |
+| Class          | Properties             |
+| -------------- | ---------------------- |
+| `text-left`    | `text-align: left;`    |
+| `text-center`  | `text-align: center;`  |
+| `text-right`   | `text-align: right;`   |
+| `text-justify` | `text-align: justify;` |
 
 ## Text Opacity
 
-| Class            | Properties               |
-| ---------------- | ------------------------ |
-| text-opacity-0   | --tw-text-opacity: 0;    |
-| text-opacity-5   | --tw-text-opacity: 0.05; |
-| text-opacity-10  | --tw-text-opacity: 0.1;  |
-| text-opacity-20  | --tw-text-opacity: 0.2;  |
-| text-opacity-25  | --tw-text-opacity: 0.25; |
-| text-opacity-30  | --tw-text-opacity: 0.3;  |
-| text-opacity-40  | --tw-text-opacity: 0.4;  |
-| text-opacity-50  | --tw-text-opacity: 0.5;  |
-| text-opacity-60  | --tw-text-opacity: 0.6;  |
-| text-opacity-70  | --tw-text-opacity: 0.7;  |
-| text-opacity-75  | --tw-text-opacity: 0.75; |
-| text-opacity-80  | --tw-text-opacity: 0.8;  |
-| text-opacity-90  | --tw-text-opacity: 0.9;  |
-| text-opacity-95  | --tw-text-opacity: 0.95; |
-| text-opacity-100 | --tw-text-opacity: 1;    |
+| Class              | Properties                 |
+| ------------------ | -------------------------- |
+| `text-opacity-0`   | `--tw-text-opacity: 0;`    |
+| `text-opacity-5`   | `--tw-text-opacity: 0.05;` |
+| `text-opacity-10`  | `--tw-text-opacity: 0.1;`  |
+| `text-opacity-20`  | `--tw-text-opacity: 0.2;`  |
+| `text-opacity-25`  | `--tw-text-opacity: 0.25;` |
+| `text-opacity-30`  | `--tw-text-opacity: 0.3;`  |
+| `text-opacity-40`  | `--tw-text-opacity: 0.4;`  |
+| `text-opacity-50`  | `--tw-text-opacity: 0.5;`  |
+| `text-opacity-60`  | `--tw-text-opacity: 0.6;`  |
+| `text-opacity-70`  | `--tw-text-opacity: 0.7;`  |
+| `text-opacity-75`  | `--tw-text-opacity: 0.75;` |
+| `text-opacity-80`  | `--tw-text-opacity: 0.8;`  |
+| `text-opacity-90`  | `--tw-text-opacity: 0.9;`  |
+| `text-opacity-95`  | `--tw-text-opacity: 0.95;` |
+| `text-opacity-100` | `--tw-text-opacity: 1;`    |
 
 ## Text Decoration
 
-| Class        | Properties                     |
-| ------------ | ------------------------------ |
-| underline    | text-decoration: underline;    |
-| line-through | text-decoration: line-through; |
-| no-underline | text-decoration: none;         |
+| Class          | Properties                       |
+| -------------- | -------------------------------- |
+| `underline`    | `text-decoration: underline;`    |
+| `line-through` | `text-decoration: line-through;` |
+| `no-underline` | `text-decoration: none;`         |
 
 ## Text Transformation
 
-| Class       | Properties                  |
-| ----------- | --------------------------- |
-| uppercase   | text-transform: uppercase;  |
-| lowercase   | text-transform: lowercase;  |
-| capitalize  | text-transform: capitalize; |
-| normal-case | text-transform: none;       |
+| Class         | Properties                    |
+| ------------- | ----------------------------- |
+| `uppercase`   | `text-transform: uppercase;`  |
+| `lowercase`   | `text-transform: lowercase;`  |
+| `capitalize`  | `text-transform: capitalize;` |
+| `normal-case` | `text-transform: none;`       |
 
 ## Text Overflow
 
-| Class             | Properties                                                      |
-| ----------------- | --------------------------------------------------------------- |
-| truncate          | overflow: hidden; text-overflow: ellipsis; white-space: nowrap; |
-| overflow-ellipsis | text-overflow: ellipsis;                                        |
-| overflow-clip     | text-overflow: clip;                                            |
+| Class               | Properties                                                        |
+| ------------------- | ----------------------------------------------------------------- |
+| `truncate`          | `overflow: hidden; text-overflow: ellipsis; white-space: nowrap;` |
+| `overflow-ellipsis` | `text-overflow: ellipsis;`                                        |
+| `overflow-clip`     | `text-overflow: clip;`                                            |
 
 ## Vertical Align
 
-| Class             | Properties                   |
-| ----------------- | ---------------------------- |
-| align-baseline    | vertical-align: baseline;    |
-| align-top         | vertical-align: top;         |
-| align-middle      | vertical-align: middle;      |
-| align-bottom      | vertical-align: bottom;      |
-| align-text-top    | vertical-align: text-top;    |
-| align-text-bottom | vertical-align: text-bottom; |
+| Class               | Properties                     |
+| ------------------- | ------------------------------ |
+| `align-baseline`    | `vertical-align: baseline;`    |
+| `align-top`         | `vertical-align: top;`         |
+| `align-middle`      | `vertical-align: middle;`      |
+| `align-bottom`      | `vertical-align: bottom;`      |
+| `align-text-top`    | `vertical-align: text-top;`    |
+| `align-text-bottom` | `vertical-align: text-bottom;` |
 
 ## Whitespace
 
-| Class               | Properties             |
-| ------------------- | ---------------------- |
-| whitespace-normal   | white-space: normal;   |
-| whitespace-nowrap   | white-space: nowrap;   |
-| whitespace-pre      | white-space: pre;      |
-| whitespace-pre-line | white-space: pre-line; |
-| whitespace-pre-wrap | white-space: pre-wrap; |
+| Class                 | Properties               |
+| --------------------- | ------------------------ |
+| `whitespace-normal`   | `white-space: normal;`   |
+| `whitespace-nowrap`   | `white-space: nowrap;`   |
+| `whitespace-pre`      | `white-space: pre;`      |
+| `whitespace-pre-line` | `white-space: pre-line;` |
+| `whitespace-pre-wrap` | `white-space: pre-wrap;` |
 
 ## Word Break
 
-| Class        | Properties                                 |
-| ------------ | ------------------------------------------ |
-| break-normal | overflow-wrap: normal; word-break: normal; |
-| break-words  | overflow-wrap: break-word;                 |
-| break-all    | word-break: break-all;                     |
-
-```
-
-```
+| Class          | Properties                                   |
+| -------------- | -------------------------------------------- |
+| `break-normal` | `overflow-wrap: normal; word-break: normal;` |
+| `break-words`  | `overflow-wrap: break-word;`                 |
+| `break-all`    | `word-break: break-all;`                     |


### PR DESCRIPTION
- Fixed the `tracking-*` values for the `subtitle` classes.
- Moved `fontSize`, `letterSpacing`, and `spacing` tailwind config sections out of `extend`.
- Added `letterSpacing` values to our `text-*` utility classes.
- Removed `tracking-neg-0-5` and `tracking-neg-1-5` because you can always do `-tracking-0-5` and `-tracking-1-5`.
- Replaced all uses of `.my-5` (tailwind's 20px margin) in our docs with `.my-20` (our 20px margin).
- Made a lot of changes to `typography.md`, including a few typo fixes.