### PR TITLE
ENG-124163 & ENG-136122 - Input maxlength prop (with character counter) & floatLabel prop

### DIFF
--- a/src/components/mx-input/mx-input.tsx
+++ b/src/components/mx-input/mx-input.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop } from '@stencil/core';
+import { Component, Host, h, Prop, State, Watch } from '@stencil/core';
 import { uuidv4 } from '../../utils/utils';
 
 @Component({
@@ -6,7 +6,6 @@ import { uuidv4 } from '../../utils/utils';
   shadow: false,
 })
 export class MxInput {
-  containerElem!: HTMLDivElement;
   textInput!: HTMLInputElement;
   textArea!: HTMLTextAreaElement;
   uuid: string = uuidv4();
@@ -16,146 +15,202 @@ export class MxInput {
   /** The `id` attribute for the text input */
   @Prop() inputId: string;
   @Prop() label: string;
-  @Prop() value: string;
+  @Prop({ mutable: true }) value: string;
   /** The `type` attribute for the text input */
   @Prop() type: string = 'text';
   @Prop() dense: boolean = false;
   @Prop() disabled: boolean = false;
   @Prop() readonly: boolean = false;
+  @Prop() maxlength: number;
   @Prop() leftIcon: string;
   @Prop() rightIcon: string;
-  @Prop({ mutable: true }) isActive: boolean = false;
-  @Prop({ mutable: true }) isFocused: boolean = false;
+  /** Text shown to the right of the input value */
+  @Prop() suffix: string;
   @Prop() outerContainerClass: string = '';
   @Prop({ mutable: true }) labelClass: string = '';
   @Prop({ mutable: true }) error: boolean = false;
   @Prop() assistiveText: string;
+  @Prop() floatLabel: boolean = false;
   /** Display a multi-line `textarea` instead of an `input` */
   @Prop() textarea: boolean = false;
   @Prop({ mutable: true }) textareaHeight: string = '250px';
 
+  @State() isFocused: boolean = false;
+  @State() characterCount: number = 0;
+
   connectedCallback() {
-    if (this.error || this.value) {
-      this.isActive = true;
-      this.labelClass += ' active';
-      if (this.error) this.labelClass += ' error';
-    } else {
-      this.setLabelClass();
-    }
+    this.characterCount = this.hasValue ? this.value.length : 0;
   }
 
-  setLabelClass(target = undefined) {
-    this.labelClass = '';
-    if ((this.leftIcon && !this.isActive) || (this.leftIcon && target && target.value === '')) {
-      this.setIndentedLabel();
-    }
-    if (target && target.value !== '') {
-      this.labelClass += ' active';
-    }
+  componentDidLoad() {
+    this.updateValue();
   }
 
-  setIndentedLabel() {
-    this.labelClass += ' indented';
+  @Watch('value')
+  onValueChange() {
+    this.updateValue();
+    this.characterCount = this.hasValue ? this.value.length : 0;
+  }
+
+  updateValue() {
+    this.workingElem.value = this.hasValue ? this.value : '';
+  }
+
+  onFocus() {
+    this.isFocused = true;
+    this.error = false;
+  }
+
+  onBlur() {
+    this.isFocused = false;
+  }
+
+  onInput(e: InputEvent) {
+    this.characterCount = (e.target as HTMLInputElement).value.length;
+  }
+
+  get workingElem() {
+    return this.textarea ? this.textArea : this.textInput;
+  }
+
+  get hasValue() {
+    return this.value !== null && this.value !== '' && this.value !== undefined;
   }
 
   get containerClass() {
-    let str = 'mx-input-wrapper';
-    str += this.dense ? ' dense' : ' standard';
-    if (this.isFocused) str += ' focused';
+    let str = 'mx-input-wrapper relative border rounded-lg';
+    if (!this.textarea) {
+      str += ' flex items-center';
+      str += this.dense ? ' h-36' : ' h-48';
+    }
+    if (this.error || this.isFocused) str += ' border-2';
     if (this.error) str += ' error';
     if (this.disabled) str += ' disabled';
     if (this.readonly) str += ' readonly';
     return str;
   }
 
-  handleFocus() {
-    this.isActive = true;
-    this.isFocused = true;
-    this.labelClass = ' active focus';
-    this.removeError();
+  get inputClass() {
+    let str = 'w-full overflow-hidden outline-none appearance-none bg-transparent';
+    if (!this.textarea) {
+      str += ' absolute inset-0 pl-16';
+      str += this.leftIcon ? ' pl-48 left-2' : ' pl-16';
+    } else {
+      str += ' p-16 resize-none';
+    }
+    if (this.isFocused) str += ' -m-1'; // prevent shifting due to border-width change
+    return str;
   }
 
-  handleBlur() {
-    const workingElem = this.textarea ? this.textArea : this.textInput;
-    this.isFocused = false;
-    this.setLabelClass(workingElem);
+  get labelClassNames() {
+    let str = 'block pointer-events-none';
+    if (this.floatLabel) {
+      str += ' absolute mt-0 px-4';
+      if (this.textarea) str += ' top-12';
+      str += this.leftIcon && !this.textarea ? ' left-48 has-left-icon' : ' left-12';
+      if (this.dense && !this.textarea) str += ' dense text-4';
+      if (this.isFocused || this.characterCount > 0) str += ' floating';
+      if (this.isFocused) str += ' -ml-1'; // prevent shifting due to border-width change
+      if (this.isFocused && this.textarea) str += ' -mt-1';
+    } else {
+      str += ' subtitle2 mb-4';
+    }
+    if (this.labelClass) str += this.labelClass;
+    return str;
   }
 
-  focusOnInput() {
-    const workingElem = this.textarea ? this.textArea : this.textInput;
-    workingElem.focus();
+  get leftIconWrapperClass() {
+    let str = 'flex items-center h-full pointer-events-none pl-16';
+    if (this.isFocused) str += ' -ml-1'; // prevent shifting due to border-width change
+    return str;
   }
 
-  removeError() {
-    this.error = false;
-    this.containerElem.classList.remove('error');
+  get rightContentClass() {
+    let str = 'icon-suffix absolute flex items-center h-full right-16 space-x-8 pointer-events-none';
+    if (this.isFocused) str += ' -mr-1'; // prevent shifting due to border-width change
+    return str;
   }
 
-  returnTaHeight() {
-    return { height: this.textareaHeight };
-  }
-
-  overrideTextArea() {
-    if (!this.textarea) return {};
-    return { alignItems: 'start' }; // For icon placement.
-  }
-
-  isTextarea() {
-    return this.textarea ? 'textarea' : '';
+  get textareaClass() {
+    return this.textarea ? ' textarea items-start' : '';
   }
 
   render() {
+    const labelJsx = (
+      <label htmlFor={this.inputId || this.uuid} class={this.labelClassNames}>
+        {this.label}
+      </label>
+    );
     return (
-      <Host class="mx-input">
-        <div class={this.containerClass} ref={el => (this.containerElem = el as HTMLDivElement)}>
-          <div class={`mx-input-inner-wrapper ${this.isTextarea()}`} style={this.overrideTextArea()}>
-            {this.leftIcon && (
-              <div class="mds-input-left-content">
-                <i class={this.leftIcon}></i>
-              </div>
-            )}
-            {this.label && (
-              <label htmlFor={this.inputId || this.uuid} class={this.labelClass} onClick={() => this.focusOnInput()}>
-                {this.label}
-              </label>
-            )}
-            {!this.textarea ? (
-              <div class="mds-input">
-                <input
-                  type={this.type}
-                  name={this.name}
-                  id={this.inputId || this.uuid}
-                  value={this.value}
-                  disabled={this.disabled}
-                  readonly={this.readonly}
-                  onFocus={() => this.handleFocus()}
-                  onBlur={() => this.handleBlur()}
-                  ref={el => (this.textInput = el as HTMLInputElement)}
-                />
-              </div>
-            ) : (
-              <textarea
-                style={this.returnTaHeight()}
-                name={this.name}
-                id={this.inputId || this.uuid}
-                disabled={this.disabled}
-                readonly={this.readonly}
-                onFocus={() => this.handleFocus()}
-                onBlur={() => this.handleBlur()}
-                ref={el => (this.textArea = el as HTMLTextAreaElement)}
-              >
-                {this.value}
-              </textarea>
-            )}
+      <Host class={'mx-input block' + (this.disabled ? ' disabled' : '')}>
+        {this.label && !this.floatLabel && labelJsx}
 
-            {(this.rightIcon || this.error) && (
-              <div class="mds-input-right-content">
-                {this.error ? <i class="ph-warning-circle"></i> : <i class={this.rightIcon}></i>}
-              </div>
+        <div class={this.containerClass}>
+          {this.leftIcon && (
+            <div class={this.leftIconWrapperClass}>
+              <i class={this.leftIcon}></i>
+            </div>
+          )}
+
+          {this.label && this.floatLabel && labelJsx}
+
+          {!this.textarea ? (
+            <input
+              type={this.type}
+              class={this.inputClass}
+              name={this.name}
+              id={this.inputId || this.uuid}
+              value={this.value}
+              maxlength={this.maxlength}
+              disabled={this.disabled}
+              readonly={this.readonly}
+              onFocus={this.onFocus.bind(this)}
+              onBlur={this.onBlur.bind(this)}
+              onInput={this.onInput.bind(this)}
+              ref={el => (this.textInput = el as HTMLInputElement)}
+            />
+          ) : (
+            <textarea
+              class={this.inputClass}
+              style={{ height: this.textareaHeight }}
+              name={this.name}
+              id={this.inputId || this.uuid}
+              maxlength={this.maxlength}
+              disabled={this.disabled}
+              readonly={this.readonly}
+              onFocus={this.onFocus.bind(this)}
+              onBlur={this.onBlur.bind(this)}
+              onInput={this.onInput.bind(this)}
+              ref={el => (this.textArea = el as HTMLTextAreaElement)}
+            >
+              {this.value}
+            </textarea>
+          )}
+
+          {!this.textarea && (
+            <span class={this.rightContentClass}>
+              {this.maxlength && (
+                <span class="character-count">
+                  {this.characterCount}/{this.maxlength}
+                </span>
+              )}
+              {this.suffix && <span class="suffix flex items-center h-full px-4">{this.suffix}</span>}
+              {this.error && <i class="ph-warning-circle"></i>}
+              {this.rightIcon && !this.error && <i class={this.rightIcon}></i>}
+            </span>
+          )}
+        </div>
+
+        {(this.assistiveText || (this.textarea && this.maxlength)) && (
+          <div class="flex justify-between caption1 mt-4 ml-16 space-x-32">
+            <span class="assistive-text">{this.assistiveText}</span>
+            {this.textarea && this.maxlength && (
+              <span class="character-count">
+                {this.characterCount}/{this.maxlength}
+              </span>
             )}
           </div>
-        </div>
-        {this.assistiveText && <div class="assistive-text">{this.assistiveText}</div>}
+        )}
       </Host>
     );
   }

--- a/src/components/mx-input/mx-input.tsx
+++ b/src/components/mx-input/mx-input.tsx
@@ -22,7 +22,9 @@ export class MxInput {
   @Prop() disabled: boolean = false;
   @Prop() readonly: boolean = false;
   @Prop() maxlength: number;
+  /** The class name of the icon to show on the left side of the input */
   @Prop() leftIcon: string;
+  /** The class name of the icon to show on the right side of the input */
   @Prop() rightIcon: string;
   /** Text shown to the right of the input value */
   @Prop() suffix: string;
@@ -190,11 +192,15 @@ export class MxInput {
           {!this.textarea && (
             <span class={this.rightContentClass}>
               {this.maxlength && (
-                <span class="character-count">
+                <span data-testid="character-count" class="character-count">
                   {this.characterCount}/{this.maxlength}
                 </span>
               )}
-              {this.suffix && <span class="suffix flex items-center h-full px-4">{this.suffix}</span>}
+              {this.suffix && (
+                <span data-testid="suffix" class="suffix flex items-center h-full px-4">
+                  {this.suffix}
+                </span>
+              )}
               {this.error && <i class="ph-warning-circle"></i>}
               {this.rightIcon && !this.error && <i class={this.rightIcon}></i>}
             </span>
@@ -203,9 +209,11 @@ export class MxInput {
 
         {(this.assistiveText || (this.textarea && this.maxlength)) && (
           <div class="flex justify-between caption1 mt-4 ml-16 space-x-32">
-            <span class="assistive-text">{this.assistiveText}</span>
+            <span data-testid="assistive-text" class="assistive-text">
+              {this.assistiveText}
+            </span>
             {this.textarea && this.maxlength && (
-              <span class="character-count">
+              <span data-testid="character-count" class="character-count">
                 {this.characterCount}/{this.maxlength}
               </span>
             )}

--- a/src/components/mx-input/test/mx-input.spec.tsx
+++ b/src/components/mx-input/test/mx-input.spec.tsx
@@ -14,6 +14,8 @@ describe('mx-input', () => {
           left-icon="ph-apple-logo"
           name="testInput"
           value="foo"
+          maxlength="10"
+          suffix="BAR"
           type="email"
           dense="true"
           assistive-text="Enter your test input"
@@ -31,7 +33,7 @@ describe('mx-input', () => {
 
   it('has the right name, value and type', async () => {
     expect(input.getAttribute('name')).toBe('testInput');
-    expect(input.getAttribute('value')).toBe('foo');
+    expect(input.value).toBe('foo');
     expect(input.getAttribute('type')).toBe('email');
   });
 
@@ -40,13 +42,13 @@ describe('mx-input', () => {
     expect(icon).not.toBeNull();
   });
 
-  it('is a dense input represented by the class', async () => {
+  it('is a dense input with a height of 36px', async () => {
     const elem = root.querySelector('.mx-input-wrapper');
-    expect(elem.getAttribute('class')).toContain('dense');
+    expect(elem.getAttribute('class')).toContain('h-36');
   });
 
   it('should have proper assistive text', async () => {
-    const assitive = root.querySelector('.assistive-text');
+    const assitive = root.querySelector('[data-testid="assistive-text"]');
     expect(assitive.textContent).toBe('Enter your test input');
   });
 
@@ -63,11 +65,26 @@ describe('mx-input', () => {
     await page.waitForChanges();
     expect(input.getAttribute('readonly')).not.toBeNull();
   });
+
+  it('displays the suffix', async () => {
+    const characterCount = root.querySelector('[data-testid="suffix"]');
+    expect(characterCount.textContent).toBe('BAR');
+  });
+
+  it('sets the maxlength attribute on the input', async () => {
+    expect(input.getAttribute('maxlength')).toBe('10');
+  });
+
+  it('displays a character count and limit', async () => {
+    const characterCount = root.querySelector('[data-testid="character-count"]');
+    expect(characterCount.textContent).toBe('3/10');
+  });
 });
 
 describe('mx-input as a textarea', () => {
   let page;
-  let root;
+  let root: HTMLMxInputElement;
+  let tarea: HTMLTextAreaElement;
   beforeEach(async () => {
     page = await newSpecPage({
       components: [MxInput],
@@ -77,16 +94,36 @@ describe('mx-input as a textarea', () => {
           textarea="true"
           name="testInput"
           value="foo"
+          maxlength="100"
           assistive-text="Enter your test input"
         />
       `,
       supportsShadowDom: true,
     });
     root = page.root;
+    tarea = root.querySelector('textarea');
   });
 
-  it('assigns proper value for placeholder', async () => {
-    const tarea = root.querySelector('textarea');
+  it('renders a textarea element', async () => {
     expect(tarea).not.toBeNull();
+  });
+
+  it('has the right name and value', async () => {
+    expect(tarea.getAttribute('name')).toBe('testInput');
+    expect(tarea.value).toBe('foo');
+  });
+
+  it('sets the maxlength attribute on the textarea', async () => {
+    expect(tarea.getAttribute('maxlength')).toBe('100');
+  });
+
+  it('should have proper assistive text', async () => {
+    const assitive = root.querySelector('[data-testid="assistive-text"]');
+    expect(assitive.textContent).toBe('Enter your test input');
+  });
+
+  it('displays a character count and limit', async () => {
+    const characterCount = root.querySelector('[data-testid="character-count"]');
+    expect(characterCount.textContent).toBe('3/100');
   });
 });

--- a/src/components/mx-input/test/mx-input.spec.tsx
+++ b/src/components/mx-input/test/mx-input.spec.tsx
@@ -79,6 +79,15 @@ describe('mx-input', () => {
     const characterCount = root.querySelector('[data-testid="character-count"]');
     expect(characterCount.textContent).toBe('3/10');
   });
+
+  it('renders a floating label if the float-label prop is set', async () => {
+    let label = root.querySelector('label');
+    expect(label.classList.contains('floating')).toBe(false);
+    root.floatLabel = true;
+    await page.waitForChanges();
+    label = root.querySelector('label');
+    expect(label.classList.contains('floating')).toBe(true);
+  });
 });
 
 describe('mx-input as a textarea', () => {

--- a/src/components/mx-select/mx-select.tsx
+++ b/src/components/mx-select/mx-select.tsx
@@ -1,5 +1,6 @@
-import { Component, Host, h, Prop, Element, Watch, State } from '@stencil/core';
+import { Component, Host, h, Prop, Watch, State } from '@stencil/core';
 import arrowSvg from '../../assets/svg/arrow-triangle-down.svg';
+import { uuidv4 } from '../../utils/utils';
 
 @Component({
   tag: 'mx-select',
@@ -8,6 +9,7 @@ import arrowSvg from '../../assets/svg/arrow-triangle-down.svg';
 export class MxSelect {
   selectElem!: HTMLSelectElement;
   textArea!: HTMLTextAreaElement;
+  uuid: string = uuidv4();
 
   /** Helpful text to show below the select */
   @Prop() assistiveText: string;
@@ -18,6 +20,7 @@ export class MxSelect {
   /** Style with a "flat" border color */
   @Prop() flat: boolean = false;
   @Prop() label: string;
+  @Prop() floatLabel: boolean = false;
   @Prop() ariaLabel: string;
   /** The `id` attribute for the select element */
   @Prop() selectId: string;
@@ -30,8 +33,6 @@ export class MxSelect {
   @Prop({ mutable: true }) value: any;
 
   @State() isFocused: boolean = false;
-
-  @Element() element: HTMLMxSelectElement;
 
   componentDidLoad() {
     this.updateSelectValue();
@@ -77,10 +78,15 @@ export class MxSelect {
   }
 
   get labelClassNames() {
-    let str = 'absolute block pointer-events-none mt-0 left-12 px-4';
-    if (this.dense) str += ' dense text-4';
-    if (this.isFocused || this.hasValue) str += ' floating';
-    if (this.isFocused) str += ' -ml-1'; // prevent shifting due to border-width change
+    let str = 'block pointer-events-none';
+    if (this.floatLabel) {
+      str += ' absolute mt-0 left-12 px-4';
+      if (this.dense) str += ' dense text-4';
+      if (this.isFocused || this.hasValue) str += ' floating';
+      if (this.isFocused) str += ' -ml-1'; // prevent shifting due to border-width change
+    } else {
+      str += ' subtitle2 mb-4';
+    }
     return (str += ' ' + this.labelClass);
   }
 
@@ -97,14 +103,21 @@ export class MxSelect {
   }
 
   render() {
+    const labelJsx = (
+      <label htmlFor={this.selectId || this.uuid} class={this.labelClassNames}>
+        {this.label}
+      </label>
+    );
     return (
-      <Host class="mx-select">
+      <Host class={'mx-select' + (this.disabled ? ' disabled' : '')}>
+        {this.label && !this.floatLabel && labelJsx}
+
         <div class={this.selectWrapperClass}>
           <select
             aria-label={this.label || this.ariaLabel}
             class={this.selectClass}
             disabled={this.disabled}
-            id={this.selectId}
+            id={this.selectId || this.uuid}
             name={this.name}
             onFocus={this.onFocus.bind(this)}
             onBlur={this.onBlur.bind(this)}
@@ -112,12 +125,15 @@ export class MxSelect {
           >
             <slot></slot>
           </select>
-          {this.label && <label class={this.labelClassNames}>{this.label}</label>}
+
+          {this.label && this.floatLabel && labelJsx}
+
           <span class={this.iconSuffixClass}>
             {this.suffix && <span class="suffix flex items-center h-full px-4">{this.suffix}</span>}
             {this.iconEl}
           </span>
         </div>
+
         {this.assistiveText && <div class="assistive-text caption1 mt-4 ml-16">{this.assistiveText}</div>}
       </Host>
     );

--- a/src/components/mx-select/mx-select.tsx
+++ b/src/components/mx-select/mx-select.tsx
@@ -112,7 +112,7 @@ export class MxSelect {
       <Host class={'mx-select' + (this.disabled ? ' disabled' : '')}>
         {this.label && !this.floatLabel && labelJsx}
 
-        <div class={this.selectWrapperClass}>
+        <div data-testid="select-wrapper" class={this.selectWrapperClass}>
           <select
             aria-label={this.label || this.ariaLabel}
             class={this.selectClass}

--- a/src/components/mx-select/test/mx-select.spec.tsx
+++ b/src/components/mx-select/test/mx-select.spec.tsx
@@ -26,7 +26,7 @@ describe('mx-select', () => {
     });
     root = page.root;
     select = root.querySelector('select');
-    selectWrapper = root.firstElementChild;
+    selectWrapper = root.querySelector('[data-testid="select-wrapper"]');
   });
 
   it('renders a select', async () => {
@@ -34,7 +34,7 @@ describe('mx-select', () => {
   });
 
   it('renders the label with any additional classes from the labelClass prop', async () => {
-    const label = selectWrapper.querySelector('label');
+    const label = root.querySelector('label');
     expect(label.innerText).toBe('Test Label');
     expect(label.getAttribute('class')).toContain('text-blue-500');
   });
@@ -116,5 +116,14 @@ describe('mx-select', () => {
     root.error = false;
     await page.waitForChanges();
     expect(selectWrapper.querySelector('[data-testid=arrow]')).not.toBeNull();
+  });
+
+  it('renders a floating label if the float-label prop is set', async () => {
+    let label = root.querySelector('label');
+    expect(label.classList.contains('floating')).toBe(false);
+    root.floatLabel = true;
+    await page.waitForChanges();
+    label = selectWrapper.querySelector('label');
+    expect(label.classList.contains('floating')).toBe(true);
   });
 });

--- a/src/tailwind/mx-input/index.scss
+++ b/src/tailwind/mx-input/index.scss
@@ -1,184 +1,79 @@
 .mx-input {
+  label {
+    color: var(--mds-text-input-label);
+  }
+  &.disabled label {
+    color: var(--mds-text-input-disabled);
+  }
+
+  caret-color: var(--mds-caret-input);
+
   .mx-input-wrapper {
-    position: relative;
     color: var(--mds-text-input);
     background: var(--mds-bg-input);
-    border: 1px solid var(--mds-border-input);
-    border-radius: 8px;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: space-between;
-    align-items: center;
-    align-content: center;
+    border-color: var(--mds-border-input);
+    &:hover:not(.disabled, .error, :focus-within) {
+      border-color: var(--mds-border-input-hover);
+    }
+    &:focus-within {
+      border-color: var(--mds-border-input-focus);
+    }
 
     i {
-      color: inherit;
       font-size: 24px;
     }
 
-    &.error {
-      border: 2px solid var(--mds-border-input-error);
-      color: var(--mds-text-input-error);
-    }
-
-    &:hover:not(.error, .focused, .disabled) {
-      border: 1px solid var(--mds-border-input-hover);
-    }
-
-    &.disabled label,
-    &.disabled .mds-input input,
-    &.disabled + .assistive-text {
-      color: var(--mds-text-input-disabled);
-      cursor: default;
-    }
-
-    &.readonly {
-      background: var(--mds-bg-input-readonly);
-      label {
-        background: var(--mds-bg-input-readonly);
-      }
-    }
-
     label {
-      position: absolute;
-      left: 10px;
-      display: block;
-      color: var(--mds-text-input-label);
       background: var(--mds-bg-input);
-      cursor: text;
-      -webkit-transition: color 0.1s ease-out, -webkit-transform 0.1s ease-out;
-      transition: color 0.1s ease-out, -webkit-transform 0.1s ease-out;
-      transition: transform 0.1s ease-out, color 0.1s ease-out;
-      transition: transform 0.1s ease-out, color 0.1s ease-out, -webkit-transform 0.1s ease-out;
-      -webkit-transform-origin: 0% 100%;
-      transform-origin: 0% 100%;
-      text-align: initial;
-      padding: 0 5px;
-      margin-top: 0px;
-      font-size: 16px;
-      z-index: 10;
-
+      transform-origin: 0 0;
+      transition: transform 0.1s ease-out;
+      --translate-y: -22px;
+      &.dense {
+        --translate-y: -16px;
+      }
+      &.floating {
+        transform: translate3d(0, var(--translate-y), 0) scale(0.8);
+        &.has-left-icon {
+          transform: translate3d(-36px, var(--translate-y), 0) scale(0.8);
+        }
+      }
       @media (prefers-reduced-motion: reduce) {
         transition: none;
       }
+    }
 
-      &.indented {
-        left: 50px;
-      }
+    &.error {
+      border-color: var(--mds-border-input-error);
 
-      &.active {
-        -webkit-transform-origin: 0 0;
-        transform-origin: 0 0;
-      }
-
-      &.error {
+      label,
+      i {
         color: var(--mds-text-input-error);
       }
     }
 
-    &.focused {
-      border: 2px solid var(--mds-border-input-focus);
-
-      .mx-input-inner-wrapper {
-        padding: 0 15px;
-      }
-
-      .mx-input-inner-wrapper.textarea {
-        margin: -1px 0;
-      }
+    &.disabled {
+      color: var(--mds-text-input-disabled);
     }
 
-    &.standard {
-      min-height: 48px;
-
-      label {
-        top: 11px;
-
-        &.active {
-          -webkit-transform: translateY(-22px) scale(0.8);
-          transform: translateY(-22px) scale(0.8);
-        }
-      }
-
-      &.focused {
-        label {
-          &.active {
-            padding: 0 4px;
-            top: 10px !important;
-          }
-        }
-      }
+    &.readonly {
+      background: var(--mds-bg-input-readonly);
     }
-    &.dense {
-      min-height: 36px;
-      max-height: 36px;
 
-      label {
-        top: 6px;
-        font-size: 14px;
+    .icon-suffix {
+      background: var(--mds-bg-input);
 
-        &.active {
-          -webkit-transform: translateY(-16px) scale(0.8);
-          transform: translateY(-16px) scale(0.8);
-        }
+      .suffix,
+      .character-count {
+        color: var(--mds-text-input-label);
       }
-
-      &.focused {
-        label {
-          &.active {
-            padding: 0 4px;
-            top: 5px !important;
-          }
-        }
-      }
-    }
-  }
-
-  .mx-input-inner-wrapper {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: space-between;
-    align-items: center;
-    align-content: center;
-    width: 100%;
-    padding: 0 16px;
-
-    .mds-input-left-content {
-      display: flex;
-      width: 24px;
-      flex-shrink: 0;
-      margin-right: 11px; /* Label has 5px of margin */
-    }
-    .mds-input {
-      flex-grow: 1;
-
-      input {
-        width: 100%;
-        outline: 0;
-        color: inherit;
-        background: transparent;
-      }
-    }
-    .mds-input-right-content {
-      display: flex;
-      width: 24px;
-      flex-shrink: 0;
-      margin-left: 16px;
     }
   }
 
   .assistive-text {
-    font-size: 12px;
     color: var(--mds-text-input-assistive);
-    margin: 5px 0 0 16px;
   }
 
-  textarea {
-    background: transparent;
-    width: 100%;
-    padding: 16px 0;
-    outline: none;
+  .error + .assistive-text {
+    color: var(--mds-text-input-error);
   }
 }

--- a/src/tailwind/mx-input/index.scss
+++ b/src/tailwind/mx-input/index.scss
@@ -73,7 +73,7 @@
     color: var(--mds-text-input-assistive);
   }
 
-  .error + .assistive-text {
+  .error + * > .assistive-text {
     color: var(--mds-text-input-error);
   }
 }

--- a/src/tailwind/mx-select/index.scss
+++ b/src/tailwind/mx-select/index.scss
@@ -1,4 +1,11 @@
 .mx-select {
+  label {
+    color: var(--mds-text-select-label);
+  }
+  &.disabled label {
+    color: var(--mds-text-select-disabled);
+  }
+
   .mx-select-wrapper {
     color: var(--mds-text-select);
     background: var(--mds-bg-select);
@@ -17,7 +24,6 @@
     }
 
     label {
-      color: var(--mds-text-input-label);
       background: var(--mds-bg-select);
       transform-origin: 0 0;
       transition: transform 0.1s ease-out;
@@ -26,7 +32,7 @@
         --translate-y: -16px;
       }
       &.floating {
-        transform: translate3d(-4px, var(--translate-y), 0) scale(0.8);
+        transform: translate3d(0, var(--translate-y), 0) scale(0.8);
       }
       @media (prefers-reduced-motion: reduce) {
         transition: none;
@@ -42,7 +48,7 @@
       }
     }
 
-    &.disabled label {
+    &.disabled {
       color: var(--mds-text-select-disabled);
     }
 

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -154,6 +154,7 @@
   --mds-border-input-focus: #0457af;
   --mds-border-input-hover: #2d2d2d;
   --mds-border-input: #a9a9a9;
+  --mds-caret-input: #0457af;
   --mds-text-input-assistive: #787878;
   --mds-text-input-disabled: #a9a9a9;
   --mds-text-input-error: #ff0c3e;

--- a/vuepress/components/dropdowns.md
+++ b/vuepress/components/dropdowns.md
@@ -228,8 +228,8 @@ The `mx-select` component wraps the browser's native `select` element. It is des
           </mx-select>
         </div>
         <div class="my-20">
-          <mx-select label="Disabled Select" disabled>
-            <option></option>
+          <mx-select label="Disabled Select" disabled value="Value">
+            <option>Value</option>
           </mx-select>
         </div>
       </div>
@@ -293,8 +293,8 @@ The `mx-select` component wraps the browser's native `select` element. It is des
           </mx-select>
         </div>
         <div class="my-20">
-          <mx-select label="Disabled Select" disabled dense>
-            <option></option>
+          <mx-select label="Disabled Select" disabled dense value="Value">
+            <option>Value</option>
           </mx-select>
         </div>
       </div>
@@ -304,20 +304,20 @@ The `mx-select` component wraps the browser's native `select` element. It is des
 
 <<< @/vuepress/components/dropdowns.md#selects
 
-### Alternate Label / No Label
+### Floating Label / No Label
 
-The Select component's floating label is optional. A sibling `label` element may be used instead, or the Select could simply have an `aria-label` for screen readers.
+Add the `floatLabel` prop to create a floating label. The Select component's label is also optional; the Select could simply have an `aria-label` for screen readers.
 
 <!-- #region select-labels -->
 <section class="mds">
   <div>
-    <div class="my-20 w-192">
-      <label for="favorite-animal" class="block text-4 mb-4 font-semibold tracking-0-4">
-        Favorite Animal
-      </label>
+    <div class="my-20 w-320">
       <mx-select
-        id="favorite-animal"
+        label="Favorite Animal"
         :value="animal"
+        float-label
+        assistive-text="This select has a floating label"
+        dense
         @input="animal = $event.target.value"
       >
         <option></option>
@@ -427,6 +427,7 @@ Like the [Dropdown Menu](#dropdown-menus), the Select component also has `flat` 
 | `elevated`      | `elevated`       | Style with a 1dp elevation                | `boolean` | `false`     |
 | `error`         | `error`          |                                           | `boolean` | `false`     |
 | `flat`          | `flat`           | Style with a "flat" border color          | `boolean` | `false`     |
+| `floatLabel`    | `float-label`    |                                           | `boolean` | `false`     |
 | `label`         | `label`          |                                           | `string`  | `undefined` |
 | `labelClass`    | `label-class`    | Additional classes for the label          | `string`  | `''`        |
 | `name`          | `name`           |                                           | `string`  | `undefined` |

--- a/vuepress/components/inputs.md
+++ b/vuepress/components/inputs.md
@@ -101,27 +101,27 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
 
 ### Properties
 
-| Property              | Attribute               | Description                                           | Type      | Default     |
-| --------------------- | ----------------------- | ----------------------------------------------------- | --------- | ----------- |
-| `assistiveText`       | `assistive-text`        |                                                       | `string`  | `undefined` |
-| `dense`               | `dense`                 |                                                       | `boolean` | `false`     |
-| `disabled`            | `disabled`              |                                                       | `boolean` | `false`     |
-| `error`               | `error`                 |                                                       | `boolean` | `false`     |
-| `floatLabel`          | `float-label`           |                                                       | `boolean` | `false`     |
-| `inputId`             | `input-id`              | The `id` attribute for the text input                 | `string`  | `undefined` |
-| `label`               | `label`                 |                                                       | `string`  | `undefined` |
-| `labelClass`          | `label-class`           |                                                       | `string`  | `''`        |
-| `leftIcon`            | `left-icon`             |                                                       | `string`  | `undefined` |
-| `maxlength`           | `maxlength`             |                                                       | `number`  | `undefined` |
-| `name`                | `name`                  | The `name` attribute for the text input               | `string`  | `undefined` |
-| `outerContainerClass` | `outer-container-class` |                                                       | `string`  | `''`        |
-| `readonly`            | `readonly`              |                                                       | `boolean` | `false`     |
-| `rightIcon`           | `right-icon`            |                                                       | `string`  | `undefined` |
-| `suffix`              | `suffix`                | Text shown to the right of the input value            | `string`  | `undefined` |
-| `textarea`            | `textarea`              | Display a multi-line `textarea` instead of an `input` | `boolean` | `false`     |
-| `textareaHeight`      | `textarea-height`       |                                                       | `string`  | `'250px'`   |
-| `type`                | `type`                  | The `type` attribute for the text input               | `string`  | `'text'`    |
-| `value`               | `value`                 |                                                       | `string`  | `undefined` |
+| Property              | Attribute               | Description                                                       | Type      | Default     |
+| --------------------- | ----------------------- | ----------------------------------------------------------------- | --------- | ----------- |
+| `assistiveText`       | `assistive-text`        |                                                                   | `string`  | `undefined` |
+| `dense`               | `dense`                 |                                                                   | `boolean` | `false`     |
+| `disabled`            | `disabled`              |                                                                   | `boolean` | `false`     |
+| `error`               | `error`                 |                                                                   | `boolean` | `false`     |
+| `floatLabel`          | `float-label`           |                                                                   | `boolean` | `false`     |
+| `inputId`             | `input-id`              | The `id` attribute for the text input                             | `string`  | `undefined` |
+| `label`               | `label`                 |                                                                   | `string`  | `undefined` |
+| `labelClass`          | `label-class`           |                                                                   | `string`  | `''`        |
+| `leftIcon`            | `left-icon`             | The class name of the icon to show on the left side of the input  | `string`  | `undefined` |
+| `maxlength`           | `maxlength`             |                                                                   | `number`  | `undefined` |
+| `name`                | `name`                  | The `name` attribute for the text input                           | `string`  | `undefined` |
+| `outerContainerClass` | `outer-container-class` |                                                                   | `string`  | `''`        |
+| `readonly`            | `readonly`              |                                                                   | `boolean` | `false`     |
+| `rightIcon`           | `right-icon`            | The class name of the icon to show on the right side of the input | `string`  | `undefined` |
+| `suffix`              | `suffix`                | Text shown to the right of the input value                        | `string`  | `undefined` |
+| `textarea`            | `textarea`              | Display a multi-line `textarea` instead of an `input`             | `boolean` | `false`     |
+| `textareaHeight`      | `textarea-height`       |                                                                   | `string`  | `'250px'`   |
+| `type`                | `type`                  | The `type` attribute for the text input                           | `string`  | `'text'`    |
+| `value`               | `value`                 |                                                                   | `string`  | `undefined` |
 
 ### CSS Variables
 

--- a/vuepress/components/inputs.md
+++ b/vuepress/components/inputs.md
@@ -6,62 +6,98 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
 
 <br />
 <section class="mds">
+  <!-- #region text-inputs -->
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-40">
     <div>
       <strong>Regular</strong>
       <div class="my-20">
-        <mx-input label="Placeholder"></mx-input>
+        <mx-input label="Label"></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Placeholder & Left Icon" left-icon="ph-apple-logo"></mx-input>
+        <mx-input label="Floating Label" float-label></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Placeholder & Right Icon" right-icon="ph-apple-logo"></mx-input>
+        <mx-input label="Label & Left Icon" left-icon="ph-apple-logo"></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Placeholder & Assistive Text" assistive-text="Helpful text about input"></mx-input>
+        <mx-input label="Floating Label & Left Icon" float-label left-icon="ph-apple-logo"></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Placeholder & Right Icon" value="Some Error" error></mx-input>
+        <mx-input label="Label & Right Icon" right-icon="ph-apple-logo"></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Disabled" assistive-text="This input is disabled" disabled></mx-input>
+        <mx-input label="Label & Assistive Text" assistive-text="Helpful text about input"></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Read-only" assistive-text="This input is read-only" readonly value="Input text"></mx-input>
+        <mx-input label="Label & Error" :value="inputValue" error assistive-text="Error message"></mx-input>
+      </div>
+      <div class="my-20">
+        <mx-input label="Disabled" assistive-text="This input is disabled" disabled :value="inputValue"></mx-input>
+      </div>
+      <div class="my-20">
+        <mx-input label="Read-only" assistive-text="This input is read-only" readonly :value="inputValue" @input="inputValue = $event.target.value"></mx-input>
+      </div>
+      <div class="my-20">
+        <mx-input label="Label & Suffix" suffix="SQFT" dense></mx-input>
+      </div>
+      <div class="my-20">
+        <mx-input maxlength="40" label="Label" assistive-text="This input has a maxlength attribute" :value="inputValue" @input="inputValue = $event.target.value"></mx-input>
       </div>
     </div>
     <div>
       <strong>Dense</strong>
       <div class="my-20">
-        <mx-input label="Placeholder" dense></mx-input>
+        <mx-input label="Label" dense></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Placeholder & Left Icon" left-icon="ph-apple-logo" dense></mx-input>
+        <mx-input label="Floating Label" float-label dense></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Placeholder & Right Icon" right-icon="ph-apple-logo" dense></mx-input>
+        <mx-input label="Label & Left Icon" left-icon="ph-apple-logo" dense></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Placeholder & Assistive Text" assistive-text="Helpful text about input" dense></mx-input>
+        <mx-input label="Floating Label & Left Icon" float-label left-icon="ph-apple-logo" dense></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Placeholder & Right Icon" right-icon="ph-apple-logo" value="Some Error" error dense></mx-input>
+        <mx-input label="Label & Right Icon" right-icon="ph-apple-logo" dense></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Disabled" assistive-text="This input is disabled" disabled dense></mx-input>
+        <mx-input label="Label & Assistive Text" assistive-text="Helpful text about input" dense></mx-input>
       </div>
       <div class="my-20">
-        <mx-input label="Read-only" assistive-text="This input is read-only" readonly dense value="Input text"></mx-input>
+        <mx-input label="Label & Error" :value="inputValue" error assistive-text="Error message" dense></mx-input>
+      </div>
+      <div class="my-20">
+        <mx-input label="Disabled" assistive-text="This input is disabled" disabled :value="inputValue" dense></mx-input>
+      </div>
+      <div class="my-20">
+        <mx-input label="Read-only" assistive-text="This input is read-only" readonly dense :value="inputValue" @input="inputValue = $event.target.value"></mx-input>
+      </div>
+      <div class="my-20">
+        <mx-input label="Label & Suffix" suffix="SQFT" dense></mx-input>
+      </div>
+      <div class="my-20">
+        <mx-input maxlength="40" label="Label" assistive-text="This input has a maxlength attribute" dense :value="inputValue" @input="inputValue = $event.target.value"></mx-input>
       </div>
     </div>
   </div>
+  <!-- #endregion text-inputs -->
 </section>
+
+<<< @/vuepress/components/inputs.md#text-inputs
 
 ## Text Area
 
 <br />
-<mx-input label="Placeholder" textarea=true></mx-input>
+<section class="mds">
+  <!-- #region textareas -->
+  <mx-input label="Label" textarea assistive-text="This textarea has a height of 100px" textarea-height="100px"></mx-input>
+  <mx-input class="mt-40" label="Label & Error" textarea error assistive-text="Error message"></mx-input>
+  <mx-input class="my-40" label="Floating Label" textarea float-label maxlength="255" assistive-text="This textarea has a maxlength and really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long assistive text"></mx-input>
+  <!-- #endregion textareas -->
+</section>
+
+<<< @/vuepress/components/inputs.md#textareas
 
 ### Properties
 
@@ -71,21 +107,32 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
 | `dense`               | `dense`                 |                                                       | `boolean` | `false`     |
 | `disabled`            | `disabled`              |                                                       | `boolean` | `false`     |
 | `error`               | `error`                 |                                                       | `boolean` | `false`     |
+| `floatLabel`          | `float-label`           |                                                       | `boolean` | `false`     |
 | `inputId`             | `input-id`              | The `id` attribute for the text input                 | `string`  | `undefined` |
-| `isActive`            | `is-active`             |                                                       | `boolean` | `false`     |
-| `isFocused`           | `is-focused`            |                                                       | `boolean` | `false`     |
 | `label`               | `label`                 |                                                       | `string`  | `undefined` |
 | `labelClass`          | `label-class`           |                                                       | `string`  | `''`        |
 | `leftIcon`            | `left-icon`             |                                                       | `string`  | `undefined` |
+| `maxlength`           | `maxlength`             |                                                       | `number`  | `undefined` |
 | `name`                | `name`                  | The `name` attribute for the text input               | `string`  | `undefined` |
 | `outerContainerClass` | `outer-container-class` |                                                       | `string`  | `''`        |
 | `readonly`            | `readonly`              |                                                       | `boolean` | `false`     |
 | `rightIcon`           | `right-icon`            |                                                       | `string`  | `undefined` |
+| `suffix`              | `suffix`                | Text shown to the right of the input value            | `string`  | `undefined` |
 | `textarea`            | `textarea`              | Display a multi-line `textarea` instead of an `input` | `boolean` | `false`     |
 | `textareaHeight`      | `textarea-height`       |                                                       | `string`  | `'250px'`   |
 | `type`                | `type`                  | The `type` attribute for the text input               | `string`  | `'text'`    |
 | `value`               | `value`                 |                                                       | `string`  | `undefined` |
 
-## CSS Variables
+### CSS Variables
 
 <<< @/src/tailwind/variables/index.scss#inputs
+
+<script>
+export default {
+  data() {
+    return {
+      inputValue: 'Input text'
+    }
+  }
+}
+</script>


### PR DESCRIPTION
- Updated `mx-input` to have a `maxlength` prop, which sets the `maxlength` attribute on the `input`/`textarea`, as well as displays a character counter (ENG-136122).
- Changed `mx-input` and `mx-select` to have a non-floating label by default.  The floating label can still be accessed via a new `float-label` prop (ENG-124163).

- Added missing `suffix` prop to `mx-input`.
- Copied a lot of code from `mx-select` over to `mx-input` to fix issues I discovered with value binding (and for consistency).
- Added a `uuid` to `mx-select` so the `label` can always have a unique id for the `for` attribute.  The `mx-input` component already had this.
- Added an `mx-input` caret color per the design, though it's pretty subtle


![image](https://user-images.githubusercontent.com/3342530/130460820-27c7ffd6-d6f4-47b4-827b-c9e1eebfdc1b.png)

![image](https://user-images.githubusercontent.com/3342530/130460926-e571c893-3c96-40a4-946a-bc0915bafe1a.png)

![image](https://user-images.githubusercontent.com/3342530/130460793-a2494b91-2489-457e-bf29-02bb51a57aca.png)