### PR TITLE
Table subheader rows

### DIFF
--- a/src/components/mx-table-cell/mx-table-cell.tsx
+++ b/src/components/mx-table-cell/mx-table-cell.tsx
@@ -26,7 +26,7 @@ export class MxTableCell {
   }
 
   get cellClass() {
-    let str = 'mx-table-cell flex flex-1 items-center text-4 overflow-hidden';
+    let str = 'mx-table-cell flex flex-1 items-center overflow-hidden';
     if (!this.minWidths.sm && this.isExposedMobileColumn) str += ' row-start-1 exposed-cell';
     else if (!this.minWidths.sm) str += ' py-0 pb-12 col-start-2 col-span-4';
     return str;
@@ -35,7 +35,7 @@ export class MxTableCell {
   render() {
     return (
       <Host role="gridcell" aria-describedby={`column-header-${this.columnIndex}`} class={this.cellClass}>
-        <div class="min-h-20 max-w-full break-words">
+        <div class="min-h-16 max-w-full break-words">
           {!this.minWidths.sm && !this.isExposedMobileColumn && this.heading != null && (
             <p class="subtitle5 my-0 mb-4" innerHTML={this.heading}></p>
           )}

--- a/src/components/mx-table-cell/mx-table-cell.tsx
+++ b/src/components/mx-table-cell/mx-table-cell.tsx
@@ -8,7 +8,7 @@ import { minWidthSync, MinWidths } from '../../utils/minWidthSync';
 export class MxTableCell {
   /** This is automatically set by the parent `mx-table`. */
   @Prop({ reflect: true }) isExposedMobileColumn: boolean = true;
-  /** This is automatically set by the parent `mx-table`. */
+  /** This is automatically set by the parent `mx-table`.  For subheaders, this will be null. */
   @Prop({ reflect: true }) columnIndex: number;
   /** This is automatically set by the parent `mx-table`. */
   @Prop() heading: string;

--- a/src/components/mx-table-cell/mx-table-cell.tsx
+++ b/src/components/mx-table-cell/mx-table-cell.tsx
@@ -34,8 +34,12 @@ export class MxTableCell {
 
   render() {
     return (
-      <Host role="gridcell" aria-describedby={`column-header-${this.columnIndex}`} class={this.cellClass}>
-        <div class="min-h-16 max-w-full break-words">
+      <Host
+        role="gridcell"
+        aria-describedby={this.columnIndex != null ? `column-header-${this.columnIndex}` : null}
+        class={this.cellClass}
+      >
+        <div class="min-h-16 max-w-full break-words" role={this.columnIndex == null ? 'heading' : null}>
           {!this.minWidths.sm && !this.isExposedMobileColumn && this.heading != null && (
             <p class="subtitle5 my-0 mb-4" innerHTML={this.heading}></p>
           )}

--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -74,7 +74,7 @@ export class MxTableRow {
     const table = this.element.closest('mx-table') as HTMLMxTableElement;
     this.checkable = table && table.checkable;
     this.isDraggable = table && table.draggableRows;
-    this.columnCount = table && table.columns.length;
+    this.columnCount = (table && table.columns.length) + (this.actions.length ? 1 : 0);
     if (this.checkable && this.rowId == null)
       throw new Error('Checkable rows require either a getRowId prop on the table, or a rowId on the row!');
     if (this.checkable) this.checkOnRowClick = table.checkOnRowClick;
@@ -122,7 +122,7 @@ export class MxTableRow {
     if (!this.minWidths.sm) {
       // Collapse/expand row when the exposed column cell is clicked
       const exposedCell = this.getExposedCell();
-      if (!exposedCell || this.subheader || (this.columnCount < 2 && !this.actions.length)) return;
+      if (!exposedCell || this.subheader || this.columnCount < 2) return;
       if ((e.target as HTMLElement).closest('mx-table-cell') === exposedCell) this.accordion();
     } else if (this.checkable && this.checkOnRowClick) {
       // (Un)check row
@@ -380,9 +380,7 @@ export class MxTableRow {
     let str = 'table-row-indent h-full';
     if (this.minWidths.sm) return str;
     str += ' col-start-1 row-start-1';
-    let gridRowCount = this.columnCount;
-    if (this.actions.length > 0) gridRowCount++;
-    return (str += ' row-span-' + gridRowCount);
+    return (str += ' row-span-' + this.columnCount);
   }
 
   get indentStyle() {
@@ -406,7 +404,10 @@ export class MxTableRow {
           {/* On mobile, display:contents allows those same elements to fall into the row grid. */}
           <div
             ref={el => (this.firstColumnWrapper = el)}
-            class="first-column-wrapper contents sm:flex sm:items-center min-w-0 overflow-hidden"
+            class={
+              'first-column-wrapper contents sm:flex sm:items-center min-w-0 overflow-hidden' +
+              (this.subheader ? ' sm:col-span-full' : '')
+            }
           >
             {/* Indent */}
             <div class={this.indentClass} style={this.indentStyle} data-testid={'indent-' + this.indentLevel}></div>
@@ -458,7 +459,7 @@ export class MxTableRow {
           {/* Mobile drag-handle column filler */}
           {!this.isDraggable && !this.minWidths.sm && <div class="row-start-1 col-start-3 w-0"></div>}
           {/* Mobile accordion chevron */}
-          {!this.minWidths.sm && !this.subheader && (this.columnCount > 1 || this.actions.length) && (
+          {!this.minWidths.sm && !this.subheader && this.columnCount > 1 && (
             <button
               class="flex border-0 items-center justify-end px-16 row-start-1"
               aria-hidden="true"

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -308,15 +308,19 @@ export class MxTable {
   }
 
   setCellProps() {
-    const cells = this.element.querySelectorAll('mx-table-cell');
-    let colIndex = 0;
-    cells.forEach((cell: HTMLMxTableCellElement) => {
-      cell.columnIndex = colIndex;
-      cell.isExposedMobileColumn = colIndex === this.exposedMobileColumnIndex;
-      cell.heading = this.cols[colIndex].heading;
-      cell.classList.add(...this.getAlignClass(this.cols[colIndex]).split(' '));
-      if (colIndex === this.cols.length - 1) colIndex = 0;
-      else colIndex++;
+    const rows = this.getTableRows();
+    rows.forEach((row: HTMLMxTableRowElement) => {
+      if (row.subheader) return;
+      const cells = row.querySelectorAll('mx-table-cell');
+      let colIndex = 0;
+      cells.forEach((cell: HTMLMxTableCellElement) => {
+        cell.columnIndex = colIndex;
+        cell.isExposedMobileColumn = colIndex === this.exposedMobileColumnIndex;
+        cell.heading = this.cols[colIndex].heading;
+        cell.classList.add(...this.getAlignClass(this.cols[colIndex]).split(' '));
+        if (colIndex === this.cols.length - 1) colIndex = 0;
+        else colIndex++;
+      });
     });
   }
 

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -338,6 +338,13 @@ export class MxTable {
     this.showOperationsBar = !!this.getMultiRowActions || this.hasFilter || this.hasSearch;
     this.hasActionsColumnFromSlot =
       this.hasDefaultSlot && this.getTableRows().some(row => row.actions && row.actions.length);
+    const rows = this.getTableRows();
+    if (!this.paginate) {
+      rows.forEach((row, i) => {
+        const addOrRemove = i === rows.length - 1 ? 'add' : 'remove';
+        row.classList[addOrRemove]('last-row');
+      });
+    }
     requestAnimationFrame(this.setCellProps.bind(this));
   }
 
@@ -595,7 +602,7 @@ export class MxTable {
     );
 
     return (
-      <Host class={'mx-table block' + (this.hoverable ? ' hoverable' : '') + (this.paginate ? ' paginated' : '')}>
+      <Host class={'mx-table block text-4' + (this.hoverable ? ' hoverable' : '')}>
         {/* Operations Bar */}
         {this.showOperationsBar && operationsBar}
 
@@ -643,20 +650,22 @@ export class MxTable {
                     )}
                   </div>
                 </div>
-                <div class="flex items-center">
-                  <mx-icon-button
-                    data-testid="previous-column-button"
-                    chevronLeft
-                    disabled={this.exposedMobileColumnIndex === 0}
-                    onClick={this.changeExposedColumnIndex.bind(this, -1)}
-                  />
-                  <mx-icon-button
-                    data-testid="next-column-button"
-                    chevronRight
-                    disabled={this.exposedMobileColumnIndex === this.cols.length - 1}
-                    onClick={this.changeExposedColumnIndex.bind(this, 1)}
-                  />
-                </div>
+                {this.columns.length >= 2 && (
+                  <div class="flex items-center">
+                    <mx-icon-button
+                      data-testid="previous-column-button"
+                      chevronLeft
+                      disabled={this.exposedMobileColumnIndex === 0}
+                      onClick={this.changeExposedColumnIndex.bind(this, -1)}
+                    />
+                    <mx-icon-button
+                      data-testid="next-column-button"
+                      chevronRight
+                      disabled={this.exposedMobileColumnIndex === this.cols.length - 1}
+                      onClick={this.changeExposedColumnIndex.bind(this, 1)}
+                    />
+                  </div>
+                )}
               </div>
             )}
             {this.minWidths.sm && this.hasActionsColumn && <div></div>}

--- a/src/components/mx-table/test/mx-table.spec.tsx
+++ b/src/components/mx-table/test/mx-table.spec.tsx
@@ -355,8 +355,11 @@ describe('mx-table (nested rows, non-mobile)', () => {
             <mx-table-cell>A2</mx-table-cell>
           </mx-table-row>
         </mx-table-row>
-        <mx-table-row>
+        <mx-table-row subheader>
           <mx-table-cell>B</mx-table-cell>
+          <mx-table-row>
+            <mx-table-cell>C</mx-table-cell>
+          </mx-table-row>
         </mx-table-row>
       </mx-table>
       `,
@@ -371,5 +374,10 @@ describe('mx-table (nested rows, non-mobile)', () => {
     expect(rows[1].querySelector('[data-testid="indent-1"]')).not.toBeNull();
     expect(rows[2].querySelector('[data-testid="indent-2"]')).not.toBeNull();
     expect(rows[3].querySelector('[data-testid="indent-1"]')).not.toBeNull();
+  });
+
+  it('does not add an indent to rows nested under a subheader row', () => {
+    const rows = root.querySelectorAll('mx-table-row');
+    expect(rows[4].querySelector('[data-testid="indent-0"]')).not.toBeNull();
   });
 });

--- a/src/tailwind/mx-table/index.scss
+++ b/src/tailwind/mx-table/index.scss
@@ -25,6 +25,11 @@
   .empty-state > * {
     background: var(--mds-bg-table);
   }
+  .mx-table-row > .table-row.subheader > *,
+  .table-row.subheader > .first-column-wrapper > * {
+    background: var(--mds-bg-table-subheader);
+    color: var(--mds-text-table-subheader);
+  }
 
   .empty-state {
     &:last-child {
@@ -79,9 +84,12 @@
       .table-row-indent {
         background: var(--mds-bg-table-indent);
       }
+      .drag-handle {
+        color: var(--mds-text-table-drag-handle);
+      }
     }
 
-    &:last-child > .table-row {
+    &.last-row > .table-row {
       @apply rounded-b-2xl;
 
       & > :first-child {
@@ -91,37 +99,25 @@
         @apply sm:rounded-br-2xl;
       }
     }
-    &:not(:last-child) > .table-row {
+    &:not(.last-row) > .table-row {
       @apply border-b sm:border-b-0;
     }
-    &:not(:last-child) > .table-row > * {
+    &:not(.last-row) > .table-row > * {
       @apply sm:border-b;
     }
   }
 
   @media (hover: hover) {
-    &.hoverable .hovered-row > *,
-    &.hoverable .hovered-row > .first-column-wrapper > *:not(.table-row-indent) {
+    &.hoverable .hovered-row:not(.subheader) > *,
+    &.hoverable .hovered-row:not(.subheader) > .first-column-wrapper > *:not(.table-row-indent) {
       background: var(--mds-bg-table-hover);
-    }
-  }
-
-  &.paginated {
-    .mx-table-row:last-child > .table-row {
-      @apply border-b rounded-b-none;
-      & > * {
-        @apply sm:border-b;
-      }
-      & > :first-child {
-        @apply rounded-bl-none;
-      }
-      & > :last-child {
-        @apply rounded-br-none;
-      }
     }
   }
 }
 
 .mx-table-cell {
   @apply pl-24 sm:pl-16 p-16;
+}
+.subheader > .first-column-wrapper > .mx-table-cell {
+  @apply pl-24 sm:pl-12 p-12;
 }

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -320,11 +320,14 @@
   --mds-bg-table-hover: #f5f5f5;
   --mds-bg-table-indent: #e3e3e3;
   --mds-bg-table-header: #fefefe;
+  --mds-bg-table-subheader: #dde8f4;
   --mds-bg-table: #fff;
   --mds-border-table-header: #eaeaea;
   --mds-border-table-cell: #e8e8e8;
   --mds-text-table: #333;
   --mds-text-table-mobile-row-chevron: #0457af;
+  --mds-text-table-drag-handle: #c5c5c5;
+  --mds-text-table-subheader: #0457af;
   /* #endregion tables */
 
   /* #region modals */

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -413,7 +413,7 @@ When using `mx-table-row` elements within the table's default slot, it is possib
 The example below combines nested rows with the `draggableRows` prop. For the sake of simplicity, the model in this example is not actually updated when a row is dropped. It is a good idea to provide a `rowId` when nesting draggable rows; the `rowId` will be emitted via the `mxRowMove` event, as well as the `oldIndex` and `newIndex` (relative to its siblings).
 
 <section class="mds">
-  <div class="mt-20"></div>
+  <div class="mt-20">
     <!-- #region indent -->
     <mx-table
       draggable-rows
@@ -476,6 +476,54 @@ The example below combines nested rows with the `draggableRows` prop. For the sa
 
 <<< @/vuepress/components/tables.md#indent
 <<< @/vuepress/components/tables.md#nested-row-move
+
+## Subheader rows
+
+Adding the `subheader` prop to a row styles it as a subheader. Only one `mx-table-cell` is necessary for the subheader content. When used inside a table with draggable rows, it can be used to drag a group of nested rows.
+
+<section class="mds">
+  <div class="mt-20">
+    <!-- #region subheaders -->
+    <mx-table
+      auto-width
+      paginate="false"
+      draggable-rows
+      :columns.prop="[
+        { heading: 'Name' },
+      ]"
+    >
+      <div>
+        <mx-table-row subheader>
+          <mx-table-cell>Core Tools</mx-table-cell>
+          <mx-table-row>
+            <mx-table-cell>Matrix</mx-table-cell>
+          </mx-table-row>
+          <mx-table-row>
+            <mx-table-cell>Remine</mx-table-cell>
+          </mx-table-row>
+          <mx-table-row>
+            <mx-table-cell>Realist</mx-table-cell>
+          </mx-table-row>
+        </mx-table-row subheader>
+        <mx-table-row subheader>
+          <mx-table-cell>Additional Benefits</mx-table-cell>
+          <mx-table-row>
+            <mx-table-cell>Builders Update</mx-table-cell>
+          </mx-table-row>
+          <mx-table-row>
+            <mx-table-cell>ePropertyWatch</mx-table-cell>
+          </mx-table-row>
+          <mx-table-row>
+            <mx-table-cell>Homes.com</mx-table-cell>
+          </mx-table-row>
+        </mx-table-row subheader>
+      </div>
+    </mx-table>
+    <!-- #endregion subheaders -->
+  </div>
+</section>
+
+<<< @/vuepress/components/tables.md#subheaders
 
 ## Advanced usage
 
@@ -601,11 +649,12 @@ The `ITableColumn` interface describes the objects passed to the `columns` prop.
 
 ### Table Row Properties
 
-| Property  | Attribute | Description                                                                                                           | Type                | Default     |
-| --------- | --------- | --------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------- |
-| `actions` | --        | An array of Menu Item props to create the actions menu, including a `value` property for each menu item's inner text. | `ITableRowAction[]` | `[]`        |
-| `checked` | `checked` |                                                                                                                       | `boolean`           | `false`     |
-| `rowId`   | `row-id`  | This is required for checkable rows in order to persist the checked state through sorting and pagination.             | `string`            | `undefined` |
+| Property    | Attribute   | Description                                                                                                           | Type                | Default     |
+| ----------- | ----------- | --------------------------------------------------------------------------------------------------------------------- | ------------------- | ----------- |
+| `actions`   | --          | An array of Menu Item props to create the actions menu, including a `value` property for each menu item's inner text. | `ITableRowAction[]` | `[]`        |
+| `checked`   | `checked`   |                                                                                                                       | `boolean`           | `false`     |
+| `rowId`     | `row-id`    | This is required for checkable rows in order to persist the checked state through sorting and pagination.             | `string`            | `undefined` |
+| `subheader` | `subheader` | Style the row as a subheader.                                                                                         | `boolean`           | `false`     |
 
 ### Table Events
 


### PR DESCRIPTION
This adds a `subheader` prop to `mx-table-row`, which causes the row to be styled per the design.  Any rows nested inside a subheader row are not indented.

In testing this, I noticed some bugs with single-column tables (the mobile rows showed the accordion button even though there was no content to reveal), so those have been fixed.

I discovered that the confusing combination of pseudo-selectors I was using for the rounded bottom corners of non-paginated tables didn't work when the last row was a nested row, so I ended up toggling a `last-row` class using javascript instead.

And finally, I added a color variable for the row drag handle, and I set it to match the examples in the Stellar design.

![subheaders](https://user-images.githubusercontent.com/3342530/139705734-5c2f3e5b-54d6-4dea-aa9c-dd872ade0be9.gif)
