### PR TITLE
ENG-137681 - Fix selection control issues with long labels

### DIFF
--- a/src/components/mx-checkbox/mx-checkbox.tsx
+++ b/src/components/mx-checkbox/mx-checkbox.tsx
@@ -17,7 +17,7 @@ export class MxCheckbox {
   @Prop() indeterminate: boolean = false;
 
   get checkClass(): string {
-    let str = 'flex h-18 w-18';
+    let str = 'flex h-18 w-18 flex-shrink-0';
     str += this.labelLeft ? ' order-2' : ' order-1';
     if (this.labelLeft && !this.hideLabel) str += ' ml-16';
     return str;

--- a/src/components/mx-radio/mx-radio.tsx
+++ b/src/components/mx-radio/mx-radio.tsx
@@ -21,7 +21,7 @@ export class MxRadio {
             value={this.value}
             checked={this.checked}
           />
-          <span class="flex h-20 w-20 cursor-pointer rounded-full"></span>
+          <span class="flex h-20 w-20 cursor-pointer flex-shrink-0 rounded-full"></span>
           <div class="ml-16 inline-block" data-testid="labelName">
             {this.labelName}
           </div>

--- a/src/components/mx-switch/mx-switch.tsx
+++ b/src/components/mx-switch/mx-switch.tsx
@@ -13,7 +13,7 @@ export class MxSwitch {
   render() {
     return (
       <Host class="mx-switch">
-        <label class="relative inline-flex flex-nowrap align-center items-center cursor-pointer text-4 w-36 h-14">
+        <label class="relative inline-flex flex-nowrap align-center items-center cursor-pointer text-4">
           <input
             class="absolute h-0 w-0 opacity-0"
             role="switch"
@@ -21,8 +21,8 @@ export class MxSwitch {
             name={this.name}
             checked={this.checked}
           />
-          <span class="slider round"></span>
-          <div class="pl-48 inline-block whitespace-nowrap" data-testid="labelName">
+          <div class="slider relative cursor-pointer round w-36 h-14 flex-shrink-0"></div>
+          <div class="ml-16 inline-block" data-testid="labelName">
             {this.labelName}
           </div>
         </label>

--- a/src/tailwind/mx-switch/index.scss
+++ b/src/tailwind/mx-switch/index.scss
@@ -1,11 +1,5 @@
 .mx-switch {
   .slider {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
     background-color: var(--mds-bg-switch-track);
     -webkit-transition: 0.4s;
     transition: 0.4s;

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -10,7 +10,7 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
     <div><mx-checkbox name="foo" label-name="Premier" checked /></div>
     <div><mx-checkbox name="foo" label-name="W Collection" /></div>
     <div><mx-checkbox name="foo" label-name="Equestrian" /></div>
-    <div><mx-checkbox name="foo" label-name="Warlock" /></div>
+    <div><mx-checkbox name="foo" label-name="Darkness falls across the land, The midnight hour is close at hand" /></div>
     <div><mx-checkbox name="foo" disabled label-name="Disabled" /></div>
     <div><mx-checkbox name="foo" checked disabled label-name="Disabled" /></div>
     <div><mx-checkbox name="foo" indeterminate label-name="Indeterminate" /></div>
@@ -43,7 +43,7 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
     <div><mx-radio name="foo" label-name="Premier" /></div>
     <div><mx-radio name="foo" label-name="W Collection" /></div>
     <div><mx-radio name="foo" label-name="Equestrian" /></div>
-    <div><mx-radio name="foo" label-name="Warlock" /></div>
+    <div><mx-radio name="foo" label-name="Darkness falls across the land, The midnight hour is close at hand" /></div>
   </div>
 </div>
 <!-- #endregion radio-buttons -->
@@ -67,7 +67,7 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
     <div><mx-switch name="foo" label-name="Premier" /></div>
     <div><mx-switch name="foo" label-name="W Collection" /></div>
     <div><mx-switch name="foo" label-name="Equestrian" /></div>
-    <div><mx-switch name="foo" label-name="Warlock" /></div>
+    <div><mx-switch name="foo" label-name="Darkness falls across the land, The midnight hour is close at hand" /></div>
   </div>
 </div>
 <!-- #endregion switches -->


### PR DESCRIPTION
Tweaked `mx-switch` a bit so that a multi-line label will now center with the switch.  I also tested long labels with checkboxes and radio buttons, and those just needed a `flex-shrink-0` class on the actual checkbox/button, but were otherwise good to go.

![image](https://user-images.githubusercontent.com/3342530/136077757-ce819754-df21-47fc-bffc-a2c6f8a8590f.png)
