### PR TITLE
Add subtitle prop to mx-menu-item

### DIFF
--- a/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
+++ b/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
@@ -27,12 +27,12 @@ export class MxDropdownMenu {
   @State() isFocused: boolean = false;
 
   @Listen('click')
-  onClick(e: MouseEvent) {
+  async onClick(e: MouseEvent) {
     // Resize the menu width to match the input.  This is done every click in case the input is resized after initial load.
     this.menu.style.width = this.dropdownWrapper.getBoundingClientRect().width + 'px';
     const clickedMenuItem = (e.target as HTMLElement).closest('mx-menu-item');
     if (!clickedMenuItem) return;
-    this.value = clickedMenuItem.innerText;
+    this.value = await clickedMenuItem.getValue();
     // Fire native input event for consistency with mx-select
     this.inputElem.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
   }

--- a/src/components/mx-dropdown-menu/test/mx-dropdown-menu.spec.tsx
+++ b/src/components/mx-dropdown-menu/test/mx-dropdown-menu.spec.tsx
@@ -76,6 +76,7 @@ describe('mx-menu', () => {
     const listener = jest.fn();
     root.addEventListener('input', listener);
     menuItems[0].click();
+    await page.waitForChanges();
     expect(listener).toHaveBeenCalled();
   });
 

--- a/src/components/mx-icon-button/mx-icon-button.tsx
+++ b/src/components/mx-icon-button/mx-icon-button.tsx
@@ -67,7 +67,7 @@ export class MxIconButton {
           type={this.type}
           formaction={this.formaction}
           value={this.value}
-          class="flex items-center w-48 h-48 rounded-full justify-center relative overflow-hidden cursor-pointer disabled:cursor-auto"
+          class="flex appearance-none items-center w-48 h-48 rounded-full justify-center relative overflow-hidden cursor-pointer disabled:cursor-auto"
           ref={el => (this.btnElem = el as HTMLButtonElement)}
           onClick={this.onClick.bind(this)}
           aria-disabled={this.disabled}

--- a/src/components/mx-menu-item/mx-menu-item.tsx
+++ b/src/components/mx-menu-item/mx-menu-item.tsx
@@ -28,6 +28,8 @@ export class MxMenuItem implements IMxMenuItemProps {
   @Prop() icon: string;
   /** A label to display above the menu item */
   @Prop() label: string;
+  /** A subtitle to display below the menu item text */
+  @Prop() subtitle: string;
   /** Render a checkbox as part of the menu item.  On small screens, the checkbox will appear on the left; otherwise, it will be on the right. */
   @Prop() multiSelect: boolean = false;
 
@@ -92,6 +94,12 @@ export class MxMenuItem implements IMxMenuItemProps {
       clearTimeout(this.submenuDelayTimeout);
       return await this.submenu.closeMenu();
     }
+  }
+
+  /** Returns the menu item inner text (excluding any label or subtitle) */
+  @Method()
+  async getValue(): Promise<string> {
+    return this.slotWrapper && this.slotWrapper.innerText.trim();
   }
 
   /** Focuses the menu item. */
@@ -187,7 +195,7 @@ export class MxMenuItem implements IMxMenuItemProps {
               {this.icon !== undefined && (
                 <i class={'inline-flex items-center justify-center text-1 w-20 mr-8 ' + this.icon}></i>
               )}
-              <span ref={el => (this.slotWrapper = el)} class="overflow-hidden overflow-ellipsis">
+              <span ref={el => (this.slotWrapper = el)} class="truncate">
                 <slot></slot>
               </span>
             </div>
@@ -196,6 +204,11 @@ export class MxMenuItem implements IMxMenuItemProps {
             )}
             {!!this.submenu && <span class="transform -rotate-90" data-testid="arrow" innerHTML={arrowSvg}></span>}
           </div>
+          {this.subtitle && (
+            <p class="item-subtitle flex items-start py-0 px-12 my-0 h-16 caption2">
+              <span class="block -mt-4 truncate">{this.subtitle}</span>
+            </p>
+          )}
           {this.multiSelect && (
             <mx-checkbox
               class="flex items-stretch w-full overflow-hidden h-48 sm:h-32"

--- a/src/components/mx-menu-item/test/mx-menu-item.spec.tsx
+++ b/src/components/mx-menu-item/test/mx-menu-item.spec.tsx
@@ -24,6 +24,18 @@ describe('mx-menu-item', () => {
     expect(menuItem.innerText).toBe('Open');
   });
 
+  it('renders the label', async () => {
+    root.label = 'Label';
+    await page.waitForChanges();
+    expect(menuItem.innerText).toBe(['Label', 'Open'].join(''));
+  });
+
+  it('renders the subtitle', async () => {
+    root.subtitle = 'Subtitle';
+    await page.waitForChanges();
+    expect(menuItem.innerText).toBe(['Open', 'Subtitle'].join(''));
+  });
+
   it('emits an mxClick event on click', () => {
     const listener = jest.fn();
     root.addEventListener('mxClick', listener);
@@ -82,6 +94,13 @@ describe('mx-menu-item', () => {
     await page.waitForChanges();
     checkbox = menuItem.querySelector('mx-checkbox');
     expect(checkbox.getAttribute('checked')).not.toBeNull();
+  });
+
+  it('getValue() returns the inner text without the label or subtitle', async () => {
+    root.label = 'Label';
+    root.subtitle = 'Subtitle';
+    await page.waitForChanges();
+    expect(await root.getValue()).toBe('Open');
   });
 });
 

--- a/src/tailwind/mx-menu-item/index.scss
+++ b/src/tailwind/mx-menu-item/index.scss
@@ -8,6 +8,10 @@
       color: var(--mds-text-menu-item-label);
     }
 
+    .item-subtitle {
+      color: var(--mds-text-menu-item-subtitle);
+    }
+
     .check {
       color: var(--mds-text-menu-item-check);
     }

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -310,6 +310,7 @@
   --mds-text-menu-item-check: #0457af;
   --mds-text-menu-item-disabled: #909090;
   --mds-text-menu-item-label: #828282;
+  --mds-text-menu-item-subtitle: #5a5a5a;
   --mds-text-menu-item: #333;
   --mds-text-menu-section-label: #0457af;
   /* #endregion menus */

--- a/vuepress/components/dropdowns.md
+++ b/vuepress/components/dropdowns.md
@@ -20,9 +20,9 @@ The options in the menu are represented by [Menu Items](/components/menus.html).
           @input="animal = $event.target.value"
         >
           <mx-menu-item></mx-menu-item>
-          <mx-menu-item>Cat</mx-menu-item>
-          <mx-menu-item>Dog</mx-menu-item>
-          <mx-menu-item>Walrus</mx-menu-item>
+          <mx-menu-item subtitle="Felis catus">Cat</mx-menu-item>
+          <mx-menu-item subtitle="Canis familiaris">Dog</mx-menu-item>
+          <mx-menu-item subtitle="Odobenus rosmarus">Walrus</mx-menu-item>
         </mx-dropdown-menu>
       </div>
     </div>

--- a/vuepress/components/menus.md
+++ b/vuepress/components/menus.md
@@ -58,7 +58,9 @@ To nest a Menu inside a Menu Item, add `slot="submenu"` to the child Menu compon
 <<< @/vuepress/components/menus.md#menus
 <<< @/vuepress/components/menus.md#menus-anchorEl
 
-Place a paragraph element with a `role` of "heading" inside a menu to add a section label. Use the Menu Item's `label` prop to add a label to an individual item.
+### Headings, labels, subtitles & checkboxes
+
+Place a paragraph element with a `role` of "heading" inside a menu to add a section label. Use the Menu Item's `label` prop to add a label to an individual item. Use the `subtitle` prop to add a subtitle below the menu item text.
 
 To add checkboxes to Menu Items, add the `multi-select` property, and set the `checked` accordingly. The `checked` property can also be used without `multi-select` to simply add a checkmark icon to the item.
 
@@ -73,6 +75,9 @@ To add checkboxes to Menu Items, add the `multi-select` property, and set the `c
           <mx-menu-item multi-select checked @click="clickHandler">Show Minimap</mx-menu-item>
           <mx-menu-item multi-select @click="clickHandler">Word Wrap</mx-menu-item>
           <mx-menu-item @click="clickHandler" label="Email">design@moxiworks.com</mx-menu-item>
+          <mx-menu-item @click="clickHandler" subtitle="123 Bremerton Pl Ne">
+            Office One
+          </mx-menu-item>
         </mx-menu>
       </div>
       <div>
@@ -203,6 +208,10 @@ Open the menu. Returns a promise that resolves to false if the menu was already 
 #### `closeSubMenu() => Promise<boolean>`
 
 Closes the item's submenu.
+
+#### `getValue() => Promise<string>`
+
+Returns the menu item inner text (excluding any label or subtitle)
 
 #### `focusMenuItem() => Promise<void>`
 


### PR DESCRIPTION
This adds a `subtitle` prop to `mx-menu-item`.  I also added a `getValue` method for getting the default slot's inner text; this is now used by `mx-dropdown-menu` to update its value.

![image](https://user-images.githubusercontent.com/3342530/144436574-6ca04081-d56c-4dd8-a593-685fe85a2459.png)

I'm also sneaking in an `appearance-none` class for icon buttons, which should hopefully get them looking good again in the latest version of Safari.