### PR TITLE
Nested table rows

### DIFF
--- a/src/components/mx-table-cell/mx-table-cell.tsx
+++ b/src/components/mx-table-cell/mx-table-cell.tsx
@@ -26,9 +26,9 @@ export class MxTableCell {
   }
 
   get cellClass() {
-    let str = 'mx-table-cell flex items-center text-4';
+    let str = 'mx-table-cell flex flex-1 items-center text-4 overflow-hidden';
     if (!this.minWidths.sm && this.isExposedMobileColumn) str += ' row-start-1 exposed-cell';
-    else if (!this.minWidths.sm) str += ' py-0 pb-12 col-span-4';
+    else if (!this.minWidths.sm) str += ' py-0 pb-12 col-start-2 col-span-4';
     return str;
   }
 

--- a/src/components/mx-table/test/mx-table.spec.tsx
+++ b/src/components/mx-table/test/mx-table.spec.tsx
@@ -208,7 +208,7 @@ describe('mx-table (checkable, non-mobile)', () => {
 
   it('checks the row on click by default', async () => {
     const row = root.querySelector('mx-table-row');
-    row.click();
+    (row.children[0] as HTMLElement).click();
     await page.waitForChanges();
     expect(checkboxes[1].checked).toBe(true);
   });
@@ -244,9 +244,9 @@ describe('mx-table (checkable, non-mobile)', () => {
     const listener = (e: CustomEvent) => (emitted = e.detail);
     root.addEventListener('mxRowCheck', listener);
     const row = root.querySelector('mx-table-row');
-    row.click();
+    (row.children[0] as HTMLElement).click();
     expect(JSON.stringify(emitted)).toBe('["0"]');
-    row.click();
+    (row.children[0] as HTMLElement).click();
     expect(JSON.stringify(emitted)).toBe('[]');
   });
 
@@ -255,7 +255,7 @@ describe('mx-table (checkable, non-mobile)', () => {
       let checkedRowIds = await root.getCheckedRowIds();
       expect(checkedRowIds.length).toBe(0);
       const row = root.querySelector('mx-table-row');
-      row.click();
+      (row.children[0] as HTMLElement).click();
       checkedRowIds = await root.getCheckedRowIds();
       expect(checkedRowIds.length).toBe(1);
       expect(checkedRowIds[0]).toBe('0');
@@ -332,5 +332,44 @@ describe('mx-table (slotted rows and cells)', () => {
   it('does not render the empty state when mx-table-rows are passed without a rows prop', () => {
     const emptyState = root.querySelector('[data-testid="empty-state"]');
     expect(emptyState.classList.contains('hidden')).toBe(true);
+  });
+});
+
+describe('mx-table (nested rows, non-mobile)', () => {
+  let page: SpecPage;
+  let root: HTMLMxTableElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxTable, MxTableRow, MxTableCell, MxCheckbox],
+      html: `
+      <mx-table>
+        <mx-table-row>
+          <mx-table-cell>A</mx-table-cell>
+          <mx-table-row>
+            <mx-table-cell>A1</mx-table-cell>
+            <mx-table-row>
+              <mx-table-cell>A1i</mx-table-cell>
+            </mx-table-row>
+          </mx-table-row>
+          <mx-table-row>
+            <mx-table-cell>A2</mx-table-cell>
+          </mx-table-row>
+        </mx-table-row>
+        <mx-table-row>
+          <mx-table-cell>B</mx-table-cell>
+        </mx-table-row>
+      </mx-table>
+      `,
+    });
+    root = page.root as HTMLMxTableElement;
+    root.columns = [{ heading: 'Name', sortable: false }];
+    await page.waitForChanges();
+  });
+
+  it('adds an indent to nested rows', () => {
+    const rows = root.querySelectorAll('mx-table-row');
+    expect(rows[1].querySelector('[data-testid="indent-1"]')).not.toBeNull();
+    expect(rows[2].querySelector('[data-testid="indent-2"]')).not.toBeNull();
+    expect(rows[3].querySelector('[data-testid="indent-1"]')).not.toBeNull();
   });
 });

--- a/src/tailwind/mx-table/index.scss
+++ b/src/tailwind/mx-table/index.scss
@@ -20,7 +20,8 @@
     }
   }
 
-  .mx-table-row > *,
+  .mx-table-row > .table-row > *,
+  .first-column-wrapper > *,
   .empty-state > * {
     background: var(--mds-bg-table);
   }
@@ -40,55 +41,74 @@
   }
 
   .mx-table-row {
-    border-color: var(--mds-border-table-cell);
-    transition: max-height 0.15s ease;
-    & > :first-child:not(:empty) {
-      @apply pl-24;
+    & > .table-row {
+      border-color: var(--mds-border-table-cell);
+
+      & > :last-child:not(.pr-0, .p-0) {
+        @apply sm:pr-24;
+      }
+
+      & > * > .mx-table-row {
+        &:first-of-type {
+          @apply border-t sm:border-t-0;
+        }
+        &:last-of-type {
+          @apply border-b-0;
+        }
+      }
+      &:focus-within > *,
+      &:focus-within > .first-column-wrapper > *:not(.table-row-indent) {
+        background: var(--mds-bg-table-focus);
+      }
+      .first-column-wrapper > :nth-child(2) {
+        @apply pl-24;
+      }
+      .mobile-row-chevron {
+        color: var(--mds-text-table-mobile-row-chevron);
+        transition: transform 0.15s ease;
+      }
+      &.mobile-collapsed {
+        .mx-table-cell:not(.exposed-cell),
+        .action-cell {
+          @apply sr-only;
+        }
+      }
+      &.checkable-row .exposed-cell {
+        @apply pl-16;
+      }
+      .table-row-indent {
+        background: var(--mds-bg-table-indent);
+      }
     }
-    & > :last-child:not(.pr-0, .p-0) {
-      @apply sm:pr-24;
-    }
-    &:last-child {
+
+    &:last-child > .table-row {
+      @apply rounded-b-2xl;
+
       & > :first-child {
-        @apply rounded-bl-2xl;
+        @apply sm:rounded-bl-2xl;
       }
       & > :last-child {
-        @apply rounded-br-2xl;
+        @apply sm:rounded-br-2xl;
       }
     }
-    &:not(:last-child) {
+    &:not(:last-child) > .table-row {
       @apply border-b sm:border-b-0;
     }
-    &:not(:last-child) > * {
+    &:not(:last-child) > .table-row > * {
       @apply sm:border-b;
-    }
-    &:focus-within > * {
-      background: var(--mds-bg-table-focus);
-    }
-    .mobile-row-chevron {
-      color: var(--mds-text-table-mobile-row-chevron);
-      transition: transform 0.15s ease;
-    }
-    &.mobile-collapsed {
-      .mx-table-cell:not(.exposed-cell),
-      .action-cell {
-        @apply sr-only;
-      }
-    }
-    &.checkable-row .exposed-cell {
-      @apply pl-16;
     }
   }
 
   @media (hover: hover) {
-    &.hoverable .mx-table-row:not(:focus-within):hover > * {
+    &.hoverable .hovered-row > *,
+    &.hoverable .hovered-row > .first-column-wrapper > *:not(.table-row-indent) {
       background: var(--mds-bg-table-hover);
     }
   }
 
   &.paginated {
-    .mx-table-row:last-child {
-      @apply border-b;
+    .mx-table-row:last-child > .table-row {
+      @apply border-b rounded-b-none;
       & > * {
         @apply sm:border-b;
       }

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -318,6 +318,7 @@
   /* Data Tables */
   --mds-bg-table-focus: #e0e0e0;
   --mds-bg-table-hover: #f5f5f5;
+  --mds-bg-table-indent: #e3e3e3;
   --mds-bg-table-header: #fefefe;
   --mds-bg-table: #fff;
   --mds-border-table-header: #eaeaea;

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -410,7 +410,7 @@ The `rows` array is not mutated by the component, so you must update the array u
 
 When using `mx-table-row` elements within the table's default slot, it is possible to nest table rows.
 
-For the sake of simplicity, row dragging does not actually update the model in the example below.
+The example below combines nested rows with the `draggableRows` prop. For the sake of simplicity, the model in this example is not actually updated when a row is dropped. It is a good idea to provide a `rowId` when nesting draggable rows; the `rowId` will be emitted via the `mxRowMove` event, as well as the `oldIndex` and `newIndex` (relative to its siblings).
 
 <section class="mds">
   <div class="mt-20"></div>
@@ -423,37 +423,38 @@ For the sake of simplicity, row dragging does not actually update the model in t
         { heading: 'Qty', sortable: false, align: 'right'  },
         { heading: 'Total Cost', sortable: false, align: 'right' }
       ]"
+      @mxRowMove="onNestedRowMove"
     >
       <div>
-        <mx-table-row>
+        <mx-table-row row-id="0">
           <mx-table-cell>Chair</mx-table-cell>
           <mx-table-cell>$65.00</mx-table-cell>
           <mx-table-cell>1</mx-table-cell>
           <mx-table-cell>$65.00</mx-table-cell>
         </mx-table-row>
-        <mx-table-row>
+        <mx-table-row row-id="1">
           <mx-table-cell>Produce</mx-table-cell>
           <mx-table-cell>-</mx-table-cell>
           <mx-table-cell>-</mx-table-cell>
           <mx-table-cell>$24.94</mx-table-cell>
-          <mx-table-row>
+          <mx-table-row row-id="2">
             <mx-table-cell>Roma Tomato (lb)</mx-table-cell>
             <mx-table-cell>$0.99</mx-table-cell>
             <mx-table-cell>12</mx-table-cell>
             <mx-table-cell>$11.88</mx-table-cell>
           </mx-table-row>
-          <mx-table-row>
+          <mx-table-row row-id="3">
             <mx-table-cell>Avocado, Large</mx-table-cell>
             <mx-table-cell>$1.79</mx-table-cell>
             <mx-table-cell>4</mx-table-cell>
             <mx-table-cell>$7.16</mx-table-cell>
           </mx-table-row>
-          <mx-table-row>
+          <mx-table-row row-id="4">
             <mx-table-cell>Cucumber</mx-table-cell>
             <mx-table-cell>-</mx-table-cell>
             <mx-table-cell>-</mx-table-cell>
             <mx-table-cell>$5.90</mx-table-cell>
-            <mx-table-row>
+            <mx-table-row row-id="5">
               <mx-table-cell>English Cucumber</mx-table-cell>
               <mx-table-cell>$2.59</mx-table-cell>
               <mx-table-cell>10</mx-table-cell>
@@ -461,7 +462,7 @@ For the sake of simplicity, row dragging does not actually update the model in t
             </mx-table-row>
           </mx-table-row>
         </mx-table-row>
-        <mx-table-row>
+        <mx-table-row row-id="6">
           <mx-table-cell>Apron</mx-table-cell>
           <mx-table-cell>$16.00</mx-table-cell>
           <mx-table-cell>4</mx-table-cell>
@@ -474,6 +475,7 @@ For the sake of simplicity, row dragging does not actually update the model in t
 </section>
 
 <<< @/vuepress/components/tables.md#indent
+<<< @/vuepress/components/tables.md#nested-row-move
 
 ## Advanced usage
 
@@ -1072,6 +1074,14 @@ export default {
       this.draggableBeatles = beatles
     },
     // #endregion row-move
+    // #region nested-row-move
+    onNestedRowMove(e) {
+      const { rowId, oldIndex, newIndex } = e.detail
+      const upOrDown = oldIndex < newIndex ? 'down' : 'up'
+      const distance = Math.abs(newIndex - oldIndex)
+      console.log(`Row with id ${rowId} was moved ${upOrDown} ${distance} position(s).`)
+    },
+    // #endregion nested-row-move
     // #region api-request
     async getApiData() {
       this.apiLoading = true

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -406,6 +406,75 @@ The `rows` array is not mutated by the component, so you must update the array u
 <<< @/vuepress/components/tables.md#draggable
 <<< @/vuepress/components/tables.md#row-move
 
+## Nested rows
+
+When using `mx-table-row` elements within the table's default slot, it is possible to nest table rows.
+
+For the sake of simplicity, row dragging does not actually update the model in the example below.
+
+<section class="mds">
+  <div class="mt-20"></div>
+    <!-- #region indent -->
+    <mx-table
+      draggable-rows
+      :columns.prop="[
+        { heading: 'Item', sortable: false },
+        { heading: 'Cost', sortable: false, align: 'right' },
+        { heading: 'Qty', sortable: false, align: 'right'  },
+        { heading: 'Total Cost', sortable: false, align: 'right' }
+      ]"
+    >
+      <div>
+        <mx-table-row>
+          <mx-table-cell>Chair</mx-table-cell>
+          <mx-table-cell>$65.00</mx-table-cell>
+          <mx-table-cell>1</mx-table-cell>
+          <mx-table-cell>$65.00</mx-table-cell>
+        </mx-table-row>
+        <mx-table-row>
+          <mx-table-cell>Produce</mx-table-cell>
+          <mx-table-cell>-</mx-table-cell>
+          <mx-table-cell>-</mx-table-cell>
+          <mx-table-cell>$24.94</mx-table-cell>
+          <mx-table-row>
+            <mx-table-cell>Roma Tomato (lb)</mx-table-cell>
+            <mx-table-cell>$0.99</mx-table-cell>
+            <mx-table-cell>12</mx-table-cell>
+            <mx-table-cell>$11.88</mx-table-cell>
+          </mx-table-row>
+          <mx-table-row>
+            <mx-table-cell>Avocado, Large</mx-table-cell>
+            <mx-table-cell>$1.79</mx-table-cell>
+            <mx-table-cell>4</mx-table-cell>
+            <mx-table-cell>$7.16</mx-table-cell>
+          </mx-table-row>
+          <mx-table-row>
+            <mx-table-cell>Cucumber</mx-table-cell>
+            <mx-table-cell>-</mx-table-cell>
+            <mx-table-cell>-</mx-table-cell>
+            <mx-table-cell>$5.90</mx-table-cell>
+            <mx-table-row>
+              <mx-table-cell>English Cucumber</mx-table-cell>
+              <mx-table-cell>$2.59</mx-table-cell>
+              <mx-table-cell>10</mx-table-cell>
+              <mx-table-cell>$25.90</mx-table-cell>
+            </mx-table-row>
+          </mx-table-row>
+        </mx-table-row>
+        <mx-table-row>
+          <mx-table-cell>Apron</mx-table-cell>
+          <mx-table-cell>$16.00</mx-table-cell>
+          <mx-table-cell>4</mx-table-cell>
+          <mx-table-cell>$64.00</mx-table-cell>
+        </mx-table-row>
+      </div>
+    </mx-table>
+<!-- #endregion indent -->
+  </div>
+</section>
+
+<<< @/vuepress/components/tables.md#indent
+
 ## Advanced usage
 
 The following example combines checkable, slotted table rows with pagination, row actions, multi-row actions, searching, and filtering.


### PR DESCRIPTION
This is a pretty heavy refactor, mostly of the `mx-table-row` component.

Long-winded explanations of a few big changes that may or may not help:

- The row checkbox and drag handle used to be in separate grid cells, but the design of the indenting requires them to be in the same grid cell as the first `mx-table-cell`.  Since that first `mx-table-cell` can come from the default slot, I have to actually move the element during `componentWillRender` (see `wrapFirstColumn()`).
- Similarly, the slotted, nested rows need to be outside the `rowEl` container that collapses on mobile, so I have to also move nested `mx-table-row` elements during `componentWillRender` (see `moveNestedRows()`).  I could have used a named slot specifically for the child rows to avoid this, but there still would have been some hacky-ness to it, so I opted for the path that gave the consumer the simplest API.
- The `mx-table-row` element has some new methods.  The `getChildren` method gets all the child elements that need to be moved on drag.  It excludes any wrapper elements that are `display: contents`, and it recurses for nested rows.  The `getHeight` method calculates the height of the row, including the height of its nested rows, which is also needed for dragging.  Stencil requires all component methods to return a promise, so there's a lot more `async/await` everywhere now.