### PR TITLE
Table row dragging fixes

### DIFF
--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -210,11 +210,6 @@ export class MxTable {
       // If row was dragged to a new position AND dragging wasn't cancelled,
       // mutate the rows array (if applicable) and emit the mxRowMove event
       if (this.rows && this.mutateOnDrag) this.reorderRowsArray();
-      this.mxRowMove.emit({
-        rowId: this.dragRowEl.rowId,
-        oldIndex: this.dragRowEl.rowIndex == null ? this.dragRowElIndex : this.dragRowEl.rowIndex,
-        newIndex: this.dragOverRowEl.rowIndex == null ? this.dragOverRowElIndex : this.dragOverRowEl.rowIndex,
-      });
       if (e.detail.isKeyboard) {
         // Focus the handle at the element's new index
         requestAnimationFrame(() => {
@@ -225,7 +220,6 @@ export class MxTable {
         });
       }
     }
-    this.dragRowElIndex = null;
     // Remove transitions and transforms from rows
     requestAnimationFrame(() => {
       this.dragRowElSiblings.forEach(async row => {
@@ -236,6 +230,14 @@ export class MxTable {
       });
     });
     document.body.style.cursor = '';
+    // If mutating the rows prop, wait a frame for Stencil to update the property on the element
+    if (this.rows && this.mutateOnDrag) await new Promise(requestAnimationFrame);
+    this.mxRowMove.emit({
+      rowId: this.dragRowEl.rowId,
+      oldIndex: this.dragRowEl.rowIndex == null ? this.dragRowElIndex : this.dragRowEl.rowIndex,
+      newIndex: this.dragOverRowEl.rowIndex == null ? this.dragOverRowElIndex : this.dragOverRowEl.rowIndex,
+    });
+    this.dragRowElIndex = null;
   }
 
   @Watch('sortBy')

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -338,13 +338,20 @@ export class MxTable {
     if (draggedRowIndexes.length) {
       const reorderedRows = this.groupedRows.slice();
       draggedRowIndexes.reverse();
-      let targetRowIndex = this.dragOverRowEl.rowIndex;
-      if (targetRowIndex == null) targetRowIndex = (await this.dragOverRowEl.getNestedRowIndexes())[0];
+      let spliceIndex = this.dragOverRowEl.rowIndex;
+      if (spliceIndex == null) {
+        const targetNestedRowIndexes = await this.dragOverRowEl.getNestedRowIndexes();
+        // Splice above top row in group OR below last row depending on drag direction
+        const draggedDownward = draggedRowIndexes[0] < targetNestedRowIndexes[0];
+        spliceIndex = draggedDownward
+          ? targetNestedRowIndexes[targetNestedRowIndexes.length - 1]
+          : targetNestedRowIndexes[0];
+        if (draggedDownward) draggedRowIndexes.reverse();
+      }
       const draggedRows = draggedRowIndexes.map(index => this.groupedRows[index]);
-      if (targetRowIndex > reorderedRows.indexOf(draggedRows[0])) draggedRows.reverse();
       draggedRows.forEach(draggedRow => {
         reorderedRows.splice(reorderedRows.indexOf(draggedRow), 1)[0];
-        reorderedRows.splice(targetRowIndex, 0, draggedRow);
+        reorderedRows.splice(spliceIndex, 0, draggedRow);
       });
       this.rows = reorderedRows;
     }

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -556,22 +556,24 @@ The `groupBy` prop specifies a property on the `rows` objects to use for groupin
 If the `groupBy` values are not suitable for use as headings, pass a `getGroupByHeading` function to translate them into display-friendly headings for the subheader rows.
 
 <section class="mds">
-  <div class="mt-20">
+  <div class="mt-20 grid grid-cols-1 md:grid-cols-2 gap-8">
   <!-- #region grouping -->
   <mx-table
+    ref="appsTable"
     auto-width
     draggable-rows
     paginate="false" 
     :rows.prop="apps"
     :columns.prop="[{ property: 'name', heading: 'Name', sortable: false }]"
     group-by="section"
+    @mxRowMove="() => apps = $refs.appsTable.rows"
   />
+  <code class="whitespace-pre-wrap">{{ apps }}</code>
   <!-- #endregion grouping -->
   </div>
 </section>
 
 <<< @/vuepress/components/tables.md#grouping
-<<< @/vuepress/components/tables.md#apps
 
 Adding the `subheader` prop to a row styles it as a subheader. Only one `mx-table-cell` is necessary for the subheader content. When used inside a table with draggable rows, it can be used to drag a group of nested rows.
 
@@ -1095,7 +1097,6 @@ const albums = [
     "label": "Parlophone"
   }
 ]
-// #region apps
 const apps = [
   { name: 'Matrix', section: 'Core Tools' },
   { name: 'Remine', section: 'Core Tools' },
@@ -1103,8 +1104,8 @@ const apps = [
   { name: 'Builders Update', section: 'Additional Benefits' },
   { name: 'ePropertyWatch', section: 'Additional Benefits' },
   { name: 'Homes.com', section: 'Additional Benefits' },
+  { name: 'FarmersOnly.com', section: 'Dating' }
 ]
-// #endregion apps
 
 export default {
   data() {


### PR DESCRIPTION
- Fixed the `onRowMove` event firing before the `HTMLMxTableElement.rows` property was updated.
- Fixed reordering that would render correctly, but was actually not grouped correctly in the updated `rows` array (because the rows were spliced above the first row in the target group instead of below the last row).
- Made the draggable grouped rows example in the docs much better.

![Kapture 2021-11-16 at 13 56 47](https://user-images.githubusercontent.com/3342530/142048547-4aa7f448-5d08-4c7a-821b-5e07a12b0cca.gif)
