### PR TITLE
Sync component minWidths state

### DIFF
--- a/src/utils/minWidthSync.ts
+++ b/src/utils/minWidthSync.ts
@@ -1,0 +1,62 @@
+const SCREENS = {
+  'sm': '640px',
+  'md': '720px',
+  'lg': '1024px',
+  'xl': '1280px',
+  '2xl': '1536px',
+};
+
+/** A key-value pair of breakpoint abbreviations and a boolean for whether the `min-width` meets or exceeds it.
+For example, `MinWidths.md` will be true for windows that are tablet-sized or larger */
+export class MinWidths {
+  'sm' = false;
+  'md' = false;
+  'lg' = false;
+  'xl' = false;
+  '2xl' = false;
+}
+
+class MinWidthSync {
+  componentRefs: any[] = [];
+  minWidths = new MinWidths();
+  listeners: Map<MediaQueryList, (this: MediaQueryList, ev: MediaQueryListEvent) => any> = new Map();
+
+  subscribeComponent(componentRef: any) {
+    // If this is the first subscribed component, set up listeners.
+    if (this.componentRefs.length === 0) this.addListeners();
+    this.componentRefs.push(componentRef);
+    // Immediately sync minWidths to component.
+    componentRef.minWidths = { ...this.minWidths };
+  }
+
+  addListeners() {
+    Object.keys(SCREENS).forEach(screen => {
+      const mql = window.matchMedia(`(min-width: ${SCREENS[screen]})`);
+      const listener = (e: MediaQueryList | MediaQueryListEvent) => {
+        this.minWidths[screen] = e.matches;
+        // Sync minWidths to all subscribed components
+        this.componentRefs.forEach(componentRef => {
+          componentRef.minWidths = { ...this.minWidths };
+        });
+      };
+      listener(mql);
+      mql.addListener(listener);
+      this.listeners.set(mql, listener); // Store listener so it can be removed later
+    });
+  }
+
+  unsubscribeComponent(componentRef: any) {
+    this.componentRefs = this.componentRefs.filter(c => c !== componentRef);
+    // If no more subscribed components, remove listeners to prevent memory leaks.
+    if (this.componentRefs.length === 0) this.removeListeners();
+  }
+
+  removeListeners() {
+    this.listeners.forEach((listener, mql) => {
+      mql.removeListener(listener);
+    });
+  }
+}
+
+/** Update subscribed components' `minWidths` state object based on `min-width` media query listeners. */
+export const minWidthSync = new MinWidthSync();

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,22 @@ const config = {
       '1-25': '0.078rem',
       '1-5': '0.094rem',
     },
+    screens: {
+      'sm': '640px',
+      // => @media (min-width: 640px) { ... }
+
+      'md': '720px',
+      // => @media (min-width: 720px) { ... }
+
+      'lg': '1024px',
+      // => @media (min-width: 1024px) { ... }
+
+      'xl': '1280px',
+      // => @media (min-width: 1280px) { ... }
+
+      '2xl': '1536px',
+      // => @media (min-width: 1536px) { ... }
+    },
     spacing: {
       0: '0px',
       1: '1px',
@@ -97,22 +113,6 @@ const config = {
       },
       container: {
         center: true,
-      },
-      screens: {
-        'sm': '640px',
-        // => @media (min-width: 640px) { ... }
-
-        'md': '768px',
-        // => @media (min-width: 768px) { ... }
-
-        'lg': '1024px',
-        // => @media (min-width: 1024px) { ... }
-
-        'xl': '1280px',
-        // => @media (min-width: 1280px) { ... }
-
-        '2xl': '1536px',
-        // => @media (min-width: 1536px) { ... }
       },
     },
   },


### PR DESCRIPTION
This adds a `minWidthSync` helper that can be used to update components' `minWidths` state whenever the window width changes (e.g. `this.minWidths.md` becomes `true` when the window width is >= 720px).  Each component just has to call `minWidthSync.subscribeComponent(this)` in its `connectedCallback`.  Rather than register listeners for every component instance, all components that subscribe to the `minWidthSync` share the same listeners, and if all the components unsubscribe, then the listeners are removed to be extra sure we don't end up with memory leaks.

I updated `mx-tabs` to use this instead of its own `MediaQueryListener`.  The upcoming `mx-page-header` component will also use this.  I also updated our tailwind config to use the same `md` value for its breakpoint, and I moved the `screens` out of `extend` so we fully replace the tailwind default breakpoints.  I'm sure we'll tweak these a bit more eventually.

Another thing I want to eventually address, but didn't get into this PR, is not having those breakpoint values in two files.  As simple as it seems, I struggled to make both tailwind and stencil/rollup happy with one source of truth, but I'll circle back some time.  Pinky promise.