### PR TITLE
Fix Page Header grid bugginess in Safari

### DIFF
--- a/src/components/mx-page-header/mx-page-header.tsx
+++ b/src/components/mx-page-header/mx-page-header.tsx
@@ -175,7 +175,11 @@ export class MxPageHeader {
           )}
         </slot>
         <div class="flex flex-col py-10 space-y-14 md:space-y-0 md:flex-row flex-grow md:items-center justify-center md:justify-between flex-wrap">
-          <div class={'grid grid-cols-1 flex-1 items-center' + (this.hasModalHeaderCenter ? ' sm:grid-cols-3' : '')}>
+          <div
+            class={
+              'flex-1 items-center' + (this.hasModalHeaderCenter ? ' grid grid-cols-1 sm:grid-cols-3 h-full' : ' flex') // HACK: Safari needs the `h-full` to constrain the grid to its parent
+            }
+          >
             <h1 class={this.headingClass}>
               <slot></slot>
             </h1>


### PR DESCRIPTION
Safari 15.0 (and maybe earlier?) are having trouble with one particular CSS grid in the Page Header component.  You can see it on the Page Headers page at < 768px, and in the Modal component's `header-center` slot example.  I've tried coming up with a minimum reproduction in codepen to no avail.  It seems to be a combination of a grid with `align-items: center` inside a column flex box that is inside another flex box... and something else.  The end result is that the grid height extends way beyond its parent.

In any case, I came up with a workaround.  When there is only one child element (and no need for the grid), the element in question uses flex instead.  And when it does need to be a grid, setting it to `height: 100%` makes it behave normally.