### PR TITLE
Fix check-all checkbox state for slotted rows

### DIFF
--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -393,11 +393,23 @@ export class MxTable {
   }
 
   get allRowsChecked(): boolean {
-    return this.rows.length && this.rows.length === this.checkedRowIds.length;
+    if (this.checkedRowIds.length === 0) return false;
+    if (this.rows && this.rows.length) {
+      return this.rows.length === this.checkedRowIds.length;
+    } else if (this.hasDefaultSlot) {
+      return this.getTableRows().length === this.checkedRowIds.length;
+    }
+    return false;
   }
 
   get someRowsChecked(): boolean {
-    return this.checkedRowIds.length > 0 && this.checkedRowIds.length < this.rows.length;
+    if (this.checkedRowIds.length === 0) return false;
+    if (this.rows && this.rows.length) {
+      return this.checkedRowIds.length < this.rows.length;
+    } else if (this.hasDefaultSlot) {
+      return this.checkedRowIds.length < this.getTableRows().length;
+    }
+    return false;
   }
 
   get multiRowActions(): ITableRowAction[] {

--- a/src/components/mx-table/test/mx-table.spec.tsx
+++ b/src/components/mx-table/test/mx-table.spec.tsx
@@ -347,6 +347,10 @@ describe('mx-table (slotted rows and cells)', () => {
     await page.waitForChanges();
     expect(checkbox.indeterminate).toBe(false);
     expect(checkbox.checked).toBe(true);
+    checkbox.click();
+    await page.waitForChanges();
+    expect(checkbox.indeterminate).toBe(false);
+    expect(checkbox.checked).toBe(false);
   });
 });
 

--- a/src/components/mx-table/test/mx-table.spec.tsx
+++ b/src/components/mx-table/test/mx-table.spec.tsx
@@ -298,12 +298,12 @@ describe('mx-table (slotted rows and cells)', () => {
     page = await newSpecPage({
       components: [MxTable, MxTableRow, MxTableCell, MxCheckbox, MxPagination],
       html: `
-      <mx-table>
-        <mx-table-row>
+      <mx-table checkable>
+        <mx-table-row row-id="0">
           <mx-table-cell>Santa</mx-table-cell>
           <mx-table-cell>Claus</mx-table-cell>
         </mx-table-row>
-        <mx-table-row>
+        <mx-table-row row-id="1">
           <mx-table-cell>Great</mx-table-cell>
           <mx-table-cell>Pumpkin</mx-table-cell>
         </mx-table-row>
@@ -332,6 +332,21 @@ describe('mx-table (slotted rows and cells)', () => {
   it('does not render the empty state when mx-table-rows are passed without a rows prop', () => {
     const emptyState = root.querySelector('[data-testid="empty-state"]');
     expect(emptyState.classList.contains('hidden')).toBe(true);
+  });
+
+  it('updates the (un)check-all checkbox state when rows are (un)checked', async () => {
+    const checkbox = root.querySelector('mx-checkbox');
+    expect(checkbox.indeterminate).toBe(false);
+    expect(checkbox.checked).toBe(false);
+    const rows = root.querySelectorAll('mx-table-row');
+    (rows[0].children[0] as HTMLElement).click();
+    await page.waitForChanges();
+    expect(checkbox.indeterminate).toBe(true);
+    expect(checkbox.checked).toBe(false);
+    (rows[1].children[0] as HTMLElement).click();
+    await page.waitForChanges();
+    expect(checkbox.indeterminate).toBe(false);
+    expect(checkbox.checked).toBe(true);
   });
 });
 


### PR DESCRIPTION
This updates the `allRowsChecked` and `someRowsChecked` getters to work with rows that are purely slotted.  The check-all checkbox uses those two getters for its `checked` and `indeterminate` states.  I added a unit test for this as well.