### PR TITLE
Text Input Fixes, etc.

### DIFF
--- a/src/components/mx-input/mx-input.tsx
+++ b/src/components/mx-input/mx-input.tsx
@@ -14,6 +14,7 @@ export class MxInput {
   @Prop() value: string;
   @Prop() type: string = 'text';
   @Prop() dense: boolean = false;
+  @Prop() disabled: boolean = false;
   @Prop() leftIcon: string;
   @Prop() rightIcon: string;
   @Prop({ mutable: true }) isActive: boolean = false;
@@ -48,9 +49,13 @@ export class MxInput {
     this.labelClass += ' indented';
   }
 
-  makeTypeClass() {
-    const type = this.dense ? 'dense' : 'standard';
-    return `mx-input-wrapper ${type}`;
+  get containerClass() {
+    let str = 'mx-input-wrapper';
+    str += this.dense ? ' dense' : ' standard';
+    if (this.isFocused) str += ' focused';
+    if (this.error) str += ' error';
+    if (this.disabled) str += ' disabled';
+    return str;
   }
 
   handleFocus() {
@@ -92,10 +97,7 @@ export class MxInput {
   render() {
     return (
       <Host class="mx-input">
-        <div
-          class={`${this.makeTypeClass()} ${this.isFocused ? 'focused' : ''} ${this.error ? 'error' : ''}`}
-          ref={el => (this.containerElem = el as HTMLDivElement)}
-        >
+        <div class={this.containerClass} ref={el => (this.containerElem = el as HTMLDivElement)}>
           <div class={`mx-input-inner-wrapper ${this.isTextarea()}`} style={this.overrideTextArea()}>
             {this.leftIcon && (
               <div class="mds-input-left-content">
@@ -113,6 +115,7 @@ export class MxInput {
                   type={this.type}
                   name={this.name}
                   value={this.value}
+                  disabled={this.disabled}
                   onFocus={() => this.handleFocus()}
                   onBlur={() => this.handleBlur()}
                   ref={el => (this.textInput = el as HTMLInputElement)}
@@ -122,6 +125,7 @@ export class MxInput {
               <textarea
                 style={this.returnTaHeight()}
                 name={this.name}
+                disabled={this.disabled}
                 onFocus={() => this.handleFocus()}
                 onBlur={() => this.handleBlur()}
                 ref={el => (this.textArea = el as HTMLTextAreaElement)}

--- a/src/components/mx-input/mx-input.tsx
+++ b/src/components/mx-input/mx-input.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop } from '@stencil/core';
-
+import { uuidv4 } from '../../utils/utils';
 @Component({
   tag: 'mx-input',
   shadow: false,
@@ -8,10 +8,15 @@ export class MxInput {
   containerElem!: HTMLDivElement;
   textInput!: HTMLInputElement;
   textArea!: HTMLTextAreaElement;
+  uuid: string = uuidv4();
 
+  /** The `name` attribute for the text input */
   @Prop() name: string;
+  /** The `id` attribute for the text input */
+  @Prop() inputId: string;
   @Prop() label: string;
   @Prop() value: string;
+  /** The `type` attribute for the text input */
   @Prop() type: string = 'text';
   @Prop() dense: boolean = false;
   @Prop() disabled: boolean = false;
@@ -23,6 +28,7 @@ export class MxInput {
   @Prop({ mutable: true }) labelClass: string = '';
   @Prop({ mutable: true }) error: boolean = false;
   @Prop() assistiveText: string;
+  /** Display a multi-line `textarea` instead of an `input` */
   @Prop() textarea: boolean = false;
   @Prop({ mutable: true }) textareaHeight: string = '250px';
 
@@ -105,7 +111,7 @@ export class MxInput {
               </div>
             )}
             {this.label && (
-              <label class={this.labelClass} onClick={() => this.focusOnInput()}>
+              <label htmlFor={this.inputId || this.uuid} class={this.labelClass} onClick={() => this.focusOnInput()}>
                 {this.label}
               </label>
             )}
@@ -114,6 +120,7 @@ export class MxInput {
                 <input
                   type={this.type}
                   name={this.name}
+                  id={this.inputId || this.uuid}
                   value={this.value}
                   disabled={this.disabled}
                   onFocus={() => this.handleFocus()}
@@ -125,6 +132,7 @@ export class MxInput {
               <textarea
                 style={this.returnTaHeight()}
                 name={this.name}
+                id={this.inputId || this.uuid}
                 disabled={this.disabled}
                 onFocus={() => this.handleFocus()}
                 onBlur={() => this.handleBlur()}

--- a/src/components/mx-input/mx-input.tsx
+++ b/src/components/mx-input/mx-input.tsx
@@ -1,5 +1,6 @@
 import { Component, Host, h, Prop } from '@stencil/core';
 import { uuidv4 } from '../../utils/utils';
+
 @Component({
   tag: 'mx-input',
   shadow: false,

--- a/src/tailwind/mx-input/index.scss
+++ b/src/tailwind/mx-input/index.scss
@@ -22,6 +22,16 @@
       color: var(--mds-text-input-error);
     }
 
+    &:hover:not(.error, .focused, .disabled) {
+      border: 1px solid var(--mds-border-input-hover);
+    }
+
+    &.disabled label,
+    &.disabled + .assistive-text {
+      color: var(--mds-text-input-disabled);
+      cursor: default;
+    }
+
     label {
       position: absolute;
       left: 10px;
@@ -40,7 +50,6 @@
       margin-top: 0px;
       font-size: 16px;
       z-index: 10;
-      cursor: pointer;
 
       @media (prefers-reduced-motion: reduce) {
         transition: none;

--- a/src/tailwind/mx-toggle-button/index.scss
+++ b/src/tailwind/mx-toggle-button/index.scss
@@ -5,6 +5,7 @@
 
   .btn-toggle {
     background: var(--mds-bg-btn-toggle);
+    outline-offset: -1px;
 
     &:focus:not([aria-disabled]) {
       background: var(--mds-bg-btn-toggle-focus);

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -151,8 +151,10 @@
   --mds-bg-input: #fff;
   --mds-border-input-error: #ff0c3e;
   --mds-border-input-focus: #0457af;
+  --mds-border-input-hover: #2d2d2d;
   --mds-border-input: #a9a9a9;
   --mds-text-input-assistive: #787878;
+  --mds-text-input-disabled: #a9a9a9;
   --mds-text-input-error: #ff0c3e;
   --mds-text-input-label: #7a7a7a;
   --mds-text-input: #454545;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,10 @@
-export function format(first: string, middle: string, last: string): string {
-  return (first || '') + (middle ? ` ${middle}` : '') + (last ? ` ${last}` : '');
+// https://github.com/ionic-team/capacitor/blob/b893a57aaaf3a16e13db9c33037a12f1a5ac92e0/cli/src/util/uuid.ts
+export function uuidv4(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0;
+    const v = c == 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
 }
 
 export function queryPrefersReducedMotion(): boolean {

--- a/vuepress/components/inputs.md
+++ b/vuepress/components/inputs.md
@@ -59,24 +59,25 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
 
 ### Properties
 
-| Property              | Attribute               | Description | Type      | Default     |
-| --------------------- | ----------------------- | ----------- | --------- | ----------- |
-| `assistiveText`       | `assistive-text`        |             | `string`  | `undefined` |
-| `dense`               | `dense`                 |             | `boolean` | `false`     |
-| `disabled`            | `disabled`              |             | `boolean` | `false`     |
-| `error`               | `error`                 |             | `boolean` | `false`     |
-| `isActive`            | `is-active`             |             | `boolean` | `false`     |
-| `isFocused`           | `is-focused`            |             | `boolean` | `false`     |
-| `label`               | `label`                 |             | `string`  | `undefined` |
-| `labelClass`          | `label-class`           |             | `string`  | `''`        |
-| `leftIcon`            | `left-icon`             |             | `string`  | `undefined` |
-| `name`                | `name`                  |             | `string`  | `undefined` |
-| `outerContainerClass` | `outer-container-class` |             | `string`  | `''`        |
-| `rightIcon`           | `right-icon`            |             | `string`  | `undefined` |
-| `textarea`            | `textarea`              |             | `boolean` | `false`     |
-| `textareaHeight`      | `textarea-height`       |             | `string`  | `'250px'`   |
-| `type`                | `type`                  |             | `string`  | `'text'`    |
-| `value`               | `value`                 |             | `string`  | `undefined` |
+| Property              | Attribute               | Description                                           | Type      | Default     |
+| --------------------- | ----------------------- | ----------------------------------------------------- | --------- | ----------- |
+| `assistiveText`       | `assistive-text`        |                                                       | `string`  | `undefined` |
+| `dense`               | `dense`                 |                                                       | `boolean` | `false`     |
+| `disabled`            | `disabled`              |                                                       | `boolean` | `false`     |
+| `error`               | `error`                 |                                                       | `boolean` | `false`     |
+| `inputId`             | `input-id`              | The `id` attribute for the text input                 | `string`  | `undefined` |
+| `isActive`            | `is-active`             |                                                       | `boolean` | `false`     |
+| `isFocused`           | `is-focused`            |                                                       | `boolean` | `false`     |
+| `label`               | `label`                 |                                                       | `string`  | `undefined` |
+| `labelClass`          | `label-class`           |                                                       | `string`  | `''`        |
+| `leftIcon`            | `left-icon`             |                                                       | `string`  | `undefined` |
+| `name`                | `name`                  | The `name` attribute for the text input               | `string`  | `undefined` |
+| `outerContainerClass` | `outer-container-class` |                                                       | `string`  | `''`        |
+| `rightIcon`           | `right-icon`            |                                                       | `string`  | `undefined` |
+| `textarea`            | `textarea`              | Display a multi-line `textarea` instead of an `input` | `boolean` | `false`     |
+| `textareaHeight`      | `textarea-height`       |                                                       | `string`  | `'250px'`   |
+| `type`                | `type`                  | The `type` attribute for the text input               | `string`  | `'text'`    |
+| `value`               | `value`                 |                                                       | `string`  | `undefined` |
 
 ## CSS Variables
 

--- a/vuepress/components/inputs.md
+++ b/vuepress/components/inputs.md
@@ -6,8 +6,8 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
 
 <br />
 <section class="mds">
-  <div class="flex flex-row flex-nowrap justify-between">
-    <div style="width: 47%;">
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-40">
+    <div>
       <strong>Regular</strong>
       <div class="my-20">
         <mx-input label="Placeholder"></mx-input>
@@ -24,8 +24,11 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
       <div class="my-20">
         <mx-input label="Placeholder & Right Icon" value="Some Error" error></mx-input>
       </div>
+      <div class="my-20">
+        <mx-input label="Disabled" assistive-text="This input is disabled" disabled></mx-input>
+      </div>
     </div>
-    <div style="width: 47%;">
+    <div>
       <strong>Dense</strong>
       <div class="my-20">
         <mx-input label="Placeholder" dense></mx-input>
@@ -42,6 +45,9 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
       <div class="my-20">
         <mx-input label="Placeholder & Right Icon" right-icon="ph-apple-logo" value="Some Error" error dense></mx-input>
       </div>
+      <div class="my-20">
+        <mx-input label="Disabled" assistive-text="This input is disabled" disabled dense></mx-input>
+      </div>
     </div>
   </div>
 </section>
@@ -57,6 +63,7 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
 | --------------------- | ----------------------- | ----------- | --------- | ----------- |
 | `assistiveText`       | `assistive-text`        |             | `string`  | `undefined` |
 | `dense`               | `dense`                 |             | `boolean` | `false`     |
+| `disabled`            | `disabled`              |             | `boolean` | `false`     |
 | `error`               | `error`                 |             | `boolean` | `false`     |
 | `isActive`            | `is-active`             |             | `boolean` | `false`     |
 | `isFocused`           | `is-focused`            |             | `boolean` | `false`     |


### PR DESCRIPTION
- Added missing hover and disabled states to `mx-input`.
- Made changes to ensure the `label` in `mx-input` always has a `for` attribute that points to the `id` of the input.  This meant adding an `inputId` prop if the user wants to set that manually, as well as providing a default `id` via a new `uuidv4` utility function.
- Added a little bit more info to `inputs.md` and made the page more responsive.
Before:
![image](https://user-images.githubusercontent.com/3342530/126517544-b305124b-e49b-4a9d-aa6a-74d129fe4a92.png)
After:
![image](https://user-images.githubusercontent.com/3342530/126517644-2ed7583e-7da3-4c29-b4eb-8c137ddca480.png)


- Added a negative `outline-offset` to toggle buttons so the outline isn't clipped.
Before:
![image](https://user-images.githubusercontent.com/3342530/126517165-e86574ab-f041-4774-9003-0f990f3d2bd7.png)
After:
![image](https://user-images.githubusercontent.com/3342530/126517046-dd278ca2-6fad-4900-b9bd-dbfc291c0fc9.png)
