### PR TITLE
Hexify colors

### DIFF
--- a/src/components/mx-button/mx-button.tsx
+++ b/src/components/mx-button/mx-button.tsx
@@ -50,8 +50,8 @@ export class MxButton {
     if (['contained', 'outlined'].includes(this.btnType)) {
       str += ' w-full rounded-lg font-semibold uppercase';
       if (this.btnType === 'outlined') str += ' border';
-      if (this.xl) str += ' h-48 px-32 text-base';
-      else str += ' h-36 px-16 text-sm';
+      if (this.xl) str += ' h-48 px-32 text-base tracking-1-5';
+      else str += ' h-36 px-16 text-sm tracking tracking-1-25';
     }
 
     // Action Button
@@ -62,7 +62,7 @@ export class MxButton {
     // Text Button
     if (this.btnType === 'text') {
       str += ' w-full h-36 px-8 py-10 text-sm rounded-lg';
-      str += this.dropdown ? ' font-normal' : ' font-semibold uppercase';
+      str += this.dropdown ? ' font-normal' : ' font-semibold uppercase tracking-1-25';
     }
 
     // Icon Button

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -16,77 +16,77 @@
   /* #region buttons */
   /* Contained Buttons */
   --mds-bg-btn-contained-active: #0457af;
-  --mds-bg-btn-contained-disabled: rgba(51, 51, 51, 0.38);
+  --mds-bg-btn-contained-disabled: #a4a4a4;
   --mds-bg-btn-contained-focus: #3874ba;
   --mds-bg-btn-contained-hover: #0457af;
   --mds-bg-btn-contained: #0457af;
   --mds-ripple-btn-contained: rgba(255, 255, 255, 0.32);
-  --mds-text-btn-contained-disabled: rgba(51, 51, 51, 0.38);
+  --mds-text-btn-contained-disabled: #747474;
   --mds-text-btn-contained: #fff;
 
   /* Outline Buttons */
   --mds-bg-btn-outlined-active: #fff;
-  --mds-bg-btn-outlined-disabled: rgba(255, 255, 255, 0.38);
-  --mds-bg-btn-outlined-focus: rgba(51, 51, 51, 0.12);
-  --mds-bg-btn-outlined-hover: rgba(0, 0, 0, 0.04);
+  --mds-bg-btn-outlined-disabled: #fcfcfc;
+  --mds-bg-btn-outlined-focus: #dedede;
+  --mds-bg-btn-outlined-hover: #eeeeee;
   --mds-bg-btn-outlined: #fff;
-  --mds-border-btn-outlined-disabled: rgba(234, 234, 234, 0.38);
-  --mds-border-btn-outlined: #eaeaea;
+  --mds-border-btn-outlined-disabled: #f3f3f3;
+  --mds-border-btn-outlined: #e7e7e7;
   --mds-ripple-btn-outlined: rgba(51, 51, 51, 0.12);
-  --mds-text-btn-outlined-disabled: rgba(51, 51, 51, 0.38);
-  --mds-text-btn-outlined: #333;
+  --mds-text-btn-outlined-disabled: #a7a7a7;
+  --mds-text-btn-outlined: #2d2d2d;
 
   /* Action Buttons */
   --mds-bg-btn-action-active: #fff;
-  --mds-bg-btn-action-disabled: rgba(255, 255, 255, 0.38);
-  --mds-bg-btn-action-focus: rgba(0, 0, 0, 0.12);
-  --mds-bg-btn-action-hover: rgba(0, 0, 0, 0.04);
+  --mds-bg-btn-action-disabled: #fcfcfc;
+  --mds-bg-btn-action-focus: #d7d7d7;
+  --mds-bg-btn-action-hover: #eeeeee;
   --mds-bg-btn-action: #fff;
-  --mds-border-btn-action-disabled: rgba(234, 234, 234, 0.38);
-  --mds-border-btn-action: #eaeaea;
+  --mds-border-btn-action-disabled: #f2f2f2;
+  --mds-border-btn-action: #e7e7e7;
   --mds-ripple-btn-action: rgba(0, 0, 0, 0.12);
-  --mds-text-btn-action-disabled: rgba(51, 51, 51, 0.38);
-  --mds-text-btn-action: #333;
+  --mds-text-btn-action-disabled: #909090;
+  --mds-text-btn-action: #2d2d2d;
 
   /* Text Buttons */
   --mds-bg-btn-text-active: transparent;
   --mds-bg-btn-text-disabled: transparent;
-  --mds-bg-btn-text-dropdown-separator-focus: rgba(4, 87, 175, 0.24);
-  --mds-bg-btn-text-dropdown-separator-hover: rgba(4, 87, 175, 0.08);
-  --mds-bg-btn-text-dropdown-separator: #eaeaea;
-  --mds-bg-btn-text-focus: #c3d7ec;
-  --mds-bg-btn-text-hover: #ebf2f9;
+  --mds-bg-btn-text-dropdown-separator-focus: #8aafd8;
+  --mds-bg-btn-text-dropdown-separator-hover: #d4e2f1;
+  --mds-bg-btn-text-dropdown-separator: #e7e7e7;
+  --mds-bg-btn-text-focus: #bbd1e9;
+  --mds-bg-btn-text-hover: #e8f0f8;
   --mds-bg-btn-text: transparent;
-  --mds-ripple-btn-text: #afc9e6;
-  --mds-text-btn-text-disabled: rgba(51, 51, 51, 0.38);
-  --mds-text-btn-text-dropdown: #333; /* Dropdown text buttons use a different text color */
+  --mds-ripple-btn-text: rgba(4, 87, 175, 0.16);
+  --mds-text-btn-text-disabled: #a4a4a4;
+  --mds-text-btn-text-dropdown: #2d2d2d; /* Dropdown text buttons use a different text color */
   --mds-text-btn-text: #0457af;
 
   /* Icon Buttons */
-  --mds-bg-btn-icon-active: rgba(0, 0, 0, 0.12);
+  --mds-bg-btn-icon-active: #d7d7d7;
   --mds-bg-btn-icon-disabled: transparent;
   --mds-bg-btn-icon-dropdown-active: #dcdcdc;
   --mds-bg-btn-icon-dropdown-focus: #dcdcdc;
-  --mds-bg-btn-icon-dropdown-hover: #f3f3f4;
+  --mds-bg-btn-icon-dropdown-hover: #f3f3f3;
   --mds-bg-btn-icon-dropdown: #fff;
-  --mds-bg-btn-icon-focus: rgba(0, 0, 0, 0.12);
-  --mds-bg-btn-icon-hover: rgba(0, 0, 0, 0.04);
+  --mds-bg-btn-icon-focus: #d7d7d7;
+  --mds-bg-btn-icon-hover: #eeeeee;
   --mds-bg-btn-icon: transparent;
-  --mds-text-btn-icon-disabled: rgba(0, 0, 0, 0.24);
-  --mds-text-btn-icon: #333;
+  --mds-text-btn-icon-disabled: #b5b5b5;
+  --mds-text-btn-icon: #434343;
 
   /* Toggle Buttons */
   --mds-bg-btn-toggle-active: #fff;
   --mds-bg-btn-toggle-disabled: #fff;
-  --mds-bg-btn-toggle-focus: rgba(0, 0, 0, 0.12);
-  --mds-bg-btn-toggle-hover: rgba(0, 0, 0, 0.04);
+  --mds-bg-btn-toggle-focus: #dcdcdc;
+  --mds-bg-btn-toggle-hover: #eeeeee;
   --mds-bg-btn-toggle-selected: #dde8f4;
   --mds-bg-btn-toggle: #fff;
   --mds-border-btn-toggle: #bcbcbc;
-  --mds-ripple-btn-toggle: #afc9e6;
+  --mds-ripple-btn-toggle: rgba(4, 87, 175, 0.16);
   --mds-text-btn-toggle-active: #0457af;
-  --mds-text-btn-toggle-disabled: rgba(51, 51, 51, 0.38);
-  --mds-text-btn-toggle: #333;
+  --mds-text-btn-toggle-disabled: #a9a9a9;
+  --mds-text-btn-toggle: #434343;
   /* #endregion buttons */
 
   /* #region inputs */
@@ -94,11 +94,11 @@
   --mds-bg-input: #fff;
   --mds-border-input-error: #ff0c3e;
   --mds-border-input-focus: #0457af;
-  --mds-border-input: rgba(51, 51, 51, 0.38);
-  --mds-text-input-assistive: rgba(51, 51, 51, 0.6);
+  --mds-border-input: #a9a9a9;
+  --mds-text-input-assistive: #787878;
   --mds-text-input-error: #ff0c3e;
-  --mds-text-input-label: rgba(51, 51, 51, 0.6);
-  --mds-text-input: rgba(51, 51, 51, 0.87);
+  --mds-text-input-label: #7a7a7a;
+  --mds-text-input: #454545;
   /* #endregion inputs */
 
   /* #region dropdowns */
@@ -108,13 +108,13 @@
   --mds-border-select-error: #ff0c3e;
   --mds-border-select-flat: #eaeaea;
   --mds-border-select-focus: #0457af;
-  --mds-border-select-hover: rgba(51, 51, 51, 0.86);
-  --mds-border-select: rgba(51, 51, 51, 0.38);
-  --mds-text-select-assistive: rgba(51, 51, 51, 0.6);
-  --mds-text-select-disabled: rgba(51, 51, 51, 0.38);
+  --mds-border-select-hover: #2d2d2d;
+  --mds-border-select: #a9a9a9;
+  --mds-text-select-assistive: #787878;
+  --mds-text-select-disabled: #a9a9a9;
   --mds-text-select-error: #ff0c3e;
-  --mds-text-select-label: rgba(51, 51, 51, 0.6);
-  --mds-text-select: rgba(51, 51, 51, 0.87);
+  --mds-text-select-label: #7a7a7a;
+  --mds-text-select: #454545;
   /* #endregion dropdowns */
 
   /* #region selection-controls */
@@ -126,7 +126,7 @@
   --mds-bg-radio-overlay-checked-hover: rgba(4, 87, 175, 0.08);
   --mds-bg-radio-overlay-focus: rgba(0, 0, 0, 0.12);
   --mds-bg-radio-overlay-hover: rgba(0, 0, 0, 0.04);
-  --mds-border-radio: rgba(0, 0, 0, 0.64);
+  --mds-border-radio: #505050;
 
   /* Switches */
   --mds-bg-switch-overlay-active: rgba(0, 0, 0, 0.12);
@@ -149,7 +149,7 @@
   --mds-bg-checkbox-overlay-focus: rgba(0, 0, 0, 0.12);
   --mds-bg-checkbox-overlay-hover: rgba(0, 0, 0, 0.04);
   --mds-border-checkbox-check: #fff;
-  --mds-border-checkbox: rgba(0, 0, 0, 0.64);
+  --mds-border-checkbox: #505050;
   /* #endregion selection-controls */
 
   /* #region tabs */
@@ -165,11 +165,11 @@
   --mds-border-tab-focus: #b9b9b9;
   --mds-border-tab-hover: #b9b9b9;
   --mds-border-tab: transparent;
-  --mds-ripple-tab: #afc9e6;
+  --mds-ripple-tab: rgba(4, 87, 175, 0.16);
   --mds-text-tab-active: #0457af;
-  --mds-text-tab-icon-only: rgba(51, 51, 51, 0.38);
-  --mds-text-tab-icon: rgba(0, 0, 0, 0.64);
+  --mds-text-tab-icon-only: #a4a4a4;
+  --mds-text-tab-icon: #505050;
   --mds-text-tab-selected: #0457af;
-  --mds-text-tab: #333;
+  --mds-text-tab: #434343;
   /* #endregion tabs */
 }


### PR DESCRIPTION
This replaces most of the rgba colors with an opaque hex color.  I used a picker to double-check pretty much every color, so I also corrected a few colors that were already hex.  There are more unique color values in our variables file now because a color like `rgba(51, 51, 51, 0.87)` is `#434343` against the default `#f9f9f9` background, but it becomes `#454545` against the white background of a button.

I also noticed that some of the buttons had some extra letter spacing in figma, so I earmarked that fix onto this PR.