### PR TITLE
ENG-135466 - Add readonly prop to mx-input

### DIFF
--- a/src/components/mx-input/mx-input.tsx
+++ b/src/components/mx-input/mx-input.tsx
@@ -35,9 +35,10 @@ export class MxInput {
   @Prop({ mutable: true }) textareaHeight: string = '250px';
 
   connectedCallback() {
-    if (this.error) {
+    if (this.error || this.value) {
       this.isActive = true;
-      this.labelClass += ' active error';
+      this.labelClass += ' active';
+      if (this.error) this.labelClass += ' error';
     } else {
       this.setLabelClass();
     }

--- a/src/components/mx-input/mx-input.tsx
+++ b/src/components/mx-input/mx-input.tsx
@@ -21,6 +21,7 @@ export class MxInput {
   @Prop() type: string = 'text';
   @Prop() dense: boolean = false;
   @Prop() disabled: boolean = false;
+  @Prop() readonly: boolean = false;
   @Prop() leftIcon: string;
   @Prop() rightIcon: string;
   @Prop({ mutable: true }) isActive: boolean = false;
@@ -62,6 +63,7 @@ export class MxInput {
     if (this.isFocused) str += ' focused';
     if (this.error) str += ' error';
     if (this.disabled) str += ' disabled';
+    if (this.readonly) str += ' readonly';
     return str;
   }
 
@@ -124,6 +126,7 @@ export class MxInput {
                   id={this.inputId || this.uuid}
                   value={this.value}
                   disabled={this.disabled}
+                  readonly={this.readonly}
                   onFocus={() => this.handleFocus()}
                   onBlur={() => this.handleBlur()}
                   ref={el => (this.textInput = el as HTMLInputElement)}
@@ -135,6 +138,7 @@ export class MxInput {
                 name={this.name}
                 id={this.inputId || this.uuid}
                 disabled={this.disabled}
+                readonly={this.readonly}
                 onFocus={() => this.handleFocus()}
                 onBlur={() => this.handleBlur()}
                 ref={el => (this.textArea = el as HTMLTextAreaElement)}

--- a/src/components/mx-input/test/mx-input.spec.tsx
+++ b/src/components/mx-input/test/mx-input.spec.tsx
@@ -3,7 +3,8 @@ import { MxInput } from '../mx-input';
 
 describe('mx-input', () => {
   let page;
-  let root;
+  let root: HTMLMxInputElement;
+  let input: HTMLInputElement;
   beforeEach(async () => {
     page = await newSpecPage({
       components: [MxInput],
@@ -20,6 +21,7 @@ describe('mx-input', () => {
       `,
     });
     root = page.root;
+    input = root.querySelector('input');
   });
 
   it('assigns proper value for placeholder', async () => {
@@ -28,7 +30,6 @@ describe('mx-input', () => {
   });
 
   it('has the right name, value and type', async () => {
-    const input = root.querySelector('input');
     expect(input.getAttribute('name')).toBe('testInput');
     expect(input.getAttribute('value')).toBe('foo');
     expect(input.getAttribute('type')).toBe('email');
@@ -47,6 +48,20 @@ describe('mx-input', () => {
   it('should have proper assistive text', async () => {
     const assitive = root.querySelector('.assistive-text');
     expect(assitive.textContent).toBe('Enter your test input');
+  });
+
+  it('disables the input based on the disabled prop', async () => {
+    expect(input.getAttribute('disabled')).toBeNull();
+    root.disabled = true;
+    await page.waitForChanges();
+    expect(input.getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('sets the inputs to read-only if the readonly prop is set', async () => {
+    expect(input.getAttribute('readonly')).toBeNull();
+    root.readonly = true;
+    await page.waitForChanges();
+    expect(input.getAttribute('readonly')).not.toBeNull();
   });
 });
 

--- a/src/tailwind/mx-input/index.scss
+++ b/src/tailwind/mx-input/index.scss
@@ -32,6 +32,13 @@
       cursor: default;
     }
 
+    &.readonly {
+      background: var(--mds-bg-input-readonly);
+      label {
+        background: var(--mds-bg-input-readonly);
+      }
+    }
+
     label {
       position: absolute;
       left: 10px;

--- a/src/tailwind/mx-input/index.scss
+++ b/src/tailwind/mx-input/index.scss
@@ -27,6 +27,7 @@
     }
 
     &.disabled label,
+    &.disabled .mds-input input,
     &.disabled + .assistive-text {
       color: var(--mds-text-input-disabled);
       cursor: default;

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -148,6 +148,7 @@
 
   /* #region inputs */
   /* Text Inputs & Textareas */
+  --mds-bg-input-readonly: #f5f5f5;
   --mds-bg-input: #fff;
   --mds-border-input-error: #ff0c3e;
   --mds-border-input-focus: #0457af;

--- a/vuepress/components/inputs.md
+++ b/vuepress/components/inputs.md
@@ -27,6 +27,9 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
       <div class="my-20">
         <mx-input label="Disabled" assistive-text="This input is disabled" disabled></mx-input>
       </div>
+      <div class="my-20">
+        <mx-input label="Read-only" assistive-text="This input is read-only" readonly value="Input text"></mx-input>
+      </div>
     </div>
     <div>
       <strong>Dense</strong>
@@ -47,6 +50,9 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
       </div>
       <div class="my-20">
         <mx-input label="Disabled" assistive-text="This input is disabled" disabled dense></mx-input>
+      </div>
+      <div class="my-20">
+        <mx-input label="Read-only" assistive-text="This input is read-only" readonly dense value="Input text"></mx-input>
       </div>
     </div>
   </div>
@@ -73,6 +79,7 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
 | `leftIcon`            | `left-icon`             |                                                       | `string`  | `undefined` |
 | `name`                | `name`                  | The `name` attribute for the text input               | `string`  | `undefined` |
 | `outerContainerClass` | `outer-container-class` |                                                       | `string`  | `''`        |
+| `readonly`            | `readonly`              |                                                       | `boolean` | `false`     |
 | `rightIcon`           | `right-icon`            |                                                       | `string`  | `undefined` |
 | `textarea`            | `textarea`              | Display a multi-line `textarea` instead of an `input` | `boolean` | `false`     |
 | `textareaHeight`      | `textarea-height`       |                                                       | `string`  | `'250px'`   |


### PR DESCRIPTION
- Added `readonly` prop, which sets the `input`'s `readonly` attribute, and changes the background color.
- Fixed the active state not getting set when an `mx-input` already has a value when it's created
- Fixed the disabled text color not getting applied to the `input` itself

![image](https://user-images.githubusercontent.com/3342530/128012650-d679ac33-497f-4592-ab80-870bec84b300.png)
