### PR TITLE
Add placeholder prop to mx-input

### DIFF
--- a/src/components/mx-input/mx-input.tsx
+++ b/src/components/mx-input/mx-input.tsx
@@ -15,7 +15,10 @@ export class MxInput {
   @Prop() name: string;
   /** The `id` attribute for the text input */
   @Prop() inputId: string;
+  /** Text for the label element */
   @Prop() label: string;
+  /** Placeholder text for the input.  This will be ignored if `floatLabel` is `true`. */
+  @Prop() placeholder: string;
   @Prop({ mutable: true }) value: string;
   /** The `type` attribute for the text input */
   @Prop() type: string = 'text';
@@ -162,6 +165,7 @@ export class MxInput {
               name={this.name}
               id={this.inputId || this.uuid}
               value={this.value}
+              placeholder={this.floatLabel ? null : this.placeholder}
               maxlength={this.maxlength}
               disabled={this.disabled}
               readonly={this.readonly}
@@ -176,6 +180,7 @@ export class MxInput {
               style={{ height: this.textareaHeight }}
               name={this.name}
               id={this.inputId || this.uuid}
+              placeholder={this.floatLabel ? null : this.placeholder}
               maxlength={this.maxlength}
               disabled={this.disabled}
               readonly={this.readonly}

--- a/src/components/mx-input/test/mx-input.spec.tsx
+++ b/src/components/mx-input/test/mx-input.spec.tsx
@@ -14,6 +14,7 @@ describe('mx-input', () => {
           left-icon="ph-apple-logo"
           name="testInput"
           value="foo"
+          placeholder="bar"
           maxlength="10"
           suffix="BAR"
           type="email"
@@ -31,9 +32,10 @@ describe('mx-input', () => {
     expect(placeholder.textContent).toBe('Placeholder');
   });
 
-  it('has the right name, value and type', async () => {
+  it('has the right name, value, placeholder and type', async () => {
     expect(input.getAttribute('name')).toBe('testInput');
     expect(input.value).toBe('foo');
+    expect(input.placeholder).toBe('bar');
     expect(input.getAttribute('type')).toBe('email');
   });
 

--- a/src/tailwind/mx-input/index.scss
+++ b/src/tailwind/mx-input/index.scss
@@ -1,5 +1,6 @@
 .mx-input {
-  label {
+  label,
+  ::placeholder {
     color: var(--mds-text-input-label);
   }
   &.disabled label {

--- a/vuepress/components/inputs.md
+++ b/vuepress/components/inputs.md
@@ -11,7 +11,7 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
     <div>
       <strong>Regular</strong>
       <div class="my-20">
-        <mx-input label="Label"></mx-input>
+        <mx-input label="Label" placeholder="Placeholder"></mx-input>
       </div>
       <div class="my-20">
         <mx-input label="Floating Label" float-label></mx-input>
@@ -47,7 +47,7 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
     <div>
       <strong>Dense</strong>
       <div class="my-20">
-        <mx-input label="Label" dense></mx-input>
+        <mx-input label="Label" placeholder="Placeholder" dense></mx-input>
       </div>
       <div class="my-20">
         <mx-input label="Floating Label" float-label dense></mx-input>
@@ -91,7 +91,7 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
 <br />
 <section class="mds">
   <!-- #region textareas -->
-  <mx-input label="Label" textarea assistive-text="This textarea has a height of 100px" textarea-height="100px"></mx-input>
+  <mx-input label="Label" placeholder="Placeholder" textarea assistive-text="This textarea has a height of 100px" textarea-height="100px"></mx-input>
   <mx-input class="mt-40" label="Label & Error" textarea error assistive-text="Error message"></mx-input>
   <mx-input class="my-40" label="Floating Label" textarea float-label maxlength="255" assistive-text="This textarea has a maxlength and really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long assistive text"></mx-input>
   <!-- #endregion textareas -->
@@ -101,27 +101,28 @@ The icons for Moxi Design System are from [https://phosphoricons.com/](https://p
 
 ### Properties
 
-| Property              | Attribute               | Description                                                       | Type      | Default     |
-| --------------------- | ----------------------- | ----------------------------------------------------------------- | --------- | ----------- |
-| `assistiveText`       | `assistive-text`        |                                                                   | `string`  | `undefined` |
-| `dense`               | `dense`                 |                                                                   | `boolean` | `false`     |
-| `disabled`            | `disabled`              |                                                                   | `boolean` | `false`     |
-| `error`               | `error`                 |                                                                   | `boolean` | `false`     |
-| `floatLabel`          | `float-label`           |                                                                   | `boolean` | `false`     |
-| `inputId`             | `input-id`              | The `id` attribute for the text input                             | `string`  | `undefined` |
-| `label`               | `label`                 |                                                                   | `string`  | `undefined` |
-| `labelClass`          | `label-class`           |                                                                   | `string`  | `''`        |
-| `leftIcon`            | `left-icon`             | The class name of the icon to show on the left side of the input  | `string`  | `undefined` |
-| `maxlength`           | `maxlength`             |                                                                   | `number`  | `undefined` |
-| `name`                | `name`                  | The `name` attribute for the text input                           | `string`  | `undefined` |
-| `outerContainerClass` | `outer-container-class` |                                                                   | `string`  | `''`        |
-| `readonly`            | `readonly`              |                                                                   | `boolean` | `false`     |
-| `rightIcon`           | `right-icon`            | The class name of the icon to show on the right side of the input | `string`  | `undefined` |
-| `suffix`              | `suffix`                | Text shown to the right of the input value                        | `string`  | `undefined` |
-| `textarea`            | `textarea`              | Display a multi-line `textarea` instead of an `input`             | `boolean` | `false`     |
-| `textareaHeight`      | `textarea-height`       |                                                                   | `string`  | `'250px'`   |
-| `type`                | `type`                  | The `type` attribute for the text input                           | `string`  | `'text'`    |
-| `value`               | `value`                 |                                                                   | `string`  | `undefined` |
+| Property              | Attribute               | Description                                                                     | Type      | Default     |
+| --------------------- | ----------------------- | ------------------------------------------------------------------------------- | --------- | ----------- |
+| `assistiveText`       | `assistive-text`        |                                                                                 | `string`  | `undefined` |
+| `dense`               | `dense`                 |                                                                                 | `boolean` | `false`     |
+| `disabled`            | `disabled`              |                                                                                 | `boolean` | `false`     |
+| `error`               | `error`                 |                                                                                 | `boolean` | `false`     |
+| `floatLabel`          | `float-label`           |                                                                                 | `boolean` | `false`     |
+| `inputId`             | `input-id`              | The `id` attribute for the text input                                           | `string`  | `undefined` |
+| `label`               | `label`                 | Text for the label element                                                      | `string`  | `undefined` |
+| `labelClass`          | `label-class`           |                                                                                 | `string`  | `''`        |
+| `leftIcon`            | `left-icon`             | The class name of the icon to show on the left side of the input                | `string`  | `undefined` |
+| `maxlength`           | `maxlength`             |                                                                                 | `number`  | `undefined` |
+| `name`                | `name`                  | The `name` attribute for the text input                                         | `string`  | `undefined` |
+| `outerContainerClass` | `outer-container-class` |                                                                                 | `string`  | `''`        |
+| `placeholder`         | `placeholder`           | Placeholder text for the input. This will be ignored if `floatLabel` is `true`. | `string`  | `undefined` |
+| `readonly`            | `readonly`              |                                                                                 | `boolean` | `false`     |
+| `rightIcon`           | `right-icon`            | The class name of the icon to show on the right side of the input               | `string`  | `undefined` |
+| `suffix`              | `suffix`                | Text shown to the right of the input value                                      | `string`  | `undefined` |
+| `textarea`            | `textarea`              | Display a multi-line `textarea` instead of an `input`                           | `boolean` | `false`     |
+| `textareaHeight`      | `textarea-height`       |                                                                                 | `string`  | `'250px'`   |
+| `type`                | `type`                  | The `type` attribute for the text input                                         | `string`  | `'text'`    |
+| `value`               | `value`                 |                                                                                 | `string`  | `undefined` |
 
 ### CSS Variables
 


### PR DESCRIPTION
This adds a `placeholder` prop to `mx-input` that is only used when there isn't a floating label (since the floating label serves as the placeholder).