### PR TITLE
Fix failing mx-select unit test (due to recent icon change)

### DIFF
--- a/src/components/mx-select/test/mx-select.spec.tsx
+++ b/src/components/mx-select/test/mx-select.spec.tsx
@@ -109,7 +109,7 @@ describe('mx-select', () => {
   });
 
   it('displays an error icon when the error prop is set', async () => {
-    expect(selectWrapper.querySelector('i[data-testId=error-icon]')).not.toBeNull();
+    expect(selectWrapper.querySelector('[data-testid="error-icon"]')).not.toBeNull();
   });
 
   it('displays an arrow SVG when the error prop is NOT set', async () => {


### PR DESCRIPTION
This fixes a failing unit test that I broke with a139359e9e102ffcc77c6813c2fd0dd81f08466e (the `i` element was replaced with a `span` that wraps an SVG, so the selector in the unit test was wrong).