### PR TITLE
Honor prefers-reduced-motion

### DIFF
--- a/src/components/mx-tabs/mx-tabs.tsx
+++ b/src/components/mx-tabs/mx-tabs.tsx
@@ -1,4 +1,5 @@
 import { Component, Host, h, Prop, Listen, Element, Watch, Event, EventEmitter } from '@stencil/core';
+import { queryPrefersReducedMotion } from '../../utils/utils';
 
 @Component({
   tag: 'mx-tabs',
@@ -53,6 +54,7 @@ export class MxTabs {
   }
 
   animateIndicator(e: MouseEvent | KeyboardEvent, newSelectedTabIndex?: number) {
+    if (queryPrefersReducedMotion()) return;
     if (this.value !== null && this.value === newSelectedTabIndex) return; // no need to animate
     // Find the distance between the clicked tab and the soon-to-be-deselected tab
     const currentSelectedTab = this.element.querySelector('mx-tab[selected]') as HTMLMxTabElement;

--- a/src/tailwind/mx-input/index.scss
+++ b/src/tailwind/mx-input/index.scss
@@ -41,6 +41,10 @@
       z-index: 10;
       cursor: pointer;
 
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
+
       &.indented {
         left: 50px;
       }

--- a/src/tailwind/mx-switch/index.scss
+++ b/src/tailwind/mx-switch/index.scss
@@ -21,6 +21,10 @@
       background-color: var(--mds-bg-switch-thumb);
       -webkit-transition: 0.4s;
       transition: 0.4s;
+
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
     }
 
     &::after {

--- a/src/tailwind/ripple.scss
+++ b/src/tailwind/ripple.scss
@@ -10,6 +10,10 @@ span.ripple {
   opacity: 1;
   transform: scale(0);
   pointer-events: none;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 }
 
 @keyframes ripple {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,8 @@
 export function format(first: string, middle: string, last: string): string {
   return (first || '') + (middle ? ` ${middle}` : '') + (last ? ` ${last}` : '');
 }
+
+export function queryPrefersReducedMotion(): boolean {
+  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  return !mediaQuery || mediaQuery.matches;
+}


### PR DESCRIPTION
This updates a few places to remove animation when the user prefers reduced motion:
- Label animation in `mx-input`
- The `mx-switch` slider animation
- Ripple (in buttons and tabs)
- Indicator animation in `mx-tabs` (via a new `queryPrefersReducedMotion` util since the animation is added with javascript)

Going forward, I've added this to a list of things to consider when working on new components.

![Kapture 2021-06-04 at 09 47 10](https://user-images.githubusercontent.com/3342530/120811556-1958be80-c51a-11eb-9e3e-90112834eb80.gif)
![Kapture 2021-06-04 at 09 48 07](https://user-images.githubusercontent.com/3342530/120811558-19f15500-c51a-11eb-970e-a30ce39752be.gif)
![Kapture 2021-06-04 at 09 48 39](https://user-images.githubusercontent.com/3342530/120811560-19f15500-c51a-11eb-921e-4094fa93dcfe.gif)
