### PR TITLE
ENG-137505 - Snackbar Component

### DIFF
--- a/src/components/mx-snackbar/mx-snackbar.tsx
+++ b/src/components/mx-snackbar/mx-snackbar.tsx
@@ -1,0 +1,98 @@
+import { Component, Host, h, Element, Watch, Prop, Event, EventEmitter, State } from '@stencil/core';
+import { fadeOut, fadeScaleIn } from '../../utils/transitions';
+
+const snackbarQueue: { resolve: any; reject: any }[] = []; // Deferred promises
+
+@Component({
+  tag: 'mx-snackbar',
+  shadow: false,
+})
+export class MxSnackbar {
+  alertEl: HTMLElement;
+  durationTimer: NodeJS.Timeout;
+  portal: HTMLElement; // Snackbars are moved to a portal to break out of stacking contexts
+  queueItem: { resolve: Function; reject: Function };
+
+  @Prop() duration = 6000;
+  @Prop({ mutable: true, reflect: true }) isOpen = false;
+
+  @State() isVisible = false;
+
+  @Element() element: HTMLMxSnackbarElement;
+
+  @Event() mxClose: EventEmitter<void>;
+
+  @Watch('isOpen')
+  async toggleSnackbar() {
+    clearTimeout(this.durationTimer);
+    if (this.isOpen) {
+      try {
+        await this.waitForOtherSnackbars();
+        this.durationTimer = setTimeout(this.close.bind(this), this.duration);
+        this.isVisible = true;
+        fadeScaleIn(this.alertEl, undefined, 'center');
+      } catch (err) {
+        // Snackbar was closed programmatically before leaving the queue; do nothing.
+      }
+    } else {
+      this.removeFromQueue();
+      this.isVisible = false;
+      this.mxClose.emit();
+    }
+  }
+
+  waitForOtherSnackbars(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.queueItem = { resolve, reject };
+      snackbarQueue.push(this.queueItem);
+      if (snackbarQueue.length === 1) return resolve();
+    });
+  }
+
+  removeFromQueue() {
+    if (!this.queueItem) return;
+    const queueIndex = snackbarQueue.indexOf(this.queueItem);
+    snackbarQueue.splice(snackbarQueue.indexOf(this.queueItem), 1);
+    if (queueIndex === 0 && snackbarQueue.length > 0) snackbarQueue[0].resolve(); // Show next snackbar in queue
+  }
+
+  componentWillLoad() {
+    this.createSnackbarPortal();
+    this.portal.append(this.element);
+  }
+
+  createSnackbarPortal() {
+    this.portal = document.querySelector('.snackbar-portal');
+    if (this.portal) return;
+    this.portal = document.createElement('div');
+    this.portal.classList.add('snackbar-portal', 'mds');
+    document.body.append(this.portal);
+  }
+
+  async close() {
+    if (!this.isOpen) return;
+    await fadeOut(this.alertEl);
+    this.isOpen = false;
+  }
+
+  get alertClass(): string {
+    let str =
+      'mx-snackbar-alert flex flex-wrap items-center justify-between rounded-lg text-4 max-w-360 sm:w-360 shadow-6 px-16 py-14';
+    return str;
+  }
+
+  render() {
+    return (
+      <Host class={'flex fixed w-full z-50 left-0 bottom-40 px-16 justify-center' + (this.isVisible ? '' : ' hidden')}>
+        <div ref={el => (this.alertEl = el)} role="alert" class={this.alertClass}>
+          <p class="my-0">
+            <slot></slot>
+          </p>
+          <div class="ml-auto" onClick={this.close.bind(this)}>
+            <slot name="action"></slot>
+          </div>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/mx-snackbar/test/mx-snackbar.spec.tsx
+++ b/src/components/mx-snackbar/test/mx-snackbar.spec.tsx
@@ -1,0 +1,53 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import { MxSnackbar } from '../mx-snackbar';
+import { MxButton } from '../../mx-button/mx-button';
+
+jest.useFakeTimers();
+
+describe('mx-snackbar', () => {
+  let page: SpecPage;
+  let root: HTMLMxSnackbarElement;
+  let snackbarAlert: HTMLElement;
+  let button: HTMLMxButtonElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxSnackbar, MxButton],
+      html: `<mx-snackbar>
+        Test
+        <mx-button btn-type="text" slot="action">Dismiss</mx-button>
+      </mx-snackbar>`,
+    });
+    root = page.root as HTMLMxSnackbarElement;
+    snackbarAlert = root.querySelector('.mx-snackbar-alert');
+    button = root.querySelector('mx-button');
+  });
+
+  it('has a role of alert', () => {
+    expect(snackbarAlert.getAttribute('role')).toBe('alert');
+  });
+
+  it('is shown when isOpen is set', async () => {
+    expect(root.getAttribute('class').includes('hidden')).toBe(true);
+    root.isOpen = true;
+    await page.waitForChanges();
+    expect(root.getAttribute('class').includes('hidden')).toBe(false);
+  });
+
+  it('closes when the action button is clicked', async () => {
+    root.isOpen = true;
+    await page.waitForChanges();
+    button.click();
+    await page.waitForChanges();
+    expect(root.isOpen).toBe(false);
+  });
+
+  it('emits an mxClose event when it closes', async () => {
+    const listener = jest.fn();
+    root.addEventListener('mxClose', listener);
+    root.isOpen = true;
+    await page.waitForChanges();
+    button.click();
+    await page.waitForChanges();
+    expect(listener).toHaveBeenCalled();
+  });
+});

--- a/src/tailwind/mx-snackbar/index.scss
+++ b/src/tailwind/mx-snackbar/index.scss
@@ -1,0 +1,4 @@
+.mx-snackbar-alert {
+  background: var(--mds-bg-snackbar);
+  color: var(--mds-text-snackbar);
+}

--- a/src/tailwind/styles.css
+++ b/src/tailwind/styles.css
@@ -39,6 +39,7 @@
 @import './mx-page-header/index.scss';
 @import './mx-table/index.scss';
 @import './mx-pagination/index.scss';
+@import './mx-snackbar/index.scss';
 @import './ripple.scss';
 
 /***************************

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -324,4 +324,10 @@
   --mds-bg-pagination: #fff;
   --mds-text-pagination: #333;
   /* #endregion pagination */
+
+  /* #region snackbars */
+  /* Snackbars */
+  --mds-bg-snackbar: #202020;
+  --mds-text-snackbar: #fff;
+  /* #endregion snackbars */
 }

--- a/src/utils/transitions.ts
+++ b/src/utils/transitions.ts
@@ -65,8 +65,10 @@ function executeTransition(
           return `${transition.property} ${duration}ms ${transition.timing}`;
         })
         .join(', ');
-      transitionOptions.forEach(transition => {
-        setStyleProperty(el, transition.property, transition.endValue);
+      requestAnimationFrame(() => {
+        transitionOptions.forEach(transition => {
+          setStyleProperty(el, transition.property, transition.endValue);
+        });
       });
     });
     // Resolve once the duration passes (setTimeout is safer than transition events)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -77,6 +77,7 @@ const config = {
       256: '16rem',
       288: '18rem',
       320: '20rem',
+      360: '22.5rem',
       384: '24rem',
     },
     extend: {

--- a/vuepress/.vuepress/config.js
+++ b/vuepress/.vuepress/config.js
@@ -150,6 +150,7 @@ module.exports = {
         'tables',
         'page-headers',
         'pagination',
+        'snackbars',
       ],
     },
   },

--- a/vuepress/components/snackbars.md
+++ b/vuepress/components/snackbars.md
@@ -1,0 +1,63 @@
+# Snackbars
+
+Snackbars are used to alert the user of changes, usually in direct result of an action the user has taken. For example, a confirmation of a deleted item. These are utilitarian and should not be used for marketing alerts.
+
+The main content of the snackbar is placed in the default slot. If an action is needed, add a [Text Button](/components/buttons.html#text-buttons) to the `action` slot.
+
+If multiple snackbars are triggered, they will be queued and displayed consecutively.
+
+<!-- #region snackbars -->
+<section class="mds">
+  <div class="my-20">
+    <mx-button btn-type="action" @click="isOpen1 = true">Trigger Simple Snackbar</mx-button>
+    <mx-snackbar :is-open="isOpen1" @mxClose="isOpen1 = false">
+      Page has been published
+    </mx-snackbar>
+  </div>
+  <div class="my-20">
+    <mx-button btn-type="action" @click="isOpen2 = true">Trigger Snackbar with Action</mx-button>
+    <mx-snackbar :is-open="isOpen2" duration="5000" @mxClose="isOpen2 = false">
+      Page has been published
+      <mx-button slot="action" btn-type="text">Undo</mx-button>
+    </mx-snackbar>
+  </div>
+  <div class="my-20">
+    <mx-button btn-type="action" @click="isOpen3 = true">Trigger Multi-Line Snackbar with Action</mx-button>
+    <mx-snackbar :is-open="isOpen3" @mxClose="isOpen3 = false">
+      The <strong>Hello World</strong> page has been successfully published
+      <mx-button slot="action" btn-type="text">Dismiss</mx-button>
+    </mx-snackbar>
+  </div>
+</section>
+  <!-- #endregion snackbars -->
+
+<<< @/vuepress/components/snackbars.md#snackbars
+
+### Properties
+
+| Property   | Attribute  | Description | Type      | Default |
+| ---------- | ---------- | ----------- | --------- | ------- |
+| `duration` | `duration` |             | `number`  | `6000`  |
+| `isOpen`   | `is-open`  |             | `boolean` | `false` |
+
+### Events
+
+| Event     | Description | Type                |
+| --------- | ----------- | ------------------- |
+| `mxClose` |             | `CustomEvent<void>` |
+
+### CSS Variables
+
+<<< @/src/tailwind/variables/index.scss#snackbars
+
+<script>
+export default {
+  data() {
+    return {
+      isOpen1: false,
+      isOpen2: false,
+      isOpen3: false,
+    }
+  }
+}
+</script>


### PR DESCRIPTION
This implements `mx-snackbar`.  The message content is added via the default slot, and the optional action button is placed inside the named `action` slot.

Before the snackbar loads, a "portal" element is appended to the body (if not already created), and the snackbar is moved inside that portal.  This ensures that the fixed positioning is relative to _the page_--not some other stacking context, which can happen if a parent component has a CSS transform applied, for example.

The other tricky part to this component is that multiple snackbars do not stack per Material Design.  Instead, they are queued and shown sequentially.  This queue is implemented as an array of deferred promises.  Whenever a snackbar closes, it resolves the next promise in the queue.