### PR TITLE
ENG-133039 Tab Components

### DIFF
--- a/src/components/mx-badge/readme.md
+++ b/src/components/mx-badge/readme.md
@@ -19,6 +19,19 @@
 | `value`      | `value`       | The value to display inside the badge                              | `any`     | `undefined` |
 
 
+## Dependencies
+
+### Used by
+
+ - [mx-tab](../mx-tab)
+
+### Graph
+```mermaid
+graph TD;
+  mx-tab --> mx-badge
+  style mx-badge fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/mx-tab-content/mx-tab-content.tsx
+++ b/src/components/mx-tab-content/mx-tab-content.tsx
@@ -1,0 +1,23 @@
+import { Component, Host, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'mx-tab-content',
+  shadow: false,
+})
+export class MxTabContent {
+  /** The index of the tab that corresponds to this content */
+  @Prop() index: number;
+  /** The index of the selected tab */
+  @Prop() value: number;
+
+  get isActiveTab() {
+    return this.value >= 0 && this.index === this.value;
+  }
+  render() {
+    return (
+      <Host class={!this.isActiveTab ? 'hidden' : ''}>
+        <slot></slot>
+      </Host>
+    );
+  }
+}

--- a/src/components/mx-tab-content/readme.md
+++ b/src/components/mx-tab-content/readme.md
@@ -1,0 +1,18 @@
+# mx-tab-content
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property | Attribute | Description                                           | Type     | Default     |
+| -------- | --------- | ----------------------------------------------------- | -------- | ----------- |
+| `index`  | `index`   | The index of the tab that corresponds to this content | `number` | `undefined` |
+| `value`  | `value`   | The index of the selected tab                         | `number` | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/mx-tab-content/test/mx-tab-content.spec.tsx
+++ b/src/components/mx-tab-content/test/mx-tab-content.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { MxTabContent } from '../mx-tab-content';
+
+describe('mx-tab-content', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [MxTabContent],
+      html: `<mx-tab-content></mx-tab-content>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <mx-tab-content>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </mx-tab-content>
+    `);
+  });
+});

--- a/src/components/mx-tab-content/test/mx-tab-content.spec.tsx
+++ b/src/components/mx-tab-content/test/mx-tab-content.spec.tsx
@@ -2,17 +2,27 @@ import { newSpecPage } from '@stencil/core/testing';
 import { MxTabContent } from '../mx-tab-content';
 
 describe('mx-tab-content', () => {
-  it('renders', async () => {
-    const page = await newSpecPage({
+  let page;
+  let contents: NodeListOf<HTMLMxTabContentElement>;
+  beforeEach(async () => {
+    page = await newSpecPage({
       components: [MxTabContent],
-      html: `<mx-tab-content></mx-tab-content>`,
+      html: `
+      <mx-tab-content index="0">First</mx-tab-content>
+      <mx-tab-content index="1">Second</mx-tab-content>
+      `,
     });
-    expect(page.root).toEqualHtml(`
-      <mx-tab-content>
-        <mock:shadow-root>
-          <slot></slot>
-        </mock:shadow-root>
-      </mx-tab-content>
-    `);
+    contents = page.body.querySelectorAll('mx-tab-content');
+  });
+
+  it('does not show any tab content when value is not set', async () => {
+    expect(contents[0].getAttribute('class')).toContain('hidden');
+    expect(contents[1].getAttribute('class')).toContain('hidden');
+  });
+  it('displays content when the value matches its index', async () => {
+    contents.forEach(content => (content.value = 1));
+    await page.waitForChanges();
+    expect(contents[0].getAttribute('class')).toContain('hidden');
+    expect(contents[1].getAttribute('class')).not.toContain('hidden');
   });
 });

--- a/src/components/mx-tab/mx-tab.tsx
+++ b/src/components/mx-tab/mx-tab.tsx
@@ -1,0 +1,71 @@
+import { Component, Host, h, Prop } from '@stencil/core';
+import ripple from '../ripple';
+
+@Component({
+  tag: 'mx-tab',
+  shadow: false,
+})
+export class MxTab {
+  btnElem: HTMLButtonElement;
+
+  /** Label text to display */
+  @Prop() label: string = '';
+  /** If you are not providing a visible label, this should be provided instead for accessibility */
+  @Prop() ariaLabel: string = '';
+  /** Class name of icon to display */
+  @Prop() icon: string = '';
+  @Prop() selected: boolean = false;
+  /** Display a dot badge */
+  @Prop() badge: boolean = false;
+  /** Additional classes for the badge */
+  @Prop() badgeClass: string = '';
+
+  onClick(e: MouseEvent) {
+    ripple(e, this.btnElem);
+  }
+
+  get tabClass() {
+    let str = 'mx-tab relative inline-flex items-center justify-center min-w-full';
+    str += this.label && this.icon ? ' h-72' : ' h-48';
+    return str;
+  }
+
+  get badgeEl() {
+    return <mx-badge dot badgeClass={['w-8 h-8', this.badgeClass].join(' ')} />;
+  }
+
+  render() {
+    return (
+      <Host class={this.tabClass} style={{ width: `${this.badge && this.label ? '133' : '120'}px` }}>
+        <button
+          ref={el => (this.btnElem = el)}
+          role="tab"
+          type="button"
+          aria-selected={this.selected}
+          aria-label={this.label || this.ariaLabel}
+          class="relative overflow-hidden w-full h-full border border-transparent"
+          onClick={this.onClick.bind(this)}
+        >
+          <div class="relative flex flex-col items-center justify-center space-y-6 pointer-events-none">
+            <span class="flex items-center space-x-6">
+              {!this.label && this.badge && this.badgeEl}
+              {this.icon && <i class={this.icon + ' text-xl' + (!this.label ? ' icon-only' : '')}></i>}
+            </span>
+            {this.label && (
+              <span class="flex items-center uppercase text-sm font-semibold leading-4 tracking-1-25 space-x-6">
+                {this.badge && this.badgeEl}
+                <span>{this.label}</span>
+              </span>
+            )}
+          </div>
+        </button>
+        <span
+          class={
+            'active-tab-indicator absolute bottom-0 left-0 w-full h-2 pointer-events-none' +
+            (this.selected ? '' : ' opacity-0')
+          }
+        ></span>
+      </Host>
+    );
+  }
+}

--- a/src/components/mx-tab/mx-tab.tsx
+++ b/src/components/mx-tab/mx-tab.tsx
@@ -10,11 +10,12 @@ export class MxTab {
 
   /** Label text to display */
   @Prop() label: string = '';
-  /** If you are not providing a visible label, this should be provided instead for accessibility */
+  /** If you are not providing a `label`, this should be provided instead for accessibility */
   @Prop() ariaLabel: string = '';
   /** Class name of icon to display */
   @Prop() icon: string = '';
-  @Prop() selected: boolean = false;
+  /** Only set this if you are not using the `mx-tabs` `value` prop */
+  @Prop({ reflect: true }) selected: boolean = false;
   /** Display a dot badge */
   @Prop() badge: boolean = false;
   /** Additional classes for the badge */

--- a/src/components/mx-tab/mx-tab.tsx
+++ b/src/components/mx-tab/mx-tab.tsx
@@ -27,6 +27,7 @@ export class MxTab {
   get tabClass() {
     let str = 'mx-tab relative inline-flex items-center justify-center min-w-full';
     str += this.label && this.icon ? ' h-72' : ' h-48';
+    if (this.badge && this.label) str += ' wider';
     return str;
   }
 
@@ -36,7 +37,7 @@ export class MxTab {
 
   render() {
     return (
-      <Host class={this.tabClass} style={{ width: `${this.badge && this.label ? '133' : '120'}px` }}>
+      <Host class={this.tabClass}>
         <button
           ref={el => (this.btnElem = el)}
           role="tab"

--- a/src/components/mx-tab/readme.md
+++ b/src/components/mx-tab/readme.md
@@ -1,0 +1,35 @@
+# mx-tab
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property     | Attribute     | Description                                                                                 | Type      | Default |
+| ------------ | ------------- | ------------------------------------------------------------------------------------------- | --------- | ------- |
+| `ariaLabel`  | `aria-label`  | If you are not providing a visible label, this should be provided instead for accessibility | `string`  | `''`    |
+| `badge`      | `badge`       | Display a dot badge                                                                         | `boolean` | `false` |
+| `badgeClass` | `badge-class` | Additional classes for the badge                                                            | `string`  | `''`    |
+| `icon`       | `icon`        | Class name of icon to display (optional)                                                    | `string`  | `''`    |
+| `label`      | `label`       | Label text to display (optional)                                                            | `string`  | `''`    |
+| `selected`   | `selected`    |                                                                                             | `boolean` | `false` |
+
+
+## Dependencies
+
+### Depends on
+
+- [mx-badge](../mx-badge)
+
+### Graph
+```mermaid
+graph TD;
+  mx-tab --> mx-badge
+  style mx-tab fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/mx-tab/readme.md
+++ b/src/components/mx-tab/readme.md
@@ -7,14 +7,14 @@
 
 ## Properties
 
-| Property     | Attribute     | Description                                                                                 | Type      | Default |
-| ------------ | ------------- | ------------------------------------------------------------------------------------------- | --------- | ------- |
-| `ariaLabel`  | `aria-label`  | If you are not providing a visible label, this should be provided instead for accessibility | `string`  | `''`    |
-| `badge`      | `badge`       | Display a dot badge                                                                         | `boolean` | `false` |
-| `badgeClass` | `badge-class` | Additional classes for the badge                                                            | `string`  | `''`    |
-| `icon`       | `icon`        | Class name of icon to display (optional)                                                    | `string`  | `''`    |
-| `label`      | `label`       | Label text to display (optional)                                                            | `string`  | `''`    |
-| `selected`   | `selected`    |                                                                                             | `boolean` | `false` |
+| Property     | Attribute     | Description                                                                           | Type      | Default |
+| ------------ | ------------- | ------------------------------------------------------------------------------------- | --------- | ------- |
+| `ariaLabel`  | `aria-label`  | If you are not providing a `label`, this should be provided instead for accessibility | `string`  | `''`    |
+| `badge`      | `badge`       | Display a dot badge                                                                   | `boolean` | `false` |
+| `badgeClass` | `badge-class` | Additional classes for the badge                                                      | `string`  | `''`    |
+| `icon`       | `icon`        | Class name of icon to display                                                         | `string`  | `''`    |
+| `label`      | `label`       | Label text to display                                                                 | `string`  | `''`    |
+| `selected`   | `selected`    | Only set this if you are not using the `mx-tabs` `value` prop                         | `boolean` | `false` |
 
 
 ## Dependencies

--- a/src/components/mx-tab/test/mx-tab.spec.tsx
+++ b/src/components/mx-tab/test/mx-tab.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { MxTab } from '../mx-tab';
+
+describe('mx-tab', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [MxTab],
+      html: `<mx-tab></mx-tab>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <mx-tab>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </mx-tab>
+    `);
+  });
+});

--- a/src/components/mx-tab/test/mx-tab.spec.tsx
+++ b/src/components/mx-tab/test/mx-tab.spec.tsx
@@ -1,18 +1,63 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { MxTab } from '../mx-tab';
+import { MxTabs } from '../../mx-tabs/mx-tabs';
 
-describe('mx-tab', () => {
-  it('renders', async () => {
-    const page = await newSpecPage({
-      components: [MxTab],
-      html: `<mx-tab></mx-tab>`,
+describe('mx-tab (text, selected)', () => {
+  let page;
+  let root: HTMLMxTabsElement;
+  let tab: HTMLMxTabElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxTabs, MxTab],
+      html: `<mx-tabs>
+      <mx-tab selected label="Home" />
+      </mx-tabs>`,
     });
-    expect(page.root).toEqualHtml(`
-      <mx-tab>
-        <mock:shadow-root>
-          <slot></slot>
-        </mock:shadow-root>
-      </mx-tab>
-    `);
+    root = page.root;
+    tab = root.querySelector('mx-tab');
+  });
+
+  it('renders the label text', async () => {
+    expect(tab.innerText).toContain('Home');
+  });
+
+  it('sets the aria-label', async () => {
+    expect(tab.querySelector('[aria-label="Home"]')).not.toBeNull();
+  });
+
+  it('sets aria-selected', async () => {
+    expect(tab.querySelector('[aria-selected]')).not.toBeNull();
+  });
+});
+
+describe('mx-tab (icon, badge, not selected)', () => {
+  let page;
+  let root: HTMLMxTabsElement;
+  let tab: HTMLMxTabElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxTabs, MxTab],
+      html: `<mx-tabs>
+      <mx-tab icon="ph-house" aria-label="Home" badge />
+      </mx-tabs>`,
+    });
+    root = page.root;
+    tab = root.querySelector('mx-tab');
+  });
+
+  it('renders the icon', async () => {
+    expect(tab.querySelector('i')).not.toBeNull();
+  });
+
+  it('renders the badge', async () => {
+    expect(tab.querySelector('mx-badge')).not.toBeNull();
+  });
+
+  it('sets the aria-label', async () => {
+    expect(tab.querySelector('[aria-label="Home"]')).not.toBeNull();
+  });
+
+  it('does not set aria-selected', async () => {
+    expect(tab.querySelector('[aria-selected]')).toBeNull();
   });
 });

--- a/src/components/mx-tabs/mx-tabs.tsx
+++ b/src/components/mx-tabs/mx-tabs.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Listen, Element } from '@stencil/core';
+import { Component, Host, h, Prop, Listen, Element, Watch, Event, EventEmitter } from '@stencil/core';
 
 @Component({
   tag: 'mx-tabs',
@@ -7,6 +7,11 @@ import { Component, Host, h, Prop, Listen, Element } from '@stencil/core';
 export class MxTabs {
   /** Stretch tabs to fill the entire width */
   @Prop() fill: boolean = false;
+  /** The index of the selected tab (not needed if manually setting the `selected` prop on each tab) */
+  @Prop() value: number = null;
+
+  /** Emits the clicked tab's index as `Event.detail` */
+  @Event() mxChange: EventEmitter<number>;
 
   @Element() element: HTMLMxTabsElement;
 
@@ -20,10 +25,44 @@ export class MxTabs {
     this.animateIndicator(e);
   }
 
-  animateIndicator(e: MouseEvent | KeyboardEvent) {
+  // Get the clicked tab's index and emit it via the mxChange event
+  @Listen('click')
+  onClick(e: MouseEvent) {
+    const tab: HTMLMxTabElement = (e.target as HTMLElement).closest('mx-tab');
+    if (!tab) return;
+    const tabs = this.element.querySelectorAll('mx-tab');
+    const tabIndex = Array.prototype.indexOf.call(tabs, tab);
+    if (tabIndex >= 0) this.mxChange.emit(tabIndex);
+  }
+
+  @Watch('value')
+  onValueChange() {
+    this.animateIndicator(null, this.value);
+    this.setSelectedTab();
+  }
+
+  connectedCallback() {
+    if (this.value !== null) this.setSelectedTab();
+  }
+
+  setSelectedTab() {
+    const tabs = this.element.querySelectorAll('mx-tab');
+    tabs.forEach((tab: HTMLMxTabElement, index) => {
+      tab.selected = index === this.value;
+    });
+  }
+
+  animateIndicator(e: MouseEvent | KeyboardEvent, newSelectedTabIndex?: number) {
+    if (this.value !== null && this.value === newSelectedTabIndex) return; // no need to animate
     // Find the distance between the clicked tab and the soon-to-be-deselected tab
     const currentSelectedTab = this.element.querySelector('mx-tab[selected]') as HTMLMxTabElement;
-    const clickedTab = (e.target as HTMLElement).parentElement as HTMLMxTabElement;
+    let clickedTab: HTMLMxTabElement;
+    if (e) {
+      clickedTab = (e.target as HTMLElement).closest('mx-tab');
+    } else if (newSelectedTabIndex >= 0) {
+      const tabs = this.element.querySelectorAll('mx-tab');
+      clickedTab = tabs[newSelectedTabIndex];
+    }
     if (!currentSelectedTab || !clickedTab || clickedTab.tagName !== 'MX-TAB') return;
     const distance = currentSelectedTab.offsetLeft - clickedTab.offsetLeft;
     const indicator = clickedTab.querySelector('.active-tab-indicator') as HTMLElement;

--- a/src/components/mx-tabs/mx-tabs.tsx
+++ b/src/components/mx-tabs/mx-tabs.tsx
@@ -1,0 +1,52 @@
+import { Component, Host, h, Prop, Listen, Element } from '@stencil/core';
+
+@Component({
+  tag: 'mx-tabs',
+  shadow: false,
+})
+export class MxTabs {
+  /** Stretch tabs to fill the entire width */
+  @Prop() fill: boolean = false;
+
+  @Element() element: HTMLMxTabsElement;
+
+  @Listen('keyup')
+  onKeyUp(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') this.animateIndicator(e);
+  }
+  @Listen('mouseup')
+  onMouseUp(e: MouseEvent) {
+    this.animateIndicator(e);
+  }
+
+  animateIndicator(e: MouseEvent | KeyboardEvent) {
+    const currentSelectedTab = this.element.querySelector('mx-tab[selected]') as HTMLMxTabElement;
+    const clickedTab = (e.target as HTMLElement).parentElement as HTMLMxTabElement;
+    if (!currentSelectedTab || !clickedTab || clickedTab.tagName !== 'MX-TAB') return;
+    const deltaX = currentSelectedTab.offsetLeft - clickedTab.offsetLeft;
+    const indicator = clickedTab.querySelector('.active-tab-indicator') as HTMLElement;
+    if (!indicator) return;
+    indicator.style.transform = `translateX(${deltaX}px)`;
+    indicator.style.transition = `none`;
+    setTimeout(() => {
+      indicator.style.transform = `translateX(0)`;
+      indicator.style.transition = `transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)`;
+    }, 0);
+  }
+
+  get gridClass() {
+    let str = this.fill ? 'grid' : 'inline-grid';
+    str += ' grid-flow-col auto-cols-fr';
+    return str;
+  }
+
+  render() {
+    return (
+      <Host class="mx-tabs relative block" role="tablist">
+        <div class={this.gridClass}>
+          <slot></slot>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/mx-tabs/mx-tabs.tsx
+++ b/src/components/mx-tabs/mx-tabs.tsx
@@ -10,6 +10,7 @@ export class MxTabs {
 
   @Element() element: HTMLMxTabsElement;
 
+  // Listen to keyup and mouseup so we can get the selected tab before the click event changes it
   @Listen('keyup')
   onKeyUp(e: KeyboardEvent) {
     if (e.key === 'Enter' || e.key === ' ') this.animateIndicator(e);
@@ -20,14 +21,17 @@ export class MxTabs {
   }
 
   animateIndicator(e: MouseEvent | KeyboardEvent) {
+    // Find the distance between the clicked tab and the soon-to-be-deselected tab
     const currentSelectedTab = this.element.querySelector('mx-tab[selected]') as HTMLMxTabElement;
     const clickedTab = (e.target as HTMLElement).parentElement as HTMLMxTabElement;
     if (!currentSelectedTab || !clickedTab || clickedTab.tagName !== 'MX-TAB') return;
-    const deltaX = currentSelectedTab.offsetLeft - clickedTab.offsetLeft;
+    const distance = currentSelectedTab.offsetLeft - clickedTab.offsetLeft;
     const indicator = clickedTab.querySelector('.active-tab-indicator') as HTMLElement;
     if (!indicator) return;
-    indicator.style.transform = `translateX(${deltaX}px)`;
+    // Position clicked tab's indicator under the tab that is being deselected
+    indicator.style.transform = `translateX(${distance}px)`;
     indicator.style.transition = `none`;
+    // Transition the indicator back to the clicked tab
     setTimeout(() => {
       indicator.style.transform = `translateX(0)`;
       indicator.style.transition = `transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)`;

--- a/src/components/mx-tabs/readme.md
+++ b/src/components/mx-tabs/readme.md
@@ -1,0 +1,17 @@
+# mx-tabs
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property | Attribute | Description                           | Type      | Default |
+| -------- | --------- | ------------------------------------- | --------- | ------- |
+| `fill`   | `fill`    | Stretch tabs to fill the entire width | `boolean` | `false` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/mx-tabs/readme.md
+++ b/src/components/mx-tabs/readme.md
@@ -1,17 +1,20 @@
 # mx-tabs
 
-
-
 <!-- Auto Generated Below -->
-
 
 ## Properties
 
-| Property | Attribute | Description                           | Type      | Default |
-| -------- | --------- | ------------------------------------- | --------- | ------- |
-| `fill`   | `fill`    | Stretch tabs to fill the entire width | `boolean` | `false` |
+| Property | Attribute | Description                                                                                    | Type      | Default |
+| -------- | --------- | ---------------------------------------------------------------------------------------------- | --------- | ------- |
+| `fill`   | `fill`    | Stretch tabs to fill the entire width                                                          | `boolean` | `false` |
+| `value`  | `value`   | The index of the selected tab (not needed if manually setting the `selected` prop on each tab) | `number`  | `null`  |
 
+## Events
 
-----------------------------------------------
+| Event      | Description                                     | Type                  |
+| ---------- | ----------------------------------------------- | --------------------- |
+| `mxChange` | Emits the clicked tab's index as `Event.detail` | `CustomEvent<number>` |
 
-*Built with [StencilJS](https://stenciljs.com/)*
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/mx-tabs/test/mx-tabs.spec.tsx
+++ b/src/components/mx-tabs/test/mx-tabs.spec.tsx
@@ -5,39 +5,42 @@ import { MxTab } from '../../mx-tab/mx-tab';
 describe('mx-tabs (horizontal stack)', () => {
   let page;
   let root: HTMLMxTabsElement;
+  let tabs: NodeListOf<HTMLMxTabElement>;
   beforeEach(async () => {
     page = await newSpecPage({
       components: [MxTabs, MxTab],
       html: `<mx-tabs>
       <mx-tab label="Home" />
-      <mx-tab selected label="Search" />
+      <mx-tab label="Search" />
       </mx-tabs>`,
     });
     root = page.root;
+    tabs = root.querySelectorAll('mx-tab');
   });
 
   it('renders an inline grid by default', async () => {
     const grid = root.firstElementChild;
     expect(grid.getAttribute('class')).toContain('inline-grid');
   });
-});
-
-describe('mx-tabs (horizontal fill)', () => {
-  let page;
-  let root: HTMLMxTabsElement;
-  beforeEach(async () => {
-    page = await newSpecPage({
-      components: [MxTabs, MxTab],
-      html: `<mx-tabs fill>
-      <mx-tab label="Home" />
-      <mx-tab selected label="Search" />
-      </mx-tabs>`,
-    });
-    root = page.root;
-  });
 
   it('renders a grid with the fill prop', async () => {
+    root.fill = true;
+    await page.waitForChanges();
     const grid = root.firstElementChild;
     expect(grid.getAttribute('class')).toContain('grid');
+  });
+
+  it('sets a tab as selected based on the value prop', async () => {
+    expect(tabs[1].selected).toBe(false);
+    root.value = 1;
+    await page.waitForChanges();
+    expect(tabs[1].selected).toBe(true);
+  });
+
+  it('emits an mxChange event when a tab is clicked', async () => {
+    let emittedValue;
+    root.addEventListener('mxChange', (e: CustomEvent) => (emittedValue = e.detail));
+    tabs[1].click();
+    expect(emittedValue).toBe(1);
   });
 });

--- a/src/components/mx-tabs/test/mx-tabs.spec.tsx
+++ b/src/components/mx-tabs/test/mx-tabs.spec.tsx
@@ -1,18 +1,43 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { MxTabs } from '../mx-tabs';
+import { MxTab } from '../../mx-tab/mx-tab';
 
-describe('mx-tabs', () => {
-  it('renders', async () => {
-    const page = await newSpecPage({
-      components: [MxTabs],
-      html: `<mx-tabs></mx-tabs>`,
+describe('mx-tabs (horizontal stack)', () => {
+  let page;
+  let root: HTMLMxTabsElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxTabs, MxTab],
+      html: `<mx-tabs>
+      <mx-tab label="Home" />
+      <mx-tab selected label="Search" />
+      </mx-tabs>`,
     });
-    expect(page.root).toEqualHtml(`
-      <mx-tabs>
-        <mock:shadow-root>
-          <slot></slot>
-        </mock:shadow-root>
-      </mx-tabs>
-    `);
+    root = page.root;
+  });
+
+  it('renders an inline grid by default', async () => {
+    const grid = root.firstElementChild;
+    expect(grid.getAttribute('class')).toContain('inline-grid');
+  });
+});
+
+describe('mx-tabs (horizontal fill)', () => {
+  let page;
+  let root: HTMLMxTabsElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxTabs, MxTab],
+      html: `<mx-tabs fill>
+      <mx-tab label="Home" />
+      <mx-tab selected label="Search" />
+      </mx-tabs>`,
+    });
+    root = page.root;
+  });
+
+  it('renders a grid with the fill prop', async () => {
+    const grid = root.firstElementChild;
+    expect(grid.getAttribute('class')).toContain('grid');
   });
 });

--- a/src/components/mx-tabs/test/mx-tabs.spec.tsx
+++ b/src/components/mx-tabs/test/mx-tabs.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { MxTabs } from '../mx-tabs';
+
+describe('mx-tabs', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [MxTabs],
+      html: `<mx-tabs></mx-tabs>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <mx-tabs>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </mx-tabs>
+    `);
+  });
+});

--- a/src/tailwind/mx-tab/index.scss
+++ b/src/tailwind/mx-tab/index.scss
@@ -1,0 +1,42 @@
+.mx-tab {
+  .active-tab-indicator {
+    background: #0457af;
+  }
+
+  button {
+    color: #333;
+    --ripple-color: #afc9e6;
+
+    &[aria-selected] {
+      color: #0457af;
+    }
+
+    &:not([aria-selected]) i {
+      color: rgba(0, 0, 0, 0.64);
+      &.icon-only {
+        color: rgba(51, 51, 51, 0.38);
+      }
+    }
+
+    &:focus-visible {
+      background: #d7d7d7;
+      border-bottom-color: #b9b9b9;
+      &[aria-selected] {
+        background: #d7e2ef;
+      }
+    }
+
+    &:hover {
+      background: #eeeeee;
+      border-bottom-color: #b9b9b9;
+      &[aria-selected] {
+        background: #eef1f6;
+      }
+    }
+
+    &:active {
+      background: transparent;
+      border-bottom-color: #b9b9b9;
+    }
+  }
+}

--- a/src/tailwind/mx-tab/index.scss
+++ b/src/tailwind/mx-tab/index.scss
@@ -17,7 +17,7 @@
       color: #0457af;
     }
 
-    &:not([aria-selected]) i {
+    &:not([aria-selected], :active) i {
       color: rgba(0, 0, 0, 0.64);
       &.icon-only {
         color: rgba(51, 51, 51, 0.38);
@@ -42,6 +42,7 @@
 
     &:active {
       background: transparent;
+      color: #0457af;
       border-bottom-color: #b9b9b9;
     }
   }

--- a/src/tailwind/mx-tab/index.scss
+++ b/src/tailwind/mx-tab/index.scss
@@ -1,4 +1,10 @@
 .mx-tab {
+  width: 7.5rem; /* 120px */
+
+  &.wider {
+    width: 8.313rem; /* 133px when there is both a badge and a label */
+  }
+
   .active-tab-indicator {
     background: #0457af;
   }

--- a/src/tailwind/styles.css
+++ b/src/tailwind/styles.css
@@ -24,6 +24,7 @@
 @import './mx-checkbox/index.scss';
 @import './mx-radio/index.scss';
 @import './mx-switch/index.scss';
+@import './mx-tab/index.scss';
 @import './ripple.scss';
 
 /***************************

--- a/vuepress/.vuepress/config.js
+++ b/vuepress/.vuepress/config.js
@@ -134,7 +134,7 @@ module.exports = {
         'filters',
         'opacity',
       ],
-      '/components/': ['inputs', 'buttons', 'selection-controls', 'data-display'],
+      '/components/': ['inputs', 'buttons', 'selection-controls', 'data-display', 'tabs'],
     },
   },
   plugins: [['fulltext-search']],

--- a/vuepress/components/tabs.md
+++ b/vuepress/components/tabs.md
@@ -2,38 +2,45 @@
 
 The Moxi Design System tab implementation consists of an `mx-tabs` component that wraps `mx-tab` components.
 
+A tab becomes selected by either setting its `selected` prop to true, _or_ by passing the selected tab index
+into the parent `mx-tabs` component via the `value` prop. The `mx-tabs` component also emits a custom `mxChange`
+event, which contains the newly selected tab index in the `Event.detail` property.
+
 <!-- #region tabs -->
 <section class="mds">
+  <!-- The first two examples use the `value` prop and `mxChange` event on the `mx-tabs` component. -->
   <div class="my-20">
     <strong>Horizontal Fill (stretch tabs to fill width)</strong>
-    <mx-tabs fill>
-      <mx-tab :selected="activeTabA === 0" icon="ph-house" label="Home" @click="activeTabA = 0" />
-      <mx-tab :selected="activeTabA === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTabA = 1" />
-      <mx-tab :selected="activeTabA === 2" icon="ph-magnifying-glass" label="Search" @click="activeTabA = 2" />
+    <mx-tabs fill :value="activeTabA" @mxChange="e => activeTabA = e.detail">
+      <mx-tab icon="ph-house" label="Home" />
+      <mx-tab icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" />
+      <mx-tab icon="ph-magnifying-glass" label="Search" />
     </mx-tabs>
   </div>
   <div class="my-20">
     <strong>Horizontal Stack (set tabs to a min width)</strong>
-    <mx-tabs class="mt-10">
-      <mx-tab :selected="activeTabB === 0" icon="ph-house" label="Home" @click="activeTabB = 0" />
-      <mx-tab :selected="activeTabB === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTabB = 1" />
-      <mx-tab :selected="activeTabB === 2" icon="ph-magnifying-glass" label="Search" @click="activeTabB = 2" />
+    <mx-tabs class="mt-10" :value="activeTabB" @mxChange="e => activeTabB = e.detail">
+      <mx-tab icon="ph-house" label="Home" />
+      <mx-tab icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" />
+      <mx-tab icon="ph-magnifying-glass" label="Search" />
     </mx-tabs>
   </div>
+  <!-- The next two examples set the `selected` prop and `click` handler on each tab. -->
+  <!-- This may be preferred when you want the tab to change with the active route, for example. -->
   <div class="my-20">
     <strong>Icons Only, Horizontal Stack</strong>
     <mx-tabs class="mt-10">
-      <mx-tab :selected="activeTabC === 0" icon="ph-house" @click="activeTabC = 0" />
-      <mx-tab :selected="activeTabC === 1" icon="ph-heart" badge badge-class="bg-red-500" @click="activeTabC = 1" />
-      <mx-tab :selected="activeTabC === 2" icon="ph-magnifying-glass" @click="activeTabC = 2" />
+      <mx-tab :selected="activeTabC === 'home'" icon="ph-house" @click="activeTabC = 'home'" />
+      <mx-tab :selected="activeTabC === 'favorites'" icon="ph-heart" badge badge-class="bg-red-500" @click="activeTabC = 'favorites'" />
+      <mx-tab :selected="activeTabC === 'search'" icon="ph-magnifying-glass" @click="activeTabC = 'search'" />
     </mx-tabs>
   </div>
   <div class="my-20">
     <strong>Text Only, Horizontal Fill</strong>
     <mx-tabs class="mt-10" fill>
-      <mx-tab :selected="activeTabD === 0" label="Home" @click="activeTabD = 0" />
-      <mx-tab :selected="activeTabD === 1" label="Favorites" @click="activeTabD = 1" />
-      <mx-tab :selected="activeTabD === 2" label="Search" @click="activeTabD = 2" />
+      <mx-tab :selected="activeTabD === 'home'" label="Home" @click="activeTabD = 'home'" />
+      <mx-tab :selected="activeTabD === 'favorites'" label="Favorites" @click="activeTabD = 'favorites'" />
+      <mx-tab :selected="activeTabD === 'search'" label="Search" @click="activeTabD = 'search'" />
     </mx-tabs>
   </div>
 </section>
@@ -41,22 +48,64 @@ The Moxi Design System tab implementation consists of an `mx-tabs` component tha
 
 <<< @/vuepress/components/tabs.md#tabs
 
+## Tab Content
+
+Content can be automatically hidden or shown based on the selected tab using the `mx-tab-content` component. The `mx-tabs` component and each `mx-tab-content` must be passed the same variable
+for the `value` prop (a variable containing the active tab index), and each `mx-tab-content` must be given an `index` number that corresponds to its tab.
+
+<!-- #region tab-content -->
+<section class="mds">
+  <div class="my-20 border">
+    <mx-tabs fill :value="activeTabE" @mxChange="e => activeTabE = e.detail">
+      <mx-tab icon="ph-house" label="Home" />
+      <mx-tab icon="ph-heart" label="Favorites" />
+      <mx-tab icon="ph-magnifying-glass" label="Search" />
+    </mx-tabs>
+    <mx-tab-content :value="activeTabE" index="0">
+      <p class="px-20">This is the Home tab.</p>
+    </mx-tab-content>
+    <mx-tab-content :value="activeTabE" index="1">
+      <p class="px-20">This is the Favorites tab.</p>
+    </mx-tab-content>
+    <mx-tab-content :value="activeTabE" index="2">
+      <p class="px-20">This is the Search tab.</p>
+    </mx-tab-content>
+  </div>
+</section>
+<!-- #endregion tab-content -->
+
+<<< @/vuepress/components/tabs.md#tab-content
+
 ### Tabs Properties
 
-| Property | Attribute | Description                           | Type      | Default |
-| -------- | --------- | ------------------------------------- | --------- | ------- |
-| `fill`   | `fill`    | Stretch tabs to fill the entire width | `boolean` | `false` |
+| Property | Attribute | Description                                                                                    | Type      | Default |
+| -------- | --------- | ---------------------------------------------------------------------------------------------- | --------- | ------- |
+| `fill`   | `fill`    | Stretch tabs to fill the entire width                                                          | `boolean` | `false` |
+| `value`  | `value`   | The index of the selected tab (not needed if manually setting the `selected` prop on each tab) | `number`  | `null`  |
+
+### Tabs Events
+
+| Event      | Description                                     | Type                  |
+| ---------- | ----------------------------------------------- | --------------------- |
+| `mxChange` | Emits the clicked tab's index as `Event.detail` | `CustomEvent<number>` |
 
 ### Tab Properties
 
-| Property     | Attribute     | Description                                                                                 | Type      | Default |
-| ------------ | ------------- | ------------------------------------------------------------------------------------------- | --------- | ------- |
-| `ariaLabel`  | `aria-label`  | If you are not providing a visible label, this should be provided instead for accessibility | `string`  | `''`    |
-| `badge`      | `badge`       | Display a dot badge                                                                         | `boolean` | `false` |
-| `badgeClass` | `badge-class` | Additional classes for the badge                                                            | `string`  | `''`    |
-| `icon`       | `icon`        | Class name of icon to display                                                               | `string`  | `''`    |
-| `label`      | `label`       | Label text to display                                                                       | `string`  | `''`    |
-| `selected`   | `selected`    |                                                                                             | `boolean` | `false` |
+| Property     | Attribute     | Description                                                                           | Type      | Default |
+| ------------ | ------------- | ------------------------------------------------------------------------------------- | --------- | ------- |
+| `ariaLabel`  | `aria-label`  | If you are not providing a `label`, this should be provided instead for accessibility | `string`  | `''`    |
+| `badge`      | `badge`       | Display a dot badge                                                                   | `boolean` | `false` |
+| `badgeClass` | `badge-class` | Additional classes for the badge                                                      | `string`  | `''`    |
+| `icon`       | `icon`        | Class name of icon to display                                                         | `string`  | `''`    |
+| `label`      | `label`       | Label text to display                                                                 | `string`  | `''`    |
+| `selected`   | `selected`    | Only set this if you are not using the `mx-tabs` `value` prop                         | `boolean` | `false` |
+
+### Tab Content Properties
+
+| Property | Attribute | Description                                           | Type     | Default     |
+| -------- | --------- | ----------------------------------------------------- | -------- | ----------- |
+| `index`  | `index`   | The index of the tab that corresponds to this content | `number` | `undefined` |
+| `value`  | `value`   | The index of the selected tab                         | `number` | `undefined` |
 
 <script>
 export default {
@@ -64,8 +113,9 @@ export default {
     return {
       activeTabA: 0,
       activeTabB: 0,
-      activeTabC: 1,
-      activeTabD: 2
+      activeTabC: 'favorites',
+      activeTabD: 'search',
+      activeTabE: 1,
     }
   }
 }

--- a/vuepress/components/tabs.md
+++ b/vuepress/components/tabs.md
@@ -7,33 +7,33 @@ The Moxi Design System tab implementation consists of an `mx-tabs` component tha
   <div class="my-20">
     <strong>Horizontal Fill (stretch tabs to fill width)</strong>
     <mx-tabs fill>
-      <mx-tab :selected="activeTab === 0" icon="ph-house" label="Home" @click="activeTab = 0"></mx-tab>
-      <mx-tab :selected="activeTab === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTab = 1"></mx-tab>
-      <mx-tab :selected="activeTab === 2" icon="ph-magnifying-glass" label="Search" @click="activeTab = 2"></mx-tab>
+      <mx-tab :selected="activeTabA === 0" icon="ph-house" label="Home" @click="activeTabA = 0"></mx-tab>
+      <mx-tab :selected="activeTabA === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTabA = 1"></mx-tab>
+      <mx-tab :selected="activeTabA === 2" icon="ph-magnifying-glass" label="Search" @click="activeTabA = 2"></mx-tab>
     </mx-tabs>
   </div>
   <div class="my-20">
     <strong>Horizontal Stack (set tabs to a min width)</strong>
     <mx-tabs class="mt-10">
-      <mx-tab :selected="activeTab === 0" icon="ph-house" label="Home" @click="activeTab = 0"></mx-tab>
-      <mx-tab :selected="activeTab === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTab = 1"></mx-tab>
-      <mx-tab :selected="activeTab === 2" icon="ph-magnifying-glass" label="Search" @click="activeTab = 2"></mx-tab>
+      <mx-tab :selected="activeTabB === 0" icon="ph-house" label="Home" @click="activeTabB = 0"></mx-tab>
+      <mx-tab :selected="activeTabB === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTabB = 1"></mx-tab>
+      <mx-tab :selected="activeTabB === 2" icon="ph-magnifying-glass" label="Search" @click="activeTabB = 2"></mx-tab>
     </mx-tabs>
   </div>
   <div class="my-20">
     <strong>Icons Only, Horizontal Stack</strong>
     <mx-tabs class="mt-10">
-      <mx-tab :selected="activeTab === 0" icon="ph-house" @click="activeTab = 0"></mx-tab>
-      <mx-tab :selected="activeTab === 1" icon="ph-heart" badge badge-class="bg-red-500" @click="activeTab = 1"></mx-tab>
-      <mx-tab :selected="activeTab === 2" icon="ph-magnifying-glass" @click="activeTab = 2"></mx-tab>
+      <mx-tab :selected="activeTabC === 0" icon="ph-house" @click="activeTabC = 0"></mx-tab>
+      <mx-tab :selected="activeTabC === 1" icon="ph-heart" badge badge-class="bg-red-500" @click="activeTabC = 1"></mx-tab>
+      <mx-tab :selected="activeTabC === 2" icon="ph-magnifying-glass" @click="activeTabC = 2"></mx-tab>
     </mx-tabs>
   </div>
   <div class="my-20">
     <strong>Text Only, Horizontal Fill</strong>
     <mx-tabs class="mt-10" fill>
-      <mx-tab :selected="activeTab === 0" label="Home" @click="activeTab = 0"></mx-tab>
-      <mx-tab :selected="activeTab === 1" label="Favorites" @click="activeTab = 1"></mx-tab>
-      <mx-tab :selected="activeTab === 2" label="Search" @click="activeTab = 2"></mx-tab>
+      <mx-tab :selected="activeTabD === 0" label="Home" @click="activeTabD = 0"></mx-tab>
+      <mx-tab :selected="activeTabD === 1" label="Favorites" @click="activeTabD = 1"></mx-tab>
+      <mx-tab :selected="activeTabD === 2" label="Search" @click="activeTabD = 2"></mx-tab>
     </mx-tabs>
   </div>
 </section>
@@ -62,7 +62,10 @@ The Moxi Design System tab implementation consists of an `mx-tabs` component tha
 export default {
   data() {
     return {
-      activeTab: 1
+      activeTabA: 0,
+      activeTabB: 0,
+      activeTabC: 1,
+      activeTabD: 2
     }
   }
 }

--- a/vuepress/components/tabs.md
+++ b/vuepress/components/tabs.md
@@ -7,33 +7,33 @@ The Moxi Design System tab implementation consists of an `mx-tabs` component tha
   <div class="my-20">
     <strong>Horizontal Fill (stretch tabs to fill width)</strong>
     <mx-tabs fill>
-      <mx-tab :selected="activeTabA === 0" icon="ph-house" label="Home" @click="activeTabA = 0"></mx-tab>
-      <mx-tab :selected="activeTabA === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTabA = 1"></mx-tab>
-      <mx-tab :selected="activeTabA === 2" icon="ph-magnifying-glass" label="Search" @click="activeTabA = 2"></mx-tab>
+      <mx-tab :selected="activeTabA === 0" icon="ph-house" label="Home" @click="activeTabA = 0" />
+      <mx-tab :selected="activeTabA === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTabA = 1" />
+      <mx-tab :selected="activeTabA === 2" icon="ph-magnifying-glass" label="Search" @click="activeTabA = 2" />
     </mx-tabs>
   </div>
   <div class="my-20">
     <strong>Horizontal Stack (set tabs to a min width)</strong>
     <mx-tabs class="mt-10">
-      <mx-tab :selected="activeTabB === 0" icon="ph-house" label="Home" @click="activeTabB = 0"></mx-tab>
-      <mx-tab :selected="activeTabB === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTabB = 1"></mx-tab>
-      <mx-tab :selected="activeTabB === 2" icon="ph-magnifying-glass" label="Search" @click="activeTabB = 2"></mx-tab>
+      <mx-tab :selected="activeTabB === 0" icon="ph-house" label="Home" @click="activeTabB = 0" />
+      <mx-tab :selected="activeTabB === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTabB = 1" />
+      <mx-tab :selected="activeTabB === 2" icon="ph-magnifying-glass" label="Search" @click="activeTabB = 2" />
     </mx-tabs>
   </div>
   <div class="my-20">
     <strong>Icons Only, Horizontal Stack</strong>
     <mx-tabs class="mt-10">
-      <mx-tab :selected="activeTabC === 0" icon="ph-house" @click="activeTabC = 0"></mx-tab>
-      <mx-tab :selected="activeTabC === 1" icon="ph-heart" badge badge-class="bg-red-500" @click="activeTabC = 1"></mx-tab>
-      <mx-tab :selected="activeTabC === 2" icon="ph-magnifying-glass" @click="activeTabC = 2"></mx-tab>
+      <mx-tab :selected="activeTabC === 0" icon="ph-house" @click="activeTabC = 0" />
+      <mx-tab :selected="activeTabC === 1" icon="ph-heart" badge badge-class="bg-red-500" @click="activeTabC = 1" />
+      <mx-tab :selected="activeTabC === 2" icon="ph-magnifying-glass" @click="activeTabC = 2" />
     </mx-tabs>
   </div>
   <div class="my-20">
     <strong>Text Only, Horizontal Fill</strong>
     <mx-tabs class="mt-10" fill>
-      <mx-tab :selected="activeTabD === 0" label="Home" @click="activeTabD = 0"></mx-tab>
-      <mx-tab :selected="activeTabD === 1" label="Favorites" @click="activeTabD = 1"></mx-tab>
-      <mx-tab :selected="activeTabD === 2" label="Search" @click="activeTabD = 2"></mx-tab>
+      <mx-tab :selected="activeTabD === 0" label="Home" @click="activeTabD = 0" />
+      <mx-tab :selected="activeTabD === 1" label="Favorites" @click="activeTabD = 1" />
+      <mx-tab :selected="activeTabD === 2" label="Search" @click="activeTabD = 2" />
     </mx-tabs>
   </div>
 </section>

--- a/vuepress/components/tabs.md
+++ b/vuepress/components/tabs.md
@@ -1,0 +1,69 @@
+# Tabs
+
+The Moxi Design System tab implementation consists of an `mx-tabs` component that wraps `mx-tab` components.
+
+<!-- #region tabs -->
+<section class="mds">
+  <div class="my-20">
+    <strong>Horizontal Fill (stretch tabs to fill width)</strong>
+    <mx-tabs fill>
+      <mx-tab :selected="activeTab === 0" icon="ph-house" label="Home" @click="activeTab = 0"></mx-tab>
+      <mx-tab :selected="activeTab === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTab = 1"></mx-tab>
+      <mx-tab :selected="activeTab === 2" icon="ph-magnifying-glass" label="Search" @click="activeTab = 2"></mx-tab>
+    </mx-tabs>
+  </div>
+  <div class="my-20">
+    <strong>Horizontal Stack (set tabs to a min width)</strong>
+    <mx-tabs class="mt-10">
+      <mx-tab :selected="activeTab === 0" icon="ph-house" label="Home" @click="activeTab = 0"></mx-tab>
+      <mx-tab :selected="activeTab === 1" icon="ph-heart" label="Favorites" badge badge-class="bg-green-600" @click="activeTab = 1"></mx-tab>
+      <mx-tab :selected="activeTab === 2" icon="ph-magnifying-glass" label="Search" @click="activeTab = 2"></mx-tab>
+    </mx-tabs>
+  </div>
+  <div class="my-20">
+    <strong>Icons Only, Horizontal Stack</strong>
+    <mx-tabs class="mt-10">
+      <mx-tab :selected="activeTab === 0" icon="ph-house" @click="activeTab = 0"></mx-tab>
+      <mx-tab :selected="activeTab === 1" icon="ph-heart" badge badge-class="bg-red-500" @click="activeTab = 1"></mx-tab>
+      <mx-tab :selected="activeTab === 2" icon="ph-magnifying-glass" @click="activeTab = 2"></mx-tab>
+    </mx-tabs>
+  </div>
+  <div class="my-20">
+    <strong>Text Only, Horizontal Fill</strong>
+    <mx-tabs class="mt-10" fill>
+      <mx-tab :selected="activeTab === 0" label="Home" @click="activeTab = 0"></mx-tab>
+      <mx-tab :selected="activeTab === 1" label="Favorites" @click="activeTab = 1"></mx-tab>
+      <mx-tab :selected="activeTab === 2" label="Search" @click="activeTab = 2"></mx-tab>
+    </mx-tabs>
+  </div>
+</section>
+<!-- #endregion tabs -->
+
+<<< @/vuepress/components/tabs.md#tabs
+
+### Tabs Properties
+
+| Property | Attribute | Description                           | Type      | Default |
+| -------- | --------- | ------------------------------------- | --------- | ------- |
+| `fill`   | `fill`    | Stretch tabs to fill the entire width | `boolean` | `false` |
+
+### Tab Properties
+
+| Property     | Attribute     | Description                                                                                 | Type      | Default |
+| ------------ | ------------- | ------------------------------------------------------------------------------------------- | --------- | ------- |
+| `ariaLabel`  | `aria-label`  | If you are not providing a visible label, this should be provided instead for accessibility | `string`  | `''`    |
+| `badge`      | `badge`       | Display a dot badge                                                                         | `boolean` | `false` |
+| `badgeClass` | `badge-class` | Additional classes for the badge                                                            | `string`  | `''`    |
+| `icon`       | `icon`        | Class name of icon to display                                                               | `string`  | `''`    |
+| `label`      | `label`       | Label text to display                                                                       | `string`  | `''`    |
+| `selected`   | `selected`    |                                                                                             | `boolean` | `false` |
+
+<script>
+export default {
+  data() {
+    return {
+      activeTab: 1
+    }
+  }
+}
+</script>

--- a/vuepress/css-documentation/elevations.md
+++ b/vuepress/css-documentation/elevations.md
@@ -1,4 +1,4 @@
-# Evelevations
+# Elevations
 
 Elevations are a bit like cards in that they are containers which have a set background color and dropshadow.
 


### PR DESCRIPTION
This adds `mx-tabs` and `mx-tab` components.  The parent `mx-tabs` component simply handles the fill vs. stack appearance (by switching between `grid` and `inline-grid`), as well as the indicator animation.

One thing I wasn't 100% sure on: I decided to use a `label` prop for the visible label, and an `aria-label` prop for icon-only tabs.  Alternatively, we could just have one `label` prop that always feeds into the `aria-label` attribute, but then the user would have to set another prop like `icon-only` or `hide-text` to hide the text.

https://moxiworks.atlassian.net/browse/ENG-133039