### PR TITLE
Add focus variant to tailwind borderWidth classes

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -111,6 +111,9 @@ const config = {
   variants: {
     borderWidth: ({ after }) => after(['first-of-type', 'last-of-type']),
     borderRadius: ({ after }) => after(['first-of-type', 'last-of-type']),
+    extend: {
+      borderWidth: ['focus'],
+    },
   },
   plugins: [
     plugin(function({ addVariant, e }) {


### PR DESCRIPTION
The `focus:border-2` class is not generated by default (if not using JIT), so the `mx-search` instances in `devint` do not have 2px border on focus (similar to #63).