### PR TITLE
Random Fixes 2021-11-30

### DIFF
--- a/src/components/mx-checkbox/mx-checkbox.tsx
+++ b/src/components/mx-checkbox/mx-checkbox.tsx
@@ -60,6 +60,7 @@ export class MxCheckbox {
             value={this.value}
             checked={this.checked}
             disabled={this.disabled}
+            indeterminate={this.indeterminate}
             {...this.dataAttributes}
             onInput={this.onInput.bind(this)}
           />

--- a/src/components/mx-checkbox/test/mx-checkbox.spec.tsx
+++ b/src/components/mx-checkbox/test/mx-checkbox.spec.tsx
@@ -34,10 +34,10 @@ describe('mx-checkbox', () => {
     expect(input.disabled).toBeTruthy();
   });
 
-  it('adds an indeterminate class when the indeterminate prop is set', async () => {
+  it('sets the indeterminate attribute on the input when the indeterminate prop is set', async () => {
     root.indeterminate = true;
     await page.waitForChanges();
-    expect(input.getAttribute('class').includes('indeterminate')).toBe(true);
+    expect(input.getAttribute('indeterminate')).not.toBeNull();
   });
 
   it('applies any data attributes to the input element', async () => {

--- a/src/components/mx-image-upload/mx-image-upload.tsx
+++ b/src/components/mx-image-upload/mx-image-upload.tsx
@@ -207,7 +207,7 @@ export class MxImageUpload {
               name={this.name}
               type="file"
               accept={this.accept}
-              class="absolute inset-0 opacity-0 cursor-pointer"
+              class="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
               onInput={this.onInput.bind(this)}
               onDragOver={this.onDragOver.bind(this)}
               onDragLeave={this.onDragLeave.bind(this)}

--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -120,7 +120,7 @@ export class MxTableRow {
   }
 
   onClick(e: MouseEvent) {
-    if (!!(e.target as HTMLElement).closest('button, input, mx-menu')) return; // Ignore clicks on buttons, etc.
+    if (!!(e.target as HTMLElement).closest('a, button, input, mx-menu')) return; // Ignore clicks on links, buttons, etc.
     if (!this.minWidths.sm) {
       // Collapse/expand row when the exposed column cell is clicked
       const exposedCell = this.getExposedCell();

--- a/src/tailwind/mx-menu-item/index.scss
+++ b/src/tailwind/mx-menu-item/index.scss
@@ -28,13 +28,6 @@
   }
 }
 
-.mx-menu .mx-menu-item:first-child > div {
-  @apply mt-8;
-}
-.mx-menu .mx-menu-item:last-child > div {
-  @apply mb-8;
-}
-
 .mx-menu.autocomplete-only:not(:focus-within) .mx-menu-item:not([aria-disabled]):first-child > div {
   /* Add focused background to first enabled menu item for autocomplete-only menus */
   background: var(--mds-bg-menu-item-focus);

--- a/src/tailwind/mx-menu/index.scss
+++ b/src/tailwind/mx-menu/index.scss
@@ -1,6 +1,10 @@
 .mx-menu > div {
   background: var(--mds-bg-menu);
 
+  .scroll-wrapper:not(:empty) {
+    @apply py-8;
+  }
+
   ::-webkit-scrollbar {
     width: 12px;
     background: var(--mds-bg-menu);

--- a/src/utils/transitions.ts
+++ b/src/utils/transitions.ts
@@ -112,6 +112,7 @@ function executeTransition(
 }
 
 function setStyleProperty(el: HTMLElement, property, value) {
+  if (!el) return;
   if (property !== 'transform') {
     // Set typical style property (e.g. opacity)
     el.style[property] = value;


### PR DESCRIPTION
- Reverted back to using vertical padding in `mx-menu` instead of applying margin to the first and last menu items.  I noticed in nucleus that the `mx-menu-item` elements were sometimes wrapped in other elements due to helpers like `button_to`, which would trip up the `:first-child` and `:last-child` selectors I was using.  To get around the original problem of not wanting padding in an empty menu, I simply used `:not(:empty)`.  Seems so obvious now haha.
- Updated a table `onClick` handler to not trigger (un)checking a row when clicking an `<a>` in that row.
- Fixed a non-clickable area in `mx-image-upload`; the `<input type=file>` needed a `w-full` class in addition to `inset-0`.
- Added an additional check in `executeTransition` to prevent exceptions when an element is removed mid-transition (I noticed some console errors when navigating around in nucleus).
- Updated the `mx-checkbox` `indeterminate` prop to actually set the [`indeterminate`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#attr-indeterminate) attribute on the `<input type=checkbox>`.