### PR TITLE
Fix input border widths and modal transitions

### DIFF
--- a/src/components/mx-date-picker/mx-date-picker.tsx
+++ b/src/components/mx-date-picker/mx-date-picker.tsx
@@ -199,9 +199,9 @@ export class MxDatePicker {
   }
 
   get pickerWrapperClass() {
-    let str = 'picker-wrapper flex items-center relative border rounded-lg';
+    let str = 'picker-wrapper flex items-center relative rounded-lg';
     str += this.dense ? ' h-36' : ' h-48';
-    if (this.error || this.isFocused) str += ' border-2';
+    str += this.error || this.isFocused ? ' border-2' : ' border';
     if (this.disabled) str += ' disabled';
     if (this.isFocused) str += ' focused';
     return str;

--- a/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
+++ b/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
@@ -64,11 +64,11 @@ export class MxDropdownMenu {
   }
 
   get dropdownWrapperClass() {
-    let str = 'dropdown-wrapper flex items-center relative border rounded-lg';
+    let str = 'dropdown-wrapper flex items-center relative rounded-lg';
     str += this.dense ? ' h-36' : ' h-48';
     if (this.elevated) str += ' elevated shadow-1';
     if (this.flat) str += ' flat';
-    if (this.isFocused) str += ' focused border-2';
+    str += this.isFocused ? ' focused border-2' : ' border';
     return str;
   }
 

--- a/src/components/mx-input/mx-input.tsx
+++ b/src/components/mx-input/mx-input.tsx
@@ -90,11 +90,11 @@ export class MxInput {
   }
 
   get containerClass() {
-    let str = 'mx-input-wrapper flex items-center relative border rounded-lg';
+    let str = 'mx-input-wrapper flex items-center relative rounded-lg';
     if (!this.textarea) {
       str += this.dense ? ' h-36' : ' h-48';
     }
-    if (this.error || this.isFocused) str += ' border-2';
+    str += this.error || this.isFocused ? ' border-2' : ' border';
     if (this.error) str += ' error';
     if (this.disabled) str += ' disabled';
     if (this.readonly) str += ' readonly';

--- a/src/components/mx-modal/mx-modal.tsx
+++ b/src/components/mx-modal/mx-modal.tsx
@@ -115,7 +115,7 @@ export class MxModal {
     this.isVisible = true;
     requestAnimationFrame(async () => {
       this.getFocusElements();
-      await Promise.all([fadeIn(this.backdrop, 250), this.transition(this.modal)]);
+      await Promise.all([fadeIn(this.backdrop, 250), this.openTransition(this.modal)]);
       this.mobilePageHeader.resetResizeObserver();
     });
   }
@@ -134,7 +134,7 @@ export class MxModal {
   }
 
   async closeModal() {
-    await Promise.all([fadeOut(this.backdrop), this.transition(this.modal)]);
+    await Promise.all([fadeOut(this.backdrop), this.closeTransition(this.modal)]);
     this.isVisible = false;
     unlockBodyScroll(this.element);
     // Restore focus to the element that was focused before the modal was opened
@@ -165,9 +165,16 @@ export class MxModal {
     return str;
   }
 
-  get transition(): Function {
-    let transition: Function = this.isVisible ? fadeOut : (el: HTMLElement) => fadeScaleIn(el, 250);
-    if (this.minWidths.sm && this.fromRight) transition = this.isVisible ? fadeSlideOut : fadeSlideIn;
+  get openTransition(): Function {
+    let transition: Function = (el: HTMLElement) => fadeScaleIn(el, 250);
+    if (this.minWidths.sm && this.fromRight) transition = fadeSlideIn;
+    else if (this.minWidths.sm && this.fromLeft) transition = (el: HTMLElement) => transition(el, undefined, false); // Change fromRight/toRight to fromLeft/toLeft
+    return transition;
+  }
+
+  get closeTransition(): Function {
+    let transition: Function = fadeOut;
+    if (this.minWidths.sm && this.fromRight) transition = fadeSlideOut;
     else if (this.minWidths.sm && this.fromLeft) transition = (el: HTMLElement) => transition(el, undefined, false); // Change fromRight/toRight to fromLeft/toLeft
     return transition;
   }

--- a/src/components/mx-select/mx-select.tsx
+++ b/src/components/mx-select/mx-select.tsx
@@ -70,11 +70,11 @@ export class MxSelect {
   }
 
   get selectWrapperClass() {
-    let str = 'mx-select-wrapper flex items-center relative border rounded-lg';
+    let str = 'mx-select-wrapper flex items-center relative rounded-lg';
     str += this.dense ? ' h-36' : ' h-48';
     if (this.elevated) str += ' elevated shadow-1';
     if (this.flat) str += ' flat';
-    if (this.error || this.isFocused) str += ' border-2';
+    str += this.error || this.isFocused ? ' border-2' : ' border';
     if (this.error) str += ' error';
     if (this.disabled) str += ' disabled';
     return str;

--- a/src/components/mx-time-picker/mx-time-picker.tsx
+++ b/src/components/mx-time-picker/mx-time-picker.tsx
@@ -158,9 +158,9 @@ export class MxTimePicker {
   }
 
   get pickerWrapperClass() {
-    let str = 'picker-wrapper flex items-center relative border rounded-lg';
+    let str = 'picker-wrapper flex items-center relative rounded-lg';
     str += this.dense ? ' h-36' : ' h-48';
-    if (this.error || this.isFocused) str += ' border-2';
+    str += this.error || this.isFocused ? ' border-2' : ' border';
     if (this.disabled) str += ' disabled';
     if (this.isFocused) str += ' focused';
     return str;


### PR DESCRIPTION
Just a couple random fixes:
- Fixed several components having both a `border` and a `border-2` class when focused or in an error state.  I noticed in devint that the `border-2` class wasn't always winning the specificity war on focused text inputs.
- Fixed modal transitions.  I'm not sure how these were working for me before 🤷.  The `transition` getter is now two getters: `openTransition` and `closeTransition`.