### PR TITLE
Table grouping and `rows` reordering

### DIFF
--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -30,6 +30,8 @@ export class MxTableRow {
   @Prop() rowId: string;
   /** An array of Menu Item props to create the actions menu, including a `value` property for each menu item's inner text. */
   @Prop() actions: ITableRowAction[] = [];
+  /** This row's index in the MxTableElement.rows array.  This is set internally by the table component. */
+  @Prop() rowIndex: number;
   @Prop({ mutable: true }) checked: boolean = false;
   /** Style the row as a subheader. */
   @Prop() subheader: boolean = false;
@@ -309,6 +311,13 @@ export class MxTableRow {
       nestedRows.map(childRow => childRow.getChildren().then(grandchildren => children.push(...grandchildren))),
     );
     return children as HTMLElement[];
+  }
+
+  /** Get an array of row IDs for rows nested directly inside this row */
+  @Method()
+  async getNestedRowIndexes(): Promise<number[]> {
+    const nestedRows = Array.from(this.childRowWrapper.children) as HTMLMxTableRowElement[];
+    return nestedRows.map((row: HTMLMxTableRowElement) => row.rowIndex).filter(x => x != null);
   }
 
   /** Calculate the height of the row, including the height of nested rows */

--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -30,7 +30,7 @@ export class MxTableRow {
   @Prop() rowId: string;
   /** An array of Menu Item props to create the actions menu, including a `value` property for each menu item's inner text. */
   @Prop() actions: ITableRowAction[] = [];
-  /** This row's index in the MxTableElement.rows array.  This is set internally by the table component. */
+  /** This row's index in the `HTMLMxTableElement.rows` array.  This is set internally by the table component. */
   @Prop() rowIndex: number;
   @Prop({ mutable: true }) checked: boolean = false;
   /** Style the row as a subheader. */

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -64,11 +64,12 @@ export class MxTable {
   hasSearch: boolean = false;
   hasFilter: boolean = false;
   showOperationsBar: boolean = false;
-  dragRow: HTMLMxTableRowElement;
-  dragRowSiblings: HTMLMxTableRowElement[];
-  dragRowHeight: number;
-  dragRowIndex: number;
-  dragOverRowIndex: number;
+  dragRowEl: HTMLMxTableRowElement;
+  dragRowElSiblings: HTMLMxTableRowElement[];
+  dragOverRowEl: HTMLMxTableRowElement;
+  dragRowElIndex: number;
+  dragOverRowElIndex: number;
+  dragRowElHeight: number;
   dragMoveHandler: (e: MouseEvent) => any;
 
   /** An array of objects that defines the table's dataset. */
@@ -155,19 +156,19 @@ export class MxTable {
 
   @Listen('mxRowDragStart')
   async onMxRowDragStart(e: CustomEvent) {
-    this.dragRow = (e.target as HTMLElement).closest('mx-table-row');
+    this.dragRowEl = (e.target as HTMLElement).closest('mx-table-row');
     // Cache height of row (including any nested rows)
-    this.dragRowHeight = await this.dragRow.getHeight();
+    this.dragRowElHeight = await this.dragRowEl.getHeight();
     // Get all rows that are affected by dragging this one (i.e. the same parent node)
-    this.dragRowSiblings = Array.from(this.dragRow.parentNode.children).filter(
+    this.dragRowElSiblings = Array.from(this.dragRowEl.parentNode.children).filter(
       c => c.tagName === 'MX-TABLE-ROW',
     ) as HTMLMxTableRowElement[];
-    this.dragRowIndex = this.dragRowSiblings.indexOf(this.dragRow);
-    this.dragOverRowIndex = this.dragRowIndex;
+    this.dragRowElIndex = this.dragRowElSiblings.indexOf(this.dragRowEl);
+    this.dragOverRowElIndex = this.dragRowElIndex;
     this.dragMoveHandler = this.onDragMove.bind(this);
     // Add transitions to the rows
-    this.dragRowSiblings.forEach(async row => {
-      if (!e.detail.isKeyboard && row === this.dragRow) return; // Do not transition a row dragged with a mouse
+    this.dragRowElSiblings.forEach(async row => {
+      if (!e.detail.isKeyboard && row === this.dragRowEl) return; // Do not transition a row dragged with a mouse
       (await row.getChildren()).forEach((rowChild: HTMLElement) => {
         rowChild.classList.add('transition-transform', 'pointer-events-none');
       });
@@ -185,45 +186,49 @@ export class MxTable {
     if (['ArrowUp', 'ArrowLeft'].includes(key)) direction = -1;
     if (['ArrowDown', 'ArrowRight'].includes(key)) direction = 1;
     if (!direction) return;
-    if (direction === -1 && this.dragOverRowIndex === 0) return; // Row is at the top
-    if (direction === 1 && this.dragOverRowIndex === this.dragRowSiblings.length - 1) return; // Row is at the bottom
-    this.dragOverRowIndex += direction;
+    if (direction === -1 && this.dragOverRowElIndex === 0) return; // Row is at the top
+    if (direction === 1 && this.dragOverRowElIndex === this.dragRowElSiblings.length - 1) return; // Row is at the bottom
+    this.dragOverRowElIndex += direction;
     // Determine the translate distance based on sibling row heights
     let translateY = 0;
-    let rowIndex = this.dragOverRowIndex;
-    while (rowIndex !== this.dragRowIndex) {
-      const translateDir = this.dragOverRowIndex > this.dragRowIndex ? 1 : -1;
-      translateY += (await this.dragRowSiblings[rowIndex].getHeight()) * translateDir;
+    let rowIndex = this.dragOverRowElIndex;
+    while (rowIndex !== this.dragRowElIndex) {
+      const translateDir = this.dragOverRowElIndex > this.dragRowElIndex ? 1 : -1;
+      translateY += (await this.dragRowElSiblings[rowIndex].getHeight()) * translateDir;
       rowIndex -= translateDir;
     }
-    this.dragRow.translateRow(0, translateY);
+    this.dragRowEl.translateRow(0, translateY);
+    this.dragOverRowEl = this.dragRowElSiblings[this.dragOverRowElIndex];
     this.onDragMove();
   }
 
   @Listen('mxRowDragEnd')
-  onMxRowDragEnd(e: CustomEvent) {
+  async onMxRowDragEnd(e: CustomEvent) {
     document.removeEventListener('mousemove', this.dragMoveHandler);
     document.removeEventListener('touchmove', this.dragMoveHandler);
-    if (!e.detail.isCancel && this.dragOverRowIndex !== this.dragRowIndex) {
+    if (!e.detail.isCancel && this.dragOverRowElIndex !== this.dragRowElIndex) {
       // If row was dragged to a new position AND dragging wasn't cancelled,
       // mutate the rows array (if applicable) and emit the mxRowMove event
-      if (this.rows && this.mutateOnDrag) {
-        const reorderedRows = this.rows.slice();
-        const row = reorderedRows.splice(this.dragRowIndex, 1)[0];
-        reorderedRows.splice(this.dragOverRowIndex, 0, row);
-        this.rows = reorderedRows;
-      }
+      if (this.rows && this.mutateOnDrag) this.reorderRowsArray();
       this.mxRowMove.emit({
-        rowId: (e.target as HTMLMxTableRowElement).rowId,
-        oldIndex: this.dragRowIndex,
-        newIndex: this.dragOverRowIndex,
+        rowId: this.dragRowEl.rowId,
+        oldIndex: this.dragRowEl.rowIndex == null ? this.dragRowElIndex : this.dragRowEl.rowIndex,
+        newIndex: this.dragOverRowEl.rowIndex == null ? this.dragOverRowElIndex : this.dragOverRowEl.rowIndex,
       });
-      if (e.detail.isKeyboard) this.dragRowSiblings[this.dragOverRowIndex].focusDragHandle(); // Focus the handle at the new index
+      if (e.detail.isKeyboard) {
+        // Focus the handle at the element's new index
+        requestAnimationFrame(() => {
+          const reorderedDragRowSiblings = Array.from(this.dragRowEl.parentNode.children).filter(
+            c => c.tagName === 'MX-TABLE-ROW',
+          ) as HTMLMxTableRowElement[];
+          reorderedDragRowSiblings[this.dragOverRowElIndex].focusDragHandle();
+        });
+      }
     }
-    this.dragRowIndex = null;
+    this.dragRowElIndex = null;
     // Remove transitions and transforms from rows
     requestAnimationFrame(() => {
-      this.dragRowSiblings.forEach(async row => {
+      this.dragRowElSiblings.forEach(async row => {
         (await row.getChildren()).forEach((rowChild: HTMLElement) => {
           rowChild.classList.remove('transition-transform', 'pointer-events-none');
           rowChild.style.transform = '';
@@ -300,27 +305,49 @@ export class MxTable {
   /** Animate table rows while dragging a row */
   onDragMove(e?: MouseEvent) {
     requestAnimationFrame(() => {
-      if (this.dragRow == null) return;
-      this.dragRowSiblings.forEach(async (row, rowIndex) => {
+      if (this.dragRowEl == null) return;
+      this.dragRowElSiblings.forEach(async (row, rowIndex) => {
         const rowChildren = await row.getChildren();
         const { top } = getPageRect(rowChildren[0]);
         const { bottom } = getPageRect(rowChildren[rowChildren.length - 1]);
         if (e) {
           const { pageY } = getCursorCoords(e);
-          if (pageY >= top && pageY <= bottom) this.dragOverRowIndex = rowIndex;
+          if (pageY >= top && pageY <= bottom) {
+            this.dragOverRowEl = row;
+            this.dragOverRowElIndex = rowIndex;
+          }
         }
-        if (row === this.dragRow) return; // Do not shift row that is being dragged
-        if (rowIndex <= this.dragOverRowIndex && rowIndex > this.dragRowIndex) {
+        if (row === this.dragRowEl) return; // Do not shift row that is being dragged
+        if (rowIndex <= this.dragOverRowElIndex && rowIndex > this.dragRowElIndex) {
           // Shift rows that are below the dragged row UP
-          rowChildren.forEach(child => (child.style.transform = `translateY(-${this.dragRowHeight}px)`));
-        } else if (rowIndex >= this.dragOverRowIndex && rowIndex < this.dragRowIndex) {
+          rowChildren.forEach(child => (child.style.transform = `translateY(-${this.dragRowElHeight}px)`));
+        } else if (rowIndex >= this.dragOverRowElIndex && rowIndex < this.dragRowElIndex) {
           // Shift rows that are above the dragged row DOWN
-          rowChildren.forEach(child => (child.style.transform = `translateY(${this.dragRowHeight}px)`));
+          rowChildren.forEach(child => (child.style.transform = `translateY(${this.dragRowElHeight}px)`));
         } else {
           rowChildren.forEach(child => (child.style.transform = ''));
         }
       });
     });
+  }
+
+  async reorderRowsArray() {
+    const draggedRowIndexes = [];
+    if (this.dragRowEl.rowIndex != null) draggedRowIndexes.push(this.dragRowEl.rowIndex);
+    draggedRowIndexes.push(...(await this.dragRowEl.getNestedRowIndexes()));
+    if (draggedRowIndexes.length) {
+      const reorderedRows = this.groupedRows.slice();
+      draggedRowIndexes.reverse();
+      let targetRowIndex = this.dragOverRowEl.rowIndex;
+      if (targetRowIndex == null) targetRowIndex = (await this.dragOverRowEl.getNestedRowIndexes())[0];
+      const draggedRows = draggedRowIndexes.map(index => this.groupedRows[index]);
+      if (targetRowIndex > reorderedRows.indexOf(draggedRows[0])) draggedRows.reverse();
+      draggedRows.forEach(draggedRow => {
+        reorderedRows.splice(reorderedRows.indexOf(draggedRow), 1)[0];
+        reorderedRows.splice(targetRowIndex, 0, draggedRow);
+      });
+      this.rows = reorderedRows;
+    }
   }
 
   setCellProps() {
@@ -339,6 +366,11 @@ export class MxTable {
         else colIndex++;
       });
     });
+  }
+
+  getRowGroup(row: any): string {
+    if (row[this.groupBy] == null) return null; // one group for both `undefined` and `null`
+    return row[this.groupBy] as string;
   }
 
   setRowsChecked() {
@@ -402,10 +434,7 @@ export class MxTable {
 
   get uniqueGroups(): string[] {
     if (!this.groupBy || !this.rows.length) return [];
-    const groups = this.rows.map(row => {
-      if (row[this.groupBy] == null) return null; // one group for both `undefined` and `null`
-      return row[this.groupBy] as string;
-    });
+    const groups = this.rows.map(row => this.getRowGroup(row)) as string[];
     return [...new Set(groups)]; // remove duplicates
   }
 
@@ -430,6 +459,10 @@ export class MxTable {
     if (this.sortBy) this.sortRows(rows);
     rows = rows.slice(offset, offset + this.rowsPerPage);
     return rows;
+  }
+
+  get visibleGroups(): string[] {
+    return [...new Set(this.visibleRows.map(row => this.getRowGroup(row)))] as string[];
   }
 
   get allRowsChecked(): boolean {
@@ -587,6 +620,22 @@ export class MxTable {
     return classes;
   }
 
+  getRowJsx(row: any, rowIndex: number) {
+    return (
+      <mx-table-row
+        row-id={this.getRowId ? this.getRowId(row) : null}
+        row-index={rowIndex}
+        actions={this.getRowActions ? this.getRowActions(row) : undefined}
+      >
+        {this.cols.map((col: ITableColumn) => (
+          <mx-table-cell>
+            <div innerHTML={this.getCellValue(row, col, rowIndex)}></div>
+          </mx-table-cell>
+        ))}
+      </mx-table-row>
+    );
+  }
+
   onHeaderClick(col: ITableColumn) {
     if (this.draggableRows || !col || !col.sortable || !col.property) return;
     if (this.sortBy !== col.property) {
@@ -636,13 +685,14 @@ export class MxTable {
             data-testid="multi-action-button"
             btn-type="outlined"
             {...this.multiRowActions[0]}
-            class={'whitespace-nowrap' + (!this.checkedRowIds.length ? ' hidden' : '')}
+            class={'whitespace-nowrap' + (!this.checkedRowIds.length ? ' invisible' : '')}
+            aria-hidden={this.checkedRowIds.length === 0}
           >
             {this.multiRowActions[0].value}
           </mx-button>
         ) : (
           // Multi-Row Action Menu
-          <span class={!this.checkedRowIds.length ? 'hidden' : null}>
+          <span class={!this.checkedRowIds.length ? 'invisible' : null} aria-hidden={this.checkedRowIds.length === 0}>
             <mx-button ref={el => (this.actionMenuButton = el)} btn-type="text" dropdown>
               <span class="h-full flex items-center px-2">
                 <span innerHTML={gearSvg}></span>
@@ -678,34 +728,28 @@ export class MxTable {
       </div>
     );
 
-    let previousGroup;
-    const generatedRows = [];
-    !this.hasDefaultSlot &&
-      this.visibleRows.forEach((row, rowIndex) => {
-        if (this.groupBy && previousGroup !== row[this.groupBy]) {
-          // Add subheader row
-          const heading = this.getGroupByHeading ? this.getGroupByHeading(row[this.groupBy]) : row[this.groupBy];
-          generatedRows.push(
-            <mx-table-row subheader>
-              <mx-table-cell>{heading}</mx-table-cell>
-            </mx-table-row>,
-          );
-          previousGroup = row[this.groupBy];
-        }
-        // Add row
-        generatedRows.push(
-          <mx-table-row
-            row-id={this.getRowId ? this.getRowId(row) : null}
-            actions={this.getRowActions ? this.getRowActions(row) : undefined}
-          >
-            {this.cols.map((col: ITableColumn) => (
-              <mx-table-cell>
-                <div innerHTML={this.getCellValue(row, col, rowIndex)}></div>
-              </mx-table-cell>
-            ))}
-          </mx-table-row>,
+    let generatedRows = [];
+    if (!this.hasDefaultSlot && !this.groupBy && this.groupedRows.length) {
+      generatedRows = this.visibleRows.map(row => {
+        const index = this.rows.indexOf(row);
+        return this.getRowJsx(row, index);
+      });
+    } else if (!this.hasDefaultSlot && this.groupBy) {
+      generatedRows = this.visibleGroups.map(group => {
+        const heading = this.getGroupByHeading ? this.getGroupByHeading(group) : group;
+        return (
+          <mx-table-row subheader key={group}>
+            <mx-table-cell>{heading}</mx-table-cell>
+            {this.visibleRows
+              .filter(row => this.getRowGroup(row) === group)
+              .map(row => {
+                const index = this.groupedRows.indexOf(row);
+                return this.getRowJsx(row, index);
+              })}
+          </mx-table-row>
         );
       });
+    }
 
     return (
       <Host class={'mx-table block text-4' + (this.hoverable ? ' hoverable' : '')}>

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -87,6 +87,8 @@ export class MxTable {
   @Prop() showCheckAll: boolean = true;
   /** Enables reordering of rows via drag and drop. */
   @Prop() draggableRows: boolean = false;
+  /** Set to `false` to not mutate the `rows` prop when rows are reordered via drag and drop. */
+  @Prop() mutateOnDrag: boolean = true;
   /** The row property to use for grouping rows.  The `rows` prop must be provided as well. */
   @Prop() groupBy: string = null;
   /** A function that returns the subheader text for a `groupBy` value.  If not provided, the `row[groupBy]` value will be shown in the subheader rows. */
@@ -203,7 +205,14 @@ export class MxTable {
     document.removeEventListener('mousemove', this.dragMoveHandler);
     document.removeEventListener('touchmove', this.dragMoveHandler);
     if (!e.detail.isCancel && this.dragOverRowIndex !== this.dragRowIndex) {
-      // If row was dragged to a new position AND dragging wasn't cancelled, emit the mxRowMove event
+      // If row was dragged to a new position AND dragging wasn't cancelled,
+      // mutate the rows array (if applicable) and emit the mxRowMove event
+      if (this.rows && this.mutateOnDrag) {
+        const reorderedRows = this.rows.slice();
+        const row = reorderedRows.splice(this.dragRowIndex, 1)[0];
+        reorderedRows.splice(this.dragOverRowIndex, 0, row);
+        this.rows = reorderedRows;
+      }
       this.mxRowMove.emit({
         rowId: (e.target as HTMLMxTableRowElement).rowId,
         oldIndex: this.dragRowIndex,

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -680,31 +680,32 @@ export class MxTable {
 
     let previousGroup;
     const generatedRows = [];
-    this.visibleRows.forEach((row, rowIndex) => {
-      if (this.groupBy && previousGroup !== row[this.groupBy]) {
-        // Add subheader row
-        const heading = this.getGroupByHeading ? this.getGroupByHeading(row[this.groupBy]) : row[this.groupBy];
+    !this.hasDefaultSlot &&
+      this.visibleRows.forEach((row, rowIndex) => {
+        if (this.groupBy && previousGroup !== row[this.groupBy]) {
+          // Add subheader row
+          const heading = this.getGroupByHeading ? this.getGroupByHeading(row[this.groupBy]) : row[this.groupBy];
+          generatedRows.push(
+            <mx-table-row subheader>
+              <mx-table-cell>{heading}</mx-table-cell>
+            </mx-table-row>,
+          );
+          previousGroup = row[this.groupBy];
+        }
+        // Add row
         generatedRows.push(
-          <mx-table-row subheader>
-            <mx-table-cell>{heading}</mx-table-cell>
+          <mx-table-row
+            row-id={this.getRowId ? this.getRowId(row) : null}
+            actions={this.getRowActions ? this.getRowActions(row) : undefined}
+          >
+            {this.cols.map((col: ITableColumn) => (
+              <mx-table-cell>
+                <div innerHTML={this.getCellValue(row, col, rowIndex)}></div>
+              </mx-table-cell>
+            ))}
           </mx-table-row>,
         );
-        previousGroup = row[this.groupBy];
-      }
-      // Add row
-      generatedRows.push(
-        <mx-table-row
-          row-id={this.getRowId ? this.getRowId(row) : null}
-          actions={this.getRowActions ? this.getRowActions(row) : undefined}
-        >
-          {this.cols.map((col: ITableColumn) => (
-            <mx-table-cell>
-              <div innerHTML={this.getCellValue(row, col, rowIndex)}></div>
-            </mx-table-cell>
-          ))}
-        </mx-table-row>,
-      );
-    });
+      });
 
     return (
       <Host class={'mx-table block text-4' + (this.hoverable ? ' hoverable' : '')}>

--- a/src/components/mx-table/test/mx-table.spec.tsx
+++ b/src/components/mx-table/test/mx-table.spec.tsx
@@ -291,6 +291,44 @@ describe('mx-table (checkable, non-mobile)', () => {
   });
 });
 
+describe('mx-table (grouped rows)', () => {
+  let page: SpecPage;
+  let root: HTMLMxTableElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxTable, MxTableRow, MxTableCell, MxCheckbox, MxPagination],
+      html: `
+      <mx-table group-by="category" />
+      `,
+    });
+    root = page.root as HTMLMxTableElement;
+    root.rows = [
+      { id: 0, name: 'Dominos', category: 'pizza' },
+      { id: 1, name: 'Papa Johns', category: 'pizza' },
+      { id: 2, name: 'Little Caesars', category: 'pizza' },
+      { id: 3, name: 'Subway', category: 'sandwich' },
+      { id: 4, name: 'Jimmy Johns', category: 'sandwich' },
+    ];
+    root.columns = [{ property: 'name', heading: 'Name', sortable: false }];
+    root.getGroupByHeading = (category: string) => category.toUpperCase();
+    await page.waitForChanges();
+  });
+
+  it('groups rows under subheader rows based on the groupBy prop', () => {
+    const rows = root.querySelectorAll('mx-table-row');
+    expect(rows[0].innerText.startsWith('PIZZA'));
+    expect(rows[1].innerText).toBe('Dominos');
+    expect(rows[4].innerText.startsWith('SANDWICH'));
+    expect(rows[6].innerText).toBe('Jimmy Johns');
+  });
+
+  it('sets the rowIndex prop on all generated data rows', () => {
+    const rows = root.querySelectorAll('mx-table-row');
+    expect(rows[1].rowIndex).toBe(0); // Dominos
+    expect(rows[6].rowIndex).toBe(4); // Jimmy Johns
+  });
+});
+
 describe('mx-table (slotted rows and cells)', () => {
   let page: SpecPage;
   let root: HTMLMxTableElement;

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -539,7 +539,28 @@ The example below combines nested rows with the `draggableRows` prop. For the sa
 <<< @/vuepress/components/tables.md#indent
 <<< @/vuepress/components/tables.md#nested-row-move
 
-## Subheader rows
+## Grouping and subheader rows
+
+The `groupBy` prop specifies a property on the `rows` objects to use for grouping rows under subheaders.
+
+If the `groupBy` values are not suitable for use as headings, pass a `getGroupByHeading` function to translate them into display-friendly headings for the subheader rows.
+
+<section class="mds">
+  <div class="mt-20">
+  <!-- #region grouping -->
+  <mx-table
+    auto-width
+    paginate="false" 
+    :rows.prop="apps"
+    :columns.prop="[{ property: 'name', heading: 'Name', sortable: false }]"
+    group-by="section"
+  />
+  <!-- #endregion grouping -->
+  </div>
+</section>
+
+<<< @/vuepress/components/tables.md#grouping
+<<< @/vuepress/components/tables.md#apps
 
 Adding the `subheader` prop to a row styles it as a subheader. Only one `mx-table-cell` is necessary for the subheader content. When used inside a table with draggable rows, it can be used to drag a group of nested rows.
 
@@ -675,9 +696,11 @@ The following example combines checkable, slotted table rows with pagination, ro
 | `disableNextPage`     | `disable-next-page`     | Disable the next-page button. Useful when using server-side pagination and the total number of rows is unknown.                                                                         | `boolean`                               | `false`     |
 | `disablePagination`   | `disable-pagination`    | Disable the pagination buttons (i.e. while loading results)                                                                                                                             | `boolean`                               | `false`     |
 | `draggableRows`       | `draggable-rows`        | Enables reordering of rows via drag and drop.                                                                                                                                           | `boolean`                               | `false`     |
+| `getGroupByHeading`   | --                      | A function that returns the subheader text for a `groupBy` value. If not provided, the `row[groupBy]` value will be shown in the subheader rows.                                        | `(row: Object) => string`               | `undefined` |
 | `getMultiRowActions`  | --                      |                                                                                                                                                                                         | `(rows: string[]) => ITableRowAction[]` | `undefined` |
 | `getRowActions`       | --                      |                                                                                                                                                                                         | `(row: Object) => ITableRowAction[]`    | `undefined` |
 | `getRowId`            | --                      | A function that returns the `rowId` prop for each generated `mx-table-row`. This is only required if the table is `checkable` and is auto-generating rows (not using the default slot). | `(row: Object) => string`               | `undefined` |
+| `groupBy`             | `group-by`              | The row property to use for grouping rows. The `rows` prop must be provided as well.                                                                                                    | `string`                                | `null`      |
 | `hoverable`           | `hoverable`             |                                                                                                                                                                                         | `boolean`                               | `true`      |
 | `page`                | `page`                  | The page to display                                                                                                                                                                     | `number`                                | `1`         |
 | `paginate`            | `paginate`              | Show the pagination component. Setting this to `false` will show all rows.                                                                                                              | `boolean`                               | `true`      |
@@ -1056,12 +1079,23 @@ const albums = [
     "label": "Parlophone"
   }
 ]
+// #region apps
+const apps = [
+  { name: 'Matrix', section: 'Core Tools' },
+  { name: 'Remine', section: 'Core Tools' },
+  { name: 'Realist', section: 'Core Tools' },
+  { name: 'Builders Update', section: 'Additional Benefits' },
+  { name: 'ePropertyWatch', section: 'Additional Benefits' },
+  { name: 'Homes.com', section: 'Additional Benefits' },
+]
+// #endregion apps
 
 export default {
   data() {
     return {
       albums,
       beatles,
+      apps: apps.slice(),
       visibleRows: beatles,
       draggableBeatles: beatles.slice(),
       albumRows: albums,

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -449,7 +449,7 @@ Set the `draggableRows` prop to allow reordering rows via drag and drop.
 
 <<< @/vuepress/components/tables.md#draggable
 
-By default, the `rows` array is mutated when reordering. To disable this behavior, set `mutateOnDrag` to `false`. The component emits an `mxRowMove` event containing the `rowId` (if set), `oldIndex`, and `newIndex` for the dragged row. This information can then be used to update state in the host application.
+By default, the `rows` array is mutated when reordering. To disable this behavior, set `mutateOnDrag` to `false`. The component emits an `mxRowMove` event containing the `rowId` (if set), `oldIndex`, and `newIndex` for the dragged row. This information can then be used to update state in the host application. If a `rows` array was not provided, the `oldIndex` and `newIndex` are based on the row element's position relative to its siblings. See [nested rows](#nested-rows) and [grouped rows](#grouping-and-subheader-rows) for other examples.
 
 <section class="mds">
   <div class="mt-20">
@@ -558,6 +558,7 @@ If the `groupBy` values are not suitable for use as headings, pass a `getGroupBy
   <!-- #region grouping -->
   <mx-table
     auto-width
+    draggable-rows
     paginate="false" 
     :rows.prop="apps"
     :columns.prop="[{ property: 'name', heading: 'Name', sortable: false }]"
@@ -578,7 +579,6 @@ Adding the `subheader` prop to a row styles it as a subheader. Only one `mx-tabl
     <mx-table
       auto-width
       paginate="false"
-      draggable-rows
       :columns.prop="[
         { heading: 'Name' },
       ]"

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -749,6 +749,7 @@ The `ITableColumn` interface describes the objects passed to the `columns` prop.
 | `actions`   | --          | An array of Menu Item props to create the actions menu, including a `value` property for each menu item's inner text. | `ITableRowAction[]` | `[]`        |
 | `checked`   | `checked`   |                                                                                                                       | `boolean`           | `false`     |
 | `rowId`     | `row-id`    | This is required for checkable rows in order to persist the checked state through sorting and pagination.             | `string`            | `undefined` |
+| `rowIndex`  | `row-index` | This row's index in the `HTMLMxTableElement.rows` array. This is set internally by the table component.               | `number`            | `undefined` |
 | `subheader` | `subheader` | Style the row as a subheader.                                                                                         | `boolean`           | `false`     |
 
 ### Table Events
@@ -795,6 +796,10 @@ Collapses the row (on mobile)
 #### `expand() => Promise<void>`
 
 Expands the row (on mobile)
+
+#### `getNestedRowIndexes() => Promise<number[]>`
+
+Get an array of row IDs for rows nested directly inside this row
 
 <script>
 // #region beatles

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -427,9 +427,7 @@ Other props that may be helpful when using server-side pagination include `showP
 
 ## Draggable rows
 
-Set the `draggableRows` prop to allow reordering rows via drag and drop. The component emits an `mxRowMove` event containing the `rowId` (if set), `oldIndex`, and `newIndex` for the dragged row.
-
-The `rows` array is not mutated by the component, so you must update the array using the event data.
+Set the `draggableRows` prop to allow reordering rows via drag and drop.
 
 <section class="mds">
   <div class="mt-20">
@@ -444,12 +442,21 @@ The `rows` array is not mutated by the component, so you must update the array u
         { property: 'credits', heading: 'Song Credits', type: 'number' },
         { property: 'birthdate', heading: 'Birthdate', type: 'date' },
       ]"
-      @mxRowMove="onRowMove"
     />
+    <!-- #endregion draggable -->
+  </div>
+</section>
+
+<<< @/vuepress/components/tables.md#draggable
+
+By default, the `rows` array is mutated when reordering. To disable this behavior, set `mutateOnDrag` to `false`. The component emits an `mxRowMove` event containing the `rowId` (if set), `oldIndex`, and `newIndex` for the dragged row. This information can then be used to update state in the host application.
+
+<section class="mds">
+  <div class="mt-20">
+    <!-- #region draggable-2 -->
     <mx-table
       draggable-rows
       checkable
-      class="mt-20"
       paginate="false"
       :get-row-id.prop="row => row.firstName"
       :rows.prop="draggableBeatles"
@@ -459,13 +466,14 @@ The `rows` array is not mutated by the component, so you must update the array u
         { property: 'credits', heading: 'Song Credits', type: 'number' },
         { property: 'birthdate', heading: 'Birthdate', type: 'date' },
       ]"
+      mutate-on-drag="false"
       @mxRowMove="onRowMove"
     />
-    <!-- #endregion draggable -->
+    <!-- #endregion draggable-2 -->
   </div>
 </section>
 
-<<< @/vuepress/components/tables.md#draggable
+<<< @/vuepress/components/tables.md#draggable-2
 <<< @/vuepress/components/tables.md#row-move
 
 ## Nested rows
@@ -702,6 +710,7 @@ The following example combines checkable, slotted table rows with pagination, ro
 | `getRowId`            | --                      | A function that returns the `rowId` prop for each generated `mx-table-row`. This is only required if the table is `checkable` and is auto-generating rows (not using the default slot). | `(row: Object) => string`               | `undefined` |
 | `groupBy`             | `group-by`              | The row property to use for grouping rows. The `rows` prop must be provided as well.                                                                                                    | `string`                                | `null`      |
 | `hoverable`           | `hoverable`             |                                                                                                                                                                                         | `boolean`                               | `true`      |
+| `mutateOnDrag`        | `mutate-on-drag`        | Set to `false` to not mutate the `rows` prop when rows are reordered via drag and drop.                                                                                                 | `boolean`                               | `true`      |
 | `page`                | `page`                  | The page to display                                                                                                                                                                     | `number`                                | `1`         |
 | `paginate`            | `paginate`              | Show the pagination component. Setting this to `false` will show all rows.                                                                                                              | `boolean`                               | `true`      |
 | `progressAppearDelay` | `progress-appear-delay` | Delay the appearance of the progress bar for this many milliseconds                                                                                                                     | `number`                                | `0`         |

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -449,7 +449,9 @@ Set the `draggableRows` prop to allow reordering rows via drag and drop.
 
 <<< @/vuepress/components/tables.md#draggable
 
-By default, the `rows` array is mutated when reordering. To disable this behavior, set `mutateOnDrag` to `false`. The component emits an `mxRowMove` event containing the `rowId` (if set), `oldIndex`, and `newIndex` for the dragged row. This information can then be used to update state in the host application. If a `rows` array was not provided, the `oldIndex` and `newIndex` are based on the row element's position relative to its siblings. See [nested rows](#nested-rows) and [grouped rows](#grouping-and-subheader-rows) for other examples.
+By default, the `rows` array is mutated when reordering, so the reordered array may be read from `HTMLMxTableElement.rows`.
+
+To disable this behavior, set `mutateOnDrag` to `false`. The component emits an `mxRowMove` event containing the `rowId` (if set), `oldIndex`, and `newIndex` for the dragged row. This information can then be used to update state in the host application. If a `rows` array was not provided, the `oldIndex` and `newIndex` are based on the row element's position relative to its siblings. See [nested rows](#nested-rows) and [grouped rows](#grouping-and-subheader-rows) for other examples.
 
 <section class="mds">
   <div class="mt-20">


### PR DESCRIPTION
This adds two features to `mx-table`:
- Combining the `rows` prop with a new `groupBy` prop allows for the automatic nesting of rows under subheader rows.
- Unless `mutateOnDrag` is set to `false`, the `rows` array is now mutated by default when rows are reordered via drag and drop.  This can be combined with the aforementioned `groupBy` prop to reorder grouped rows.

Some of the supporting changes:
- Added a `rowIndex` prop to `mx-table-row` that is set by the parent `mx-table` in order to make reordering the `rows` array easier.
- Added a new method called `getNestedRowIndexes` to `mx-table-row`, which is used for the reordering of entire row groups (when the subheader row is dragged).
- Quite a few variables were renamed to help distinguish between a row's index (its index in the `rows` array) and a row _element's_ index (relative to sibling `mx-table-row` elements).

I also changed the way the multi-row action menu/button is shown and hidden to prevent layout shifts when (un)checking rows.

![image](https://user-images.githubusercontent.com/3342530/141842758-68da3301-371e-4c22-908b-c2753f2e6107.png)
