### PR TITLE
Implement Dialog Component

### DIFF
--- a/src/components/mx-dialog/mx-dialog.tsx
+++ b/src/components/mx-dialog/mx-dialog.tsx
@@ -96,7 +96,7 @@ export class MxDialog {
   async showDialog() {
     this.ancestorFocusedElement = document.activeElement as HTMLElement;
     moveToPortal(this.element);
-    lockBodyScroll();
+    lockBodyScroll(this.element);
     this.isVisible = true;
     await new Promise(resolve => requestAnimationFrame(resolve));
     await Promise.all([fadeIn(this.backdrop), fadeScaleIn(this.modal)]);
@@ -105,7 +105,7 @@ export class MxDialog {
   async closeDialog(isConfirmed = false) {
     await Promise.all([fadeOut(this.backdrop), fadeOut(this.modal)]);
     this.isVisible = false;
-    unlockBodyScroll();
+    unlockBodyScroll(this.element);
     // Restore focus to the element that was focused before the modal was opened
     this.ancestorFocusedElement && this.ancestorFocusedElement.focus();
     this.deferredResolve(isConfirmed);

--- a/src/components/mx-dialog/mx-dialog.tsx
+++ b/src/components/mx-dialog/mx-dialog.tsx
@@ -79,6 +79,10 @@ export class MxDialog {
     return this.open(message, { heading, confirmLabel, cancelLabel });
   }
 
+  disconnectedCallback() {
+    unlockBodyScroll(this.element);
+  }
+
   /** Opens a dialog using the provided parameters.
    * If/when we implement confirmation dialogs with inputs, radio groups, etc. this method can be
    * exposed with additional parameters needed to create those dialogs. */

--- a/src/components/mx-dialog/mx-dialog.tsx
+++ b/src/components/mx-dialog/mx-dialog.tsx
@@ -1,0 +1,171 @@
+import { Component, Host, h, Element, State, Listen, Method } from '@stencil/core';
+import { moveToPortal } from '../../utils/portal';
+import { fadeIn, fadeOut, fadeScaleIn } from '../../utils/transitions';
+
+export type DialogOptions = {
+  /** The label for the cancel button.  If `null`, the button is not shown. */
+  cancelLabel?: string;
+  /** The label for the confirm buttion.  If `null`, the button is not shown. */
+  confirmLabel?: string;
+  /** Optional heading text */
+  heading?: string;
+};
+
+@Component({
+  tag: 'mx-dialog',
+  shadow: false,
+})
+export class MxDialog {
+  backdrop: HTMLElement;
+  modal: HTMLElement;
+  focusElements: HTMLElement[];
+  firstFocusElement: HTMLElement;
+  lastFocusElement: HTMLElement;
+  ancestorFocusedElement: HTMLElement;
+  deferredResolve: Function;
+
+  heading: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+
+  @State() isVisible = false;
+
+  @Element() element: HTMLMxModalElement;
+
+  @Listen('keydown', { target: 'body' })
+  onKeyDown(e: KeyboardEvent) {
+    if (!this.isVisible) return;
+    const isFocusOutside = () =>
+      !document.activeElement || !this.focusElements.includes(document.activeElement as HTMLElement);
+    if (e.key === 'Tab') {
+      this.getFocusElements();
+      // Trap focus inside dialog
+      if (e.shiftKey && document.activeElement === this.firstFocusElement) {
+        this.lastFocusElement.focus();
+        e.preventDefault();
+      } else if (isFocusOutside() || document.activeElement === this.lastFocusElement) {
+        this.firstFocusElement && this.firstFocusElement.focus();
+        e.preventDefault();
+      }
+    } else if (e.key === 'Enter') {
+      // Confirm on Enter (if not already focused on a dialog focusable element)
+      this.getFocusElements();
+      if (isFocusOutside()) {
+        this.firstFocusElement && this.firstFocusElement.focus();
+        this.closeDialog(true);
+      }
+    } else if (e.key === 'Escape') {
+      // Cancel on Escape
+      this.closeDialog();
+      e.preventDefault();
+    }
+  }
+
+  /** A Promise-based replacement for `Window.alert()` with some additional options */
+  @Method()
+  async alert(message: string, { confirmLabel = 'Okay', cancelLabel, heading }: DialogOptions = {}): Promise<void> {
+    return this.open(message, { heading, confirmLabel, cancelLabel });
+  }
+
+  /** A Promise-based replacement for `Window.confirm()` that resolves to a boolean */
+  @Method()
+  async confirm(
+    message: string,
+    { confirmLabel = 'Okay', cancelLabel = 'Cancel', heading }: DialogOptions = {},
+  ): Promise<boolean> {
+    return this.open(message, { heading, confirmLabel, cancelLabel });
+  }
+
+  /** Opens a dialog using the provided parameters.
+   * If/when we implement confirmation dialogs with inputs, radio groups, etc. this method can be
+   * exposed with additional parameters needed to create those dialogs. */
+  async open(message: string, { cancelLabel, confirmLabel, heading }: DialogOptions = {}): Promise<any> {
+    this.heading = heading;
+    this.message = message;
+    this.cancelLabel = cancelLabel;
+    this.confirmLabel = confirmLabel;
+    this.showDialog();
+    return new Promise(resolve => {
+      this.deferredResolve = resolve;
+    });
+  }
+
+  async showDialog() {
+    this.ancestorFocusedElement = document.activeElement as HTMLElement;
+    moveToPortal(this.element);
+    this.isVisible = true;
+    await new Promise(resolve => requestAnimationFrame(resolve));
+    await Promise.all([fadeIn(this.backdrop), fadeScaleIn(this.modal)]);
+  }
+
+  async closeDialog(isConfirmed = false) {
+    await Promise.all([fadeOut(this.backdrop), fadeOut(this.modal)]);
+    this.isVisible = false;
+    // Restore focus to the element that was focused before the modal was opened
+    this.ancestorFocusedElement && this.ancestorFocusedElement.focus();
+    this.deferredResolve(isConfirmed);
+  }
+
+  getFocusElements() {
+    const isVisible = (el: HTMLElement) => !!el.offsetParent;
+    this.focusElements = Array.from(
+      this.element.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'),
+    ).filter(isVisible) as HTMLElement[];
+    if (this.focusElements.length) {
+      this.firstFocusElement = this.focusElements[0];
+      this.lastFocusElement = this.focusElements[this.focusElements.length - 1];
+    }
+  }
+
+  get hostClass(): string {
+    let str = 'mx-dialog fixed inset-0 flex items-center justify-center';
+    if (!this.isVisible) str += ' hidden';
+    return str;
+  }
+
+  render() {
+    return (
+      <Host class={this.hostClass}>
+        <div ref={el => (this.backdrop = el)} class="bg-dialog-backdrop absolute inset-0 z-0"></div>
+
+        <div
+          ref={el => (this.modal = el)}
+          role="alertdialog"
+          aria-labelledby={this.heading ? 'dialog-heading' : null}
+          aria-describedby={this.message ? 'dialog-message' : null}
+          aria-modal="true"
+          data-testid="modal"
+          class="modal w-320 flex flex-col rounded-lg shadow-4 relative overflow-hidden"
+        >
+          <div class="p-24 flex-grow">
+            {this.heading && (
+              <h1 id="dialog-heading" class="text-h6 emphasis !my-0 pb-16">
+                {this.heading}
+              </h1>
+            )}
+            {this.message && (
+              <p id="dialog-message" class="text-4 my-0">
+                {this.message}
+              </p>
+            )}
+          </div>
+          {(this.confirmLabel || this.cancelLabel) && (
+            <div class="flex flex-wrap items-center justify-end p-4">
+              {this.confirmLabel && (
+                <mx-button class="m-4 order-2" btnType="text" onClick={() => this.closeDialog(true)}>
+                  {this.confirmLabel}
+                </mx-button>
+              )}
+              {this.cancelLabel && (
+                <mx-button class="m-4 order-1" btnType="text" onClick={() => this.closeDialog()}>
+                  {this.cancelLabel}
+                </mx-button>
+              )}
+            </div>
+          )}
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/mx-dialog/mx-dialog.tsx
+++ b/src/components/mx-dialog/mx-dialog.tsx
@@ -52,6 +52,7 @@ export class MxDialog {
       // Confirm on Enter (if not already focused on a dialog focusable element)
       this.getFocusElements();
       if (isFocusOutside()) {
+        e.preventDefault();
         this.firstFocusElement && this.firstFocusElement.focus();
         this.closeDialog(true);
       }

--- a/src/components/mx-dialog/mx-dialog.tsx
+++ b/src/components/mx-dialog/mx-dialog.tsx
@@ -1,4 +1,5 @@
 import { Component, Host, h, Element, State, Listen, Method } from '@stencil/core';
+import { lockBodyScroll, unlockBodyScroll } from '../../utils/bodyScroll';
 import { moveToPortal } from '../../utils/portal';
 import { fadeIn, fadeOut, fadeScaleIn } from '../../utils/transitions';
 
@@ -95,6 +96,7 @@ export class MxDialog {
   async showDialog() {
     this.ancestorFocusedElement = document.activeElement as HTMLElement;
     moveToPortal(this.element);
+    lockBodyScroll();
     this.isVisible = true;
     await new Promise(resolve => requestAnimationFrame(resolve));
     await Promise.all([fadeIn(this.backdrop), fadeScaleIn(this.modal)]);
@@ -103,6 +105,7 @@ export class MxDialog {
   async closeDialog(isConfirmed = false) {
     await Promise.all([fadeOut(this.backdrop), fadeOut(this.modal)]);
     this.isVisible = false;
+    unlockBodyScroll();
     // Restore focus to the element that was focused before the modal was opened
     this.ancestorFocusedElement && this.ancestorFocusedElement.focus();
     this.deferredResolve(isConfirmed);

--- a/src/components/mx-dialog/test/mx-dialog.spec.tsx
+++ b/src/components/mx-dialog/test/mx-dialog.spec.tsx
@@ -1,0 +1,102 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import { MxButton } from '../../mx-button/mx-button';
+import { MxDialog } from '../mx-dialog';
+
+describe('mx-dialog', () => {
+  let page: SpecPage;
+  let root: HTMLMxDialogElement;
+  let getModal;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxDialog, MxButton],
+      html: `<mx-dialog />`,
+    });
+    root = page.root as HTMLMxDialogElement;
+    getModal = () => root.querySelector('[data-testid="modal"]');
+  });
+
+  it('has aria-modal set to true and a role of alertdialog', async () => {
+    const modal = getModal();
+    expect(modal.getAttribute('role')).toBe('alertdialog');
+    expect(modal.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('has aria-describedby set to the message element if a message is present', async () => {
+    root.alert('test');
+    await page.waitForChanges();
+    await page.waitForChanges();
+    expect(getModal().getAttribute('aria-describedby')).toBe('dialog-message');
+  });
+
+  it('has aria-labelledby set to the heading element if a heading is present', async () => {
+    root.alert('test', { heading: 'test' });
+    await page.waitForChanges();
+    await page.waitForChanges();
+    expect(getModal().getAttribute('aria-labelledby')).toBe('dialog-heading');
+  });
+
+  it('displays the specified message', async () => {
+    root.alert('message');
+    await page.waitForChanges();
+    await page.waitForChanges();
+    const message = root.querySelector('p').innerText;
+    expect(message).toBe('message');
+  });
+
+  it('displays a heading if specified', async () => {
+    root.alert('test', { heading: 'Heading' });
+    await page.waitForChanges();
+    await page.waitForChanges();
+    const heading = root.querySelector('h1').innerText;
+    expect(heading).toBe('Heading');
+  });
+
+  it('uses the confirmLabel and cancelLabel for the dialog buttons', async () => {
+    root.confirm('test', { confirmLabel: 'Yes', cancelLabel: 'No' });
+    await page.waitForChanges();
+    await page.waitForChanges();
+    const buttonText = Array.from(root.querySelectorAll('button')).map(button => button.innerText);
+    expect(buttonText[0]).toBe('Yes');
+    expect(buttonText[1]).toBe('No');
+  });
+
+  it('confirm() resolves to true when the Okay button is clicked', async () => {
+    let resolved;
+    root.confirm('test').then(confirmed => (resolved = confirmed));
+    await page.waitForChanges();
+    await page.waitForChanges();
+    root.querySelectorAll('button')[0].click();
+    await page.waitForChanges();
+    expect(resolved).toBe(true);
+  });
+
+  it('confirm() resolves to false when the Cancel button is clicked', async () => {
+    let resolved;
+    root.confirm('test').then(confirmed => (resolved = confirmed));
+    await page.waitForChanges();
+    await page.waitForChanges();
+    root.querySelectorAll('button')[1].click();
+    await page.waitForChanges();
+    expect(resolved).toBe(false);
+  });
+
+  it('confirm() resolves to false when Escape is pressed', async () => {
+    let resolved;
+    root.confirm('test').then(confirmed => (resolved = confirmed));
+    await page.waitForChanges();
+    await page.waitForChanges();
+    root.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await page.waitForChanges();
+    expect(resolved).toBe(false);
+  });
+
+  it('confirm() resolves to true when Enter is pressed', async () => {
+    let resolved;
+    root.confirm('test').then(confirmed => (resolved = confirmed));
+    await page.waitForChanges();
+    await page.waitForChanges();
+    root.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await page.waitForChanges();
+    expect(resolved).toBe(true);
+  });
+});

--- a/src/components/mx-dialog/test/mx-dialog.spec.tsx
+++ b/src/components/mx-dialog/test/mx-dialog.spec.tsx
@@ -5,18 +5,17 @@ import { MxDialog } from '../mx-dialog';
 describe('mx-dialog', () => {
   let page: SpecPage;
   let root: HTMLMxDialogElement;
-  let getModal;
+  let modal;
   beforeEach(async () => {
     page = await newSpecPage({
       components: [MxDialog, MxButton],
       html: `<mx-dialog />`,
     });
     root = page.root as HTMLMxDialogElement;
-    getModal = () => root.querySelector('[data-testid="modal"]');
+    modal = root.querySelector('[data-testid="modal"]');
   });
 
   it('has aria-modal set to true and a role of alertdialog', async () => {
-    const modal = getModal();
     expect(modal.getAttribute('role')).toBe('alertdialog');
     expect(modal.getAttribute('aria-modal')).toBe('true');
   });
@@ -25,14 +24,14 @@ describe('mx-dialog', () => {
     root.alert('test');
     await page.waitForChanges();
     await page.waitForChanges();
-    expect(getModal().getAttribute('aria-describedby')).toBe('dialog-message');
+    expect(modal.getAttribute('aria-describedby')).toBe('dialog-message');
   });
 
   it('has aria-labelledby set to the heading element if a heading is present', async () => {
     root.alert('test', { heading: 'test' });
     await page.waitForChanges();
     await page.waitForChanges();
-    expect(getModal().getAttribute('aria-labelledby')).toBe('dialog-heading');
+    expect(modal.getAttribute('aria-labelledby')).toBe('dialog-heading');
   });
 
   it('displays the specified message', async () => {

--- a/src/components/mx-modal/mx-modal.tsx
+++ b/src/components/mx-modal/mx-modal.tsx
@@ -2,6 +2,7 @@ import { Component, Host, h, Prop, Watch, Element, Event, EventEmitter, State, L
 import { minWidthSync, MinWidths } from '../../utils/minWidthSync';
 import { moveToPortal } from '../../utils/portal';
 import { fadeIn, fadeOut, fadeScaleIn } from '../../utils/transitions';
+import { lockBodyScroll, unlockBodyScroll } from '../../utils/bodyScroll';
 import { IMxButtonProps } from '../mx-button/mx-button';
 import arrowSvg from '../../assets/svg/arrow-left.svg';
 
@@ -105,6 +106,7 @@ export class MxModal {
 
   async openModal() {
     moveToPortal(this.element);
+    lockBodyScroll();
     this.isVisible = true;
     requestAnimationFrame(async () => {
       this.getFocusElements();
@@ -129,6 +131,7 @@ export class MxModal {
   async closeModal() {
     await Promise.all([fadeOut(this.backdrop), fadeOut(this.modal)]);
     this.isVisible = false;
+    unlockBodyScroll();
     // Restore focus to the element that was focused before the modal was opened
     this.ancestorFocusedElement && this.ancestorFocusedElement.focus();
   }

--- a/src/components/mx-modal/mx-modal.tsx
+++ b/src/components/mx-modal/mx-modal.tsx
@@ -106,7 +106,7 @@ export class MxModal {
 
   async openModal() {
     moveToPortal(this.element);
-    lockBodyScroll();
+    lockBodyScroll(this.element);
     this.isVisible = true;
     requestAnimationFrame(async () => {
       this.getFocusElements();
@@ -131,7 +131,7 @@ export class MxModal {
   async closeModal() {
     await Promise.all([fadeOut(this.backdrop), fadeOut(this.modal)]);
     this.isVisible = false;
-    unlockBodyScroll();
+    unlockBodyScroll(this.element);
     // Restore focus to the element that was focused before the modal was opened
     this.ancestorFocusedElement && this.ancestorFocusedElement.focus();
   }

--- a/src/components/mx-modal/mx-modal.tsx
+++ b/src/components/mx-modal/mx-modal.tsx
@@ -102,6 +102,7 @@ export class MxModal {
 
   disconnectedCallback() {
     minWidthSync.unsubscribeComponent(this);
+    unlockBodyScroll(this.element);
   }
 
   async openModal() {

--- a/src/tailwind/mx-dialog/index.scss
+++ b/src/tailwind/mx-dialog/index.scss
@@ -1,0 +1,11 @@
+.mx-dialog {
+  color: var(--mds-text-dialog);
+
+  .modal {
+    background: var(--mds-bg-dialog);
+  }
+
+  .bg-dialog-backdrop {
+    background: var(--mds-bg-dialog-backdrop);
+  }
+}

--- a/src/tailwind/styles.css
+++ b/src/tailwind/styles.css
@@ -38,6 +38,7 @@
 @import './mx-menu-item/index.scss';
 @import './mx-time-picker/index.scss';
 @import './mx-page-header/index.scss';
+@import './mx-dialog/index.scss';
 @import './mx-modal/index.scss';
 @import './mx-table/index.scss';
 @import './mx-pagination/index.scss';

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -330,6 +330,13 @@
   --mds-text-table-subheader: #0457af;
   /* #endregion tables */
 
+  /* #region dialogs */
+  /* Dialogs */
+  --mds-bg-dialog-backdrop: rgba(0, 0, 0, 0.5);
+  --mds-bg-dialog: #f8f8f8;
+  --mds-text-dialog: #333;
+  /* #endregion dialogs */
+
   /* #region modals */
   /* Modals */
   --mds-bg-modal-backdrop: rgba(0, 0, 0, 0.5);

--- a/src/utils/bodyScroll.ts
+++ b/src/utils/bodyScroll.ts
@@ -1,8 +1,11 @@
 let previousBodyOverflow = '';
 let previousBodyPaddingRight = '';
 let isLocked = false;
+const DATA_ATTRIBUTE = 'data-lock-body-scroll';
 
-export function lockBodyScroll() {
+export function lockBodyScroll(modalEl: HTMLElement) {
+  // Add data attribute in order to track open modal elements
+  if (modalEl) modalEl.setAttribute(DATA_ATTRIBUTE, '');
   if (isLocked) return;
   previousBodyOverflow = document.body.style.overflow || '';
   previousBodyPaddingRight = document.body.style.paddingRight || '';
@@ -16,8 +19,11 @@ export function lockBodyScroll() {
   isLocked = true;
 }
 
-export function unlockBodyScroll() {
+export function unlockBodyScroll(modalEl: HTMLElement) {
   if (!isLocked) return;
+  if (modalEl) modalEl.removeAttribute(DATA_ATTRIBUTE);
+  // If another modal is still open, do not unlock
+  if (document.querySelector(`[${DATA_ATTRIBUTE}]`)) return;
   document.body.style.paddingRight = previousBodyPaddingRight;
   document.body.style.overflow = previousBodyOverflow;
   isLocked = false;

--- a/src/utils/bodyScroll.ts
+++ b/src/utils/bodyScroll.ts
@@ -1,0 +1,24 @@
+let previousBodyOverflow = '';
+let previousBodyPaddingRight = '';
+let isLocked = false;
+
+export function lockBodyScroll() {
+  if (isLocked) return;
+  previousBodyOverflow = document.body.style.overflow || '';
+  previousBodyPaddingRight = document.body.style.paddingRight || '';
+  const scrollBarGap = window.innerWidth - document.documentElement.clientWidth;
+  const computedBodyPaddingRight = parseInt(
+    window.getComputedStyle(document.body).getPropertyValue('padding-right'),
+    10,
+  );
+  document.body.style.paddingRight = `${computedBodyPaddingRight + scrollBarGap}px`;
+  document.body.style.overflow = 'hidden';
+  isLocked = true;
+}
+
+export function unlockBodyScroll() {
+  if (!isLocked) return;
+  document.body.style.paddingRight = previousBodyPaddingRight;
+  document.body.style.overflow = previousBodyOverflow;
+  isLocked = false;
+}

--- a/vuepress/.vuepress/config.js
+++ b/vuepress/.vuepress/config.js
@@ -150,6 +150,7 @@ module.exports = {
         'pickers',
         'tables',
         'page-headers',
+        'dialogs',
         'modals',
         'pagination',
         'snackbars',

--- a/vuepress/components/dialogs.md
+++ b/vuepress/components/dialogs.md
@@ -1,6 +1,6 @@
 # Dialogs
 
-The `mx-dialog` component is used to inform users about a task and can contain critical information, require decisions, or involve multiple tasks. For more complex UI, a [Modal](/components/modals.html) may be preferrable. If user interaction is not strictly required, consider using a [Snackbar](/components/snackbars.html) instead.
+The `mx-dialog` component is used to inform users about a task and can contain critical information, require decisions, or involve multiple tasks. For more complex UI, a [Modal](/components/modals.html) may be preferrable. If user interruption is not strictly required, consider using a [Snackbar](/components/snackbars.html) instead.
 
 Currently, `mx-dialog` exposes two methods: `alert()` and `confirm()`, which are intended to be replacements for [`Window.alert()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/alert) and [`Window.confirm()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm) respectively. The signatures for these two methods are identical, but with different default values for `confirmLabel` and `cancelLabel` (to match the behavior of the aforementioned `Window` methods).
 

--- a/vuepress/components/dialogs.md
+++ b/vuepress/components/dialogs.md
@@ -1,0 +1,58 @@
+# Dialogs
+
+The `mx-dialog` component is used to inform users about a task and can contain critical information, require decisions, or involve multiple tasks. For more complex UI, a Modal may be preferrable.
+
+Currently, `mx-dialog` exposes two methods: `alert()` and `confirm()`, which are intended to be replacements for [`Window.alert()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/alert) and [`Window.confirm()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm) respectively. The signatures for these two methods are identical, but with different default values for `confirmLabel` and `cancelLabel` (to match the behavior of the aforementioned `Window` methods).
+
+Since the Dialog component is propless, it is possible to use a single instance of the `mx-dialog` element to invoke every dialog needed for the page.
+
+<section class="mds">
+  <div class="flex flex-col items-start space-y-20">
+    <!-- #region dialogs -->
+    <mx-button @click="() => $refs.dialog.alert('Greetings!')">Basic Alert Call</mx-button>
+    <mx-button @click="advancedAlert">Advanced Alert Call</mx-button>
+    <mx-button @click="confirmation">Basic Confirm Call</mx-button>
+    <mx-button @click="advancedConfirmation">Advanced Confirm Call</mx-button>
+    <mx-dialog ref="dialog" />
+    <!-- #endregion dialogs -->
+  </div>
+</section>
+
+<<< @/vuepress/components/dialogs.md#dialogs
+<<< @/vuepress/components/dialogs.md#methods
+
+### Dialog Methods
+
+#### `alert(message: string, { confirmLabel, cancelLabel, heading }?: DialogOptions) => Promise<void>`
+
+A Promise-based replacement for `Window.alert()` with some additional options
+
+#### `confirm(message: string, { confirmLabel, cancelLabel, heading }?: DialogOptions) => Promise<boolean>`
+
+A Promise-based replacement for `Window.confirm()` that resolves to a boolean
+
+### CSS Variables
+
+<<< @/src/tailwind/variables/index.scss#dialogs
+
+<script>
+export default {
+  methods: {
+    // #region methods
+    advancedAlert() {
+      const options = { heading: 'Alert!', confirmLabel: 'Okey dokey'}
+      this.$refs.dialog.alert('This alert has a heading and a custom confirmation button label.', options)
+    },
+    async confirmation() {
+      const confirmed = await this.$refs.dialog.confirm('Are you sure about this?')
+      this.$refs.dialog.alert(confirmed ? 'You clicked Okay.' : 'You did not click Okay.')
+    },
+    async advancedConfirmation() {
+      const options = { heading: 'Pancakes', confirmLabel: 'Yes please', cancelLabel: 'No, I do not want pancakes'}
+      const confirmed = await this.$refs.dialog.confirm('Would you like some pancakes?', options)
+      this.$refs.dialog.alert(confirmed ? 'You accepted the pancakes.' : 'You declined the pancakes.')
+    }
+    // #endregion methods
+  }
+}
+</script>

--- a/vuepress/components/dialogs.md
+++ b/vuepress/components/dialogs.md
@@ -1,6 +1,6 @@
 # Dialogs
 
-The `mx-dialog` component is used to inform users about a task and can contain critical information, require decisions, or involve multiple tasks. For more complex UI, a Modal may be preferrable.
+The `mx-dialog` component is used to inform users about a task and can contain critical information, require decisions, or involve multiple tasks. For more complex UI, a [Modal](/components/modals.html) may be preferrable. If user interaction is not strictly required, consider using a [Snackbar](/components/snackbars.html) instead.
 
 Currently, `mx-dialog` exposes two methods: `alert()` and `confirm()`, which are intended to be replacements for [`Window.alert()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/alert) and [`Window.confirm()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm) respectively. The signatures for these two methods are identical, but with different default values for `confirmLabel` and `cancelLabel` (to match the behavior of the aforementioned `Window` methods).
 

--- a/vuepress/components/modals.md
+++ b/vuepress/components/modals.md
@@ -1,6 +1,6 @@
 # Modals
 
-Modals appear in front of app content and remain on screen until the user takes action to close the modal.
+Modals appear in front of app content and remain on screen until the user takes action to close the modal. A Modal may be used when a [Dialog](/components/dialogs.html) will not suffice.
 
 To open or close a modal, set its `isOpen` prop to `true` or `false`. The modal will emit an `mxClose` event when the user clicks the Close button, presses <kbd>Esc</kbd>, or clicks outside the modal (unless that behavior is disabled via props).
 


### PR DESCRIPTION
This implements `mx-dialog`, which exposes two methods: `alert()` and `confirm()`.  These are Promise-based replacements for the `Window.alert()` and `Window.confirm()` methods.  The methods are pretty much identical, but `alert()` defaults to just an "Okay" button, and `confirm()` defaults to both an "Okay" and a "Cancel" button.  The second argument is an options object with properties for a `heading`, `confirmLabel`, and `cancelLabel`.

I also added a new module with some methods for locking and unlocking scrolling on the `body` while dialogs/modals are open.  It tries to prevent layout shifts caused by the removal of the scrollbar by adding the appropriate amount of padding to the right side, but there still may be some unavoidable shifting with elements that are `fixed`/`absolute` positioned relative to the body.

![image](https://user-images.githubusercontent.com/3342530/141173525-4b068de7-d7d2-46c7-884c-415761db9a4f.png)
![image](https://user-images.githubusercontent.com/3342530/141173615-1b1fcdae-70fd-4fa7-8b3e-ec49cb0e8bcb.png)
![image](https://user-images.githubusercontent.com/3342530/141173458-5ecb7cac-6ade-48fa-a832-6f55fcda9292.png)
