### PR TITLE
Add disabled and indeterminate states to checkbox

### DIFF
--- a/src/components/mx-checkbox/mx-checkbox.tsx
+++ b/src/components/mx-checkbox/mx-checkbox.tsx
@@ -11,6 +11,8 @@ export class MxCheckbox {
   @Prop() labelName: string = '';
   @Prop() labelClass: string = '';
   @Prop() checked: boolean = false;
+  @Prop() disabled: boolean = false;
+  @Prop() indeterminate: boolean = false;
 
   render() {
     return (
@@ -22,14 +24,18 @@ export class MxCheckbox {
           ].join(' ')}
         >
           <input
-            class="absolute h-0 w-0 opacity-0"
+            class={'absolute h-0 w-0 opacity-0' + (this.indeterminate ? ' indeterminate' : '')}
             type="checkbox"
             name={this.name}
             value={this.value}
             checked={this.checked}
+            disabled={this.disabled}
           />
           <span class={'flex h-18 w-18 cursor-pointer' + (this.labelLeft ? ' order-2 ml-16' : ' order-1')}></span>
-          <div class={'inline-block' + (this.labelLeft ? ' order-1 flex-1' : ' order-2 ml-16')} data-testid="labelName">
+          <div
+            class={'checkbox-label inline-block' + (this.labelLeft ? ' order-1 flex-1' : ' order-2 ml-16')}
+            data-testid="labelName"
+          >
             {this.labelName}
           </div>
         </label>

--- a/src/components/mx-checkbox/mx-checkbox.tsx
+++ b/src/components/mx-checkbox/mx-checkbox.tsx
@@ -10,9 +10,26 @@ export class MxCheckbox {
   @Prop() labelLeft: boolean = false;
   @Prop() labelName: string = '';
   @Prop() labelClass: string = '';
+  /** Hide the label text visibly, but still make it accessible for screen readers */
+  @Prop() hideLabel: boolean = false;
   @Prop() checked: boolean = false;
   @Prop() disabled: boolean = false;
   @Prop() indeterminate: boolean = false;
+
+  get checkClass(): string {
+    let str = 'flex h-18 w-18';
+    str += this.labelLeft ? ' order-2' : ' order-1';
+    if (this.labelLeft && !this.hideLabel) str += ' ml-16';
+    return str;
+  }
+
+  get checkLabelClass(): string {
+    let str = 'checkbox-label inline-block';
+    if (this.hideLabel) str += ' sr-only';
+    str += this.labelLeft ? ' order-1 flex-1' : ' order-2';
+    if (!this.labelLeft && !this.hideLabel) str += ' ml-16';
+    return str;
+  }
 
   render() {
     return (
@@ -32,11 +49,8 @@ export class MxCheckbox {
             checked={this.checked}
             disabled={this.disabled}
           />
-          <span class={'flex h-18 w-18' + (this.labelLeft ? ' order-2 ml-16' : ' order-1')}></span>
-          <div
-            class={'checkbox-label inline-block' + (this.labelLeft ? ' order-1 flex-1' : ' order-2 ml-16')}
-            data-testid="labelName"
-          >
+          <span class={this.checkClass}></span>
+          <div class={this.checkLabelClass} data-testid="labelName">
             {this.labelName}
           </div>
         </label>

--- a/src/components/mx-checkbox/mx-checkbox.tsx
+++ b/src/components/mx-checkbox/mx-checkbox.tsx
@@ -10,7 +10,7 @@ export class MxCheckbox {
   @Prop() labelLeft: boolean = false;
   @Prop() labelName: string = '';
   @Prop() labelClass: string = '';
-  /** Hide the label text visibly, but still make it accessible for screen readers */
+  /** Hide the label text visually, but still make it accessible for screen readers */
   @Prop() hideLabel: boolean = false;
   @Prop() checked: boolean = false;
   @Prop() disabled: boolean = false;

--- a/src/components/mx-checkbox/mx-checkbox.tsx
+++ b/src/components/mx-checkbox/mx-checkbox.tsx
@@ -19,7 +19,8 @@ export class MxCheckbox {
       <Host class="mx-checkbox">
         <label
           class={[
-            'relative flex-1 inline-flex flex-nowrap align-center items-center cursor-pointer text-4',
+            'relative flex-1 inline-flex flex-nowrap align-center items-center text-4' +
+              (this.disabled ? '' : ' cursor-pointer'),
             this.labelClass,
           ].join(' ')}
         >
@@ -31,7 +32,7 @@ export class MxCheckbox {
             checked={this.checked}
             disabled={this.disabled}
           />
-          <span class={'flex h-18 w-18 cursor-pointer' + (this.labelLeft ? ' order-2 ml-16' : ' order-1')}></span>
+          <span class={'flex h-18 w-18' + (this.labelLeft ? ' order-2 ml-16' : ' order-1')}></span>
           <div
             class={'checkbox-label inline-block' + (this.labelLeft ? ' order-1 flex-1' : ' order-2 ml-16')}
             data-testid="labelName"

--- a/src/components/mx-checkbox/test/mx-checkbox.spec.tsx
+++ b/src/components/mx-checkbox/test/mx-checkbox.spec.tsx
@@ -3,7 +3,7 @@ import { MxCheckbox } from '../mx-checkbox';
 
 describe('mx-checkbox', () => {
   let page;
-  let root;
+  let root: HTMLMxCheckboxElement;
   beforeEach(async () => {
     page = await newSpecPage({
       components: [MxCheckbox],
@@ -19,7 +19,7 @@ describe('mx-checkbox', () => {
 
   it('has the proper name and label', async () => {
     const input = root.querySelector('input');
-    const labelName = root.querySelector('[data-testid="labelName"]');
+    const labelName = root.querySelector('[data-testid="labelName"]') as HTMLElement;
     expect(input.getAttribute('name')).toBe('foo');
     expect(labelName.innerText).toBe('Premier');
   });
@@ -27,5 +27,19 @@ describe('mx-checkbox', () => {
   it('is checked', async () => {
     const input = root.querySelector('input');
     expect(input.checked).toBeTruthy();
+  });
+
+  it('disables the input when the disabled prop is set', async () => {
+    root.disabled = true;
+    await page.waitForChanges();
+    const input = root.querySelector('input');
+    expect(input.disabled).toBeTruthy();
+  });
+
+  it('adds an indeterminate class when the indeterminate prop is set', async () => {
+    root.indeterminate = true;
+    await page.waitForChanges();
+    const input = root.querySelector('input');
+    expect(input.getAttribute('class').includes('indeterminate')).toBe(true);
   });
 });

--- a/src/tailwind/mx-checkbox/index.scss
+++ b/src/tailwind/mx-checkbox/index.scss
@@ -1,4 +1,8 @@
 .mx-checkbox {
+  .checkbox-label {
+    color: var(--mds-text-checkbox);
+  }
+
   span {
     position: relative;
     z-index: 1;
@@ -20,10 +24,10 @@
       content: '';
       position: absolute;
       display: none;
-      left: 5px;
-      top: 1px;
-      width: 5px;
-      height: 10px;
+      left: 4px;
+      top: -1px;
+      width: 6px;
+      height: 12px;
       border: solid var(--mds-border-checkbox-check);
       border-width: 0 2px 2px 0;
       -webkit-transform: rotate(45deg);
@@ -49,13 +53,29 @@
       display: block;
       background: var(--mds-bg-checkbox-overlay-focus);
     }
-    &:checked ~ span::before {
+    &:checked ~ span::before,
+    &.indeterminate ~ span::before {
       background: var(--mds-bg-checkbox-overlay-checked-focus);
     }
   }
 
-  input:checked ~ span {
+  input.indeterminate ~ span::after {
+    content: '';
+    position: absolute;
+    display: none;
+    left: 2px;
+    top: 6px;
+    width: 10px;
+    height: 0;
+    border: solid var(--mds-border-checkbox-check);
+    border-width: 1px;
+    transform: rotate(0deg);
+  }
+
+  input:checked ~ span,
+  input.indeterminate ~ span {
     background-color: var(--mds-bg-checkbox-checked);
+    border-color: var(--mds-bg-checkbox-checked);
     &::after {
       display: block;
     }
@@ -71,5 +91,22 @@
         background: var(--mds-bg-checkbox-overlay-checked-active);
       }
     }
+  }
+
+  input:disabled ~ span {
+    border-color: var(--mds-bg-checkbox-disabled);
+    &:hover::before,
+    &:active::before {
+      background: transparent;
+    }
+  }
+
+  input:checked:disabled ~ span,
+  input.indeterminate:disabled ~ span {
+    background-color: var(--mds-bg-checkbox-disabled);
+  }
+
+  input:disabled ~ .checkbox-label {
+    color: var(--mds-text-checkbox-disabled);
   }
 }

--- a/src/tailwind/mx-checkbox/index.scss
+++ b/src/tailwind/mx-checkbox/index.scss
@@ -67,8 +67,8 @@
     top: 6px;
     width: 10px;
     height: 0;
-    border: solid var(--mds-border-checkbox-check);
-    border-width: 1px;
+    border: 0;
+    border-top: 2px solid var(--mds-border-checkbox-check);
     transform: rotate(0deg);
   }
 

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -227,14 +227,18 @@
 
   /* Checkboxes */
   --mds-bg-checkbox-checked: #0457af;
+  --mds-bg-checkbox-disabled: #a4a4a4;
   --mds-bg-checkbox-overlay-active: rgba(0, 0, 0, 0.12);
   --mds-bg-checkbox-overlay-checked-active: rgba(4, 87, 175, 0.32);
   --mds-bg-checkbox-overlay-checked-focus: rgba(4, 87, 175, 0.24);
   --mds-bg-checkbox-overlay-checked-hover: rgba(4, 87, 175, 0.08);
   --mds-bg-checkbox-overlay-focus: rgba(0, 0, 0, 0.12);
   --mds-bg-checkbox-overlay-hover: rgba(0, 0, 0, 0.04);
+  --mds-border-checkbox-disabled: #a4a4a4;
   --mds-border-checkbox-check: #fff;
   --mds-border-checkbox: #505050;
+  --mds-text-checkbox-disabled: #a4a4a4;
+  --mds-text-checkbox: #2d2d2d;
   /* #endregion selection-controls */
 
   /* #region progress */

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -23,15 +23,17 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
 
 ### Properties
 
-| Property        | Attribute       | Description | Type      | Default |
-| --------------- | --------------- | ----------- | --------- | ------- |
-| `checked`       | `checked`       |             | `boolean` | `false` |
-| `indeterminate` | `indeterminate` |             | `boolean` | `false` |
-| `labelClass`    | `label-class`   |             | `string`  | `''`    |
-| `labelLeft`     | `label-left`    |             | `boolean` | `false` |
-| `labelName`     | `label-name`    |             | `string`  | `''`    |
-| `name`          | `name`          |             | `string`  | `''`    |
-| `value`         | `value`         |             | `string`  | `''`    |
+| Property        | Attribute       | Description                                                                   | Type      | Default |
+| --------------- | --------------- | ----------------------------------------------------------------------------- | --------- | ------- |
+| `checked`       | `checked`       |                                                                               | `boolean` | `false` |
+| `disabled`      | `disabled`      |                                                                               | `boolean` | `false` |
+| `hideLabel`     | `hide-label`    | Hide the label text visually, but still make it accessible for screen readers | `boolean` | `false` |
+| `indeterminate` | `indeterminate` |                                                                               | `boolean` | `false` |
+| `labelClass`    | `label-class`   |                                                                               | `string`  | `''`    |
+| `labelLeft`     | `label-left`    |                                                                               | `boolean` | `false` |
+| `labelName`     | `label-name`    |                                                                               | `string`  | `''`    |
+| `name`          | `name`          |                                                                               | `string`  | `''`    |
+| `value`         | `value`         |                                                                               | `string`  | `''`    |
 
 ## Radio Buttons
 

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -7,10 +7,14 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
 <!-- #region checkboxes -->
 <div class="mds">
   <div class="my-12 grid grid-flow-row grid-cols-2 gap-4">
-    <div><mx-checkbox name="foo" label-name="Premier" checked="true" /></div>
+    <div><mx-checkbox name="foo" label-name="Premier" checked /></div>
     <div><mx-checkbox name="foo" label-name="W Collection" /></div>
     <div><mx-checkbox name="foo" label-name="Equestrian" /></div>
     <div><mx-checkbox name="foo" label-name="Warlock" /></div>
+    <div><mx-checkbox name="foo" disabled label-name="Disabled" /></div>
+    <div><mx-checkbox name="foo" checked disabled label-name="Disabled" /></div>
+    <div><mx-checkbox name="foo" indeterminate label-name="Indeterminate" /></div>
+    <div><mx-checkbox name="foo" indeterminate disabled label-name="Indeterminate" /></div>
   </div>
 </div>
 <!-- #endregion checkboxes -->
@@ -19,14 +23,15 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
 
 ### Properties
 
-| Property     | Attribute     | Description | Type      | Default |
-| ------------ | ------------- | ----------- | --------- | ------- |
-| `checked`    | `checked`     |             | `boolean` | `false` |
-| `labelClass` | `label-class` |             | `string`  | `''`    |
-| `labelLeft`  | `label-left`  |             | `boolean` | `false` |
-| `labelName`  | `label-name`  |             | `string`  | `''`    |
-| `name`       | `name`        |             | `string`  | `''`    |
-| `value`      | `value`       |             | `string`  | `''`    |
+| Property        | Attribute       | Description | Type      | Default |
+| --------------- | --------------- | ----------- | --------- | ------- |
+| `checked`       | `checked`       |             | `boolean` | `false` |
+| `indeterminate` | `indeterminate` |             | `boolean` | `false` |
+| `labelClass`    | `label-class`   |             | `string`  | `''`    |
+| `labelLeft`     | `label-left`    |             | `boolean` | `false` |
+| `labelName`     | `label-name`    |             | `string`  | `''`    |
+| `name`          | `name`          |             | `string`  | `''`    |
+| `value`         | `value`         |             | `string`  | `''`    |
 
 ## Radio Buttons
 


### PR DESCRIPTION
- Added disabled and indeterminate states to `mx-checkbox`.  The indeterminate state is needed for the data table (un)check-all checkboxes.
- Added a `hideLabel` prop that visually hides the label, but leaves it accessible to screen readers.  This is also needed for the data table checkboxes.
- Tweaked the styling of the checked checkbox a little to better match the design.

![image](https://user-images.githubusercontent.com/3342530/128031654-f03ebd01-09d8-44cd-a82a-df47c0608a75.png)
