### PR TITLE
Fix ARIA boolean values & Dropdown Menu roles

### DIFF
--- a/src/components/mx-button/mx-button.tsx
+++ b/src/components/mx-button/mx-button.tsx
@@ -128,7 +128,7 @@ export class MxButton implements IMxButtonProps {
             class={this.buttonClass}
             ref={el => (this.btnElem = el as HTMLButtonElement)}
             onClick={this.onClick.bind(this)}
-            aria-disabled={this.disabled}
+            aria-disabled={this.disabled ? 'true' : null}
             {...this.dataAttributes}
           >
             {buttonContent}

--- a/src/components/mx-button/test/mx-button.spec.tsx
+++ b/src/components/mx-button/test/mx-button.spec.tsx
@@ -68,7 +68,7 @@ describe('mx-button as disabled', () => {
 
   it('is a disabled button', async () => {
     const btn = root.querySelector('button');
-    expect(btn.getAttribute('aria-disabled')).not.toBeNull();
+    expect(btn.getAttribute('aria-disabled')).toBe('true');
   });
 });
 

--- a/src/components/mx-chip/mx-chip.tsx
+++ b/src/components/mx-chip/mx-chip.tsx
@@ -98,8 +98,8 @@ export class MxChip {
         <div
           ref={el => (this.chipElem = el)}
           class={this.chipClass}
-          aria-checked={this.selected}
-          aria-disabled={this.disabled}
+          aria-checked={this.selected ? 'true' : null}
+          aria-disabled={this.disabled ? 'true' : null}
           role={this.ariaRole}
           tabindex={this.isClickable ? '0' : '-1'}
           onClick={this.onClick.bind(this)}

--- a/src/components/mx-chip/test/mx-chip.spec.tsx
+++ b/src/components/mx-chip/test/mx-chip.spec.tsx
@@ -92,13 +92,13 @@ describe('mx-chip', () => {
     root.addEventListener('click', listener);
     innerDiv.click();
     expect(listener).toHaveBeenCalled();
-    expect(innerDiv.getAttribute('aria-disabled')).toBeNull();
+    expect(innerDiv.getAttribute('aria-disabled')).not.toBe('true');
     root.disabled = true;
     await page.waitForChanges();
     listener.mockReset();
     innerDiv.click();
     expect(listener).not.toHaveBeenCalled();
-    expect(innerDiv.getAttribute('aria-disabled')).not.toBeNull();
+    expect(innerDiv.getAttribute('aria-disabled')).toBe('true');
   });
 
   it('sets the role attribute appropriately', async () => {

--- a/src/components/mx-dropdown-menu/test/mx-dropdown-menu.spec.tsx
+++ b/src/components/mx-dropdown-menu/test/mx-dropdown-menu.spec.tsx
@@ -1,13 +1,14 @@
 import '../../../utils/matchMedia.mock';
 import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { MxDropdownMenu } from '../mx-dropdown-menu';
+import { MxMenu } from '../../mx-menu/mx-menu';
 import { MxMenuItem } from '../../mx-menu-item/mx-menu-item';
 
 // Behavior not tested due to spec page testing limitations:
 // - opening the menu when the anchorEl is clicked (because `anchorEl.contains(e.target)` is always false)
 // - full menu keyboard navigation (because `page.doc.activeElement` is always undefined)
 
-describe('mx-menu', () => {
+describe('mx-dropdown-menu', () => {
   let page: SpecPage;
   let root: HTMLMxDropdownMenuElement;
   let dropdownWrapper: HTMLElement;
@@ -15,7 +16,7 @@ describe('mx-menu', () => {
   let menuItems: NodeListOf<HTMLMxMenuItemElement>;
   beforeEach(async () => {
     page = await newSpecPage({
-      components: [MxDropdownMenu, MxMenuItem],
+      components: [MxDropdownMenu, MxMenu, MxMenuItem],
       html: `
       <mx-dropdown-menu
         value="1000-3000"
@@ -66,6 +67,12 @@ describe('mx-menu', () => {
     expect(root.querySelector('[data-testid="arrow"]')).not.toBeNull();
   });
 
+  it('sets the selected prop to true for the selected item', () => {
+    expect(menuItems[0].selected).toBe(false);
+    expect(menuItems[1].selected).toBe(true);
+    expect(menuItems[2].selected).toBe(false);
+  });
+
   it('updates the value when a menu item is clicked', async () => {
     menuItems[0].click();
     await page.waitForChanges();
@@ -97,5 +104,10 @@ describe('mx-menu', () => {
     root.dense = true;
     await page.waitForChanges();
     expect(dropdownWrapper.getAttribute('class')).toContain('h-36');
+  });
+
+  it('sets the mx-menu and mx-menu-item roles to "listbox" and "option"', async () => {
+    expect(root.querySelector('mx-menu').getAttribute('role')).toBe('listbox');
+    expect(Array.from(menuItems).every(m => m.children[0].getAttribute('role') === 'option')).toBe(true);
   });
 });

--- a/src/components/mx-icon-button/mx-icon-button.tsx
+++ b/src/components/mx-icon-button/mx-icon-button.tsx
@@ -70,7 +70,7 @@ export class MxIconButton {
           class="flex appearance-none items-center w-48 h-48 rounded-full justify-center relative overflow-hidden cursor-pointer disabled:cursor-auto"
           ref={el => (this.btnElem = el as HTMLButtonElement)}
           onClick={this.onClick.bind(this)}
-          aria-disabled={this.disabled}
+          aria-disabled={this.disabled ? 'true' : null}
           aria-label={this.ariaLabel}
           {...this.dataAttributes}
         >

--- a/src/components/mx-menu-item/mx-menu-item.tsx
+++ b/src/components/mx-menu-item/mx-menu-item.tsx
@@ -17,6 +17,7 @@ export interface IMxMenuItemProps {
 })
 export class MxMenuItem implements IMxMenuItemProps {
   menuItemElem: HTMLElement;
+  role: string;
   submenu: HTMLMxMenuElement;
   slotWrapper: HTMLElement;
   submenuDelayTimeout;
@@ -32,6 +33,8 @@ export class MxMenuItem implements IMxMenuItemProps {
   @Prop() subtitle: string;
   /** Render a checkbox as part of the menu item.  On small screens, the checkbox will appear on the left; otherwise, it will be on the right. */
   @Prop() multiSelect: boolean = false;
+  /** This is automatically set by a parent Dropdown Menu. */
+  @Prop() selected: boolean = false;
 
   @State() minWidths = new MinWidths();
 
@@ -80,6 +83,7 @@ export class MxMenuItem implements IMxMenuItemProps {
   }
 
   connectedCallback() {
+    this.role = !!this.element.closest('mx-dropdown-menu') ? 'option' : 'menuitem';
     minWidthSync.subscribeComponent(this);
   }
 
@@ -173,9 +177,10 @@ export class MxMenuItem implements IMxMenuItemProps {
       <Host class={'mx-menu-item block' + (!!this.submenu ? ' has-submenu' : '')}>
         <div
           ref={el => (this.menuItemElem = el)}
-          role="menuitem"
-          aria-selected={this.checked}
-          aria-disabled={this.disabled}
+          role={this.role}
+          aria-checked={this.checked ? 'true' : null}
+          aria-disabled={this.disabled ? 'true' : null}
+          aria-selected={this.selected ? 'true' : null}
           tabindex={this.disabled || this.multiSelect ? '-1' : '0'}
           class="block w-full cursor-pointer select-none text-4 outline-none"
           onClick={this.onClick.bind(this)}

--- a/src/components/mx-menu-item/test/mx-menu-item.spec.tsx
+++ b/src/components/mx-menu-item/test/mx-menu-item.spec.tsx
@@ -72,10 +72,11 @@ describe('mx-menu-item', () => {
     expect(menuItem.querySelector('i')).not.toBeNull();
   });
 
-  it('displays a checkmark if the checked prop is set', async () => {
+  it('displays a checkmark and sets aria-checked to true if the checked prop is set', async () => {
     root.checked = true;
     await page.waitForChanges();
     expect(menuItem.querySelector('[data-testid="check"]')).not.toBeNull();
+    expect(menuItem.getAttribute('aria-checked')).toBe('true');
   });
 
   it('renders an mx-checkbox if the multiSelect prop is set', async () => {
@@ -94,6 +95,13 @@ describe('mx-menu-item', () => {
     await page.waitForChanges();
     checkbox = menuItem.querySelector('mx-checkbox');
     expect(checkbox.getAttribute('checked')).not.toBeNull();
+  });
+
+  it('sets aria-selected to true if the selected prop is true', async () => {
+    expect(root.children[0].getAttribute('aria-selected')).not.toBe('true');
+    root.selected = true;
+    await page.waitForChanges();
+    expect(root.children[0].getAttribute('aria-selected')).toBe('true');
   });
 
   it('getValue() returns the inner text without the label or subtitle', async () => {

--- a/src/components/mx-menu-item/test/mx-menu-item.spec.tsx
+++ b/src/components/mx-menu-item/test/mx-menu-item.spec.tsx
@@ -60,10 +60,10 @@ describe('mx-menu-item', () => {
   });
 
   it('sets aria-disabled to true when disabled', async () => {
-    expect(menuItem.getAttribute('aria-disabled')).toBeNull();
+    expect(menuItem.getAttribute('aria-disabled')).not.toBe('true');
     root.disabled = true;
     await page.waitForChanges();
-    expect(menuItem.getAttribute('aria-disabled')).not.toBeNull();
+    expect(menuItem.getAttribute('aria-disabled')).toBe('true');
   });
 
   it('displays an icon if the prop is set', async () => {

--- a/src/components/mx-menu/mx-menu.tsx
+++ b/src/components/mx-menu/mx-menu.tsx
@@ -172,6 +172,8 @@ export class MxMenu {
   }
 
   connectedCallback() {
+    const role = !!this.element.querySelector('[role="option"]') ? 'listbox' : 'menu';
+    this.element.setAttribute('role', role);
     this.anchorEl && this.anchorEl.setAttribute('aria-haspopup', 'true');
   }
 
@@ -188,6 +190,12 @@ export class MxMenu {
     if (anyMenuItemHasIcon) {
       this.menuItems.forEach(m => {
         if (m.icon === undefined) m.icon = null;
+      });
+    }
+    // Set selected prop on dropdown menu items (which updates aria-selected attribute)
+    if (this.inputEl) {
+      this.menuItems.forEach(async (m: HTMLMxMenuItemElement) => {
+        m.selected = this.inputEl.value === (await m.getValue());
       });
     }
   }

--- a/src/components/mx-menu/mx-menu.tsx
+++ b/src/components/mx-menu/mx-menu.tsx
@@ -225,7 +225,7 @@ export class MxMenu {
 
   render() {
     return (
-      <Host class={this.hostClass} role="menu">
+      <Host class={this.hostClass}>
         <div ref={el => (this.menuElem = el)} class="flex flex-col shadow-9 rounded-lg">
           <div
             ref={el => (this.scrollElem = el)}

--- a/src/components/mx-page-header/mx-page-header.tsx
+++ b/src/components/mx-page-header/mx-page-header.tsx
@@ -147,7 +147,7 @@ export class MxPageHeader {
                 {...button}
                 xl={this.minWidths.lg}
                 btn-type={btnType}
-                aria-hidden={isTertiary && this.renderTertiaryButtonAsMenu}
+                aria-hidden={isTertiary && this.renderTertiaryButtonAsMenu ? 'true' : null}
                 class={isTertiary && this.renderTertiaryButtonAsMenu ? 'opacity-0 pointer-events-none' : ''}
               >
                 {button.label}

--- a/src/components/mx-tab/mx-tab.tsx
+++ b/src/components/mx-tab/mx-tab.tsx
@@ -62,7 +62,7 @@ export class MxTab implements IMxTabProps {
           ref={el => (this.btnElem = el)}
           role="tab"
           type="button"
-          aria-selected={this.selected}
+          aria-selected={this.selected ? 'true' : null}
           aria-label={this.label || this.ariaLabel}
           class="relative overflow-hidden w-full h-full border border-transparent"
           onClick={this.onClick.bind(this)}

--- a/src/components/mx-tab/test/mx-tab.spec.tsx
+++ b/src/components/mx-tab/test/mx-tab.spec.tsx
@@ -22,7 +22,7 @@ describe('mx-tab (text, selected)', () => {
   });
 
   it('sets aria-selected', async () => {
-    expect(root.querySelector('[aria-selected]')).not.toBeNull();
+    expect(root.querySelector('[aria-selected="true"]')).not.toBeNull();
   });
 });
 
@@ -50,6 +50,6 @@ describe('mx-tab (icon, badge, not selected)', () => {
   });
 
   it('does not set aria-selected', async () => {
-    expect(root.querySelector('[aria-selected]')).toBeNull();
+    expect(root.querySelector('[aria-selected="true"]')).toBeNull();
   });
 });

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -695,13 +695,16 @@ export class MxTable {
             btn-type="outlined"
             {...this.multiRowActions[0]}
             class={'whitespace-nowrap' + (!this.checkedRowIds.length ? ' invisible' : '')}
-            aria-hidden={this.checkedRowIds.length === 0}
+            aria-hidden={this.checkedRowIds.length === 0 ? 'true' : null}
           >
             {this.multiRowActions[0].value}
           </mx-button>
         ) : (
           // Multi-Row Action Menu
-          <span class={!this.checkedRowIds.length ? 'invisible' : null} aria-hidden={this.checkedRowIds.length === 0}>
+          <span
+            class={!this.checkedRowIds.length ? 'invisible' : null}
+            aria-hidden={this.checkedRowIds.length === 0 ? 'true' : null}
+          >
             <mx-button ref={el => (this.actionMenuButton = el)} btn-type="text" dropdown>
               <span class="h-full flex items-center px-2">
                 <span innerHTML={gearSvg}></span>

--- a/src/components/mx-toggle-button/mx-toggle-button.tsx
+++ b/src/components/mx-toggle-button/mx-toggle-button.tsx
@@ -44,9 +44,9 @@ export class MxToggleButton {
             (this.selected ? ' selected' : '')
           }
           ref={el => (this.btnElem = el as HTMLButtonElement)}
-          aria-disabled={this.disabled}
+          aria-disabled={this.disabled ? 'true' : null}
           role={this.value === undefined ? 'switch' : 'radio'}
-          aria-checked={this.selected}
+          aria-checked={this.selected ? 'true' : null}
           aria-label={this.ariaLabel}
           onClick={this.onClick.bind(this)}
           {...this.dataAttributes}

--- a/src/components/mx-toggle-button/test/mx-toggle-button.spec.tsx
+++ b/src/components/mx-toggle-button/test/mx-toggle-button.spec.tsx
@@ -20,7 +20,7 @@ describe('mx-toggle-button', () => {
 
   it('is not selected by default', async () => {
     expect(btn.getAttribute('class')).not.toContain('selected');
-    expect(btn.getAttribute('aria-checked')).toBeNull();
+    expect(btn.getAttribute('aria-checked')).not.toBe('true');
   });
 
   it('has a switch role by default', async () => {
@@ -45,15 +45,13 @@ describe('mx-toggle-button as disabled and selected', () => {
 
   it('is disabled', async () => {
     const btn = root.querySelector('button');
-    expect(btn.getAttribute('aria-disabled')).not.toBeNull();
-    expect(btn.getAttribute('aria-disabled')).not.toBe('false');
+    expect(btn.getAttribute('aria-disabled')).toBe('true');
   });
 
   it('is selected', async () => {
     const btn = root.querySelector('button');
     expect(btn.getAttribute('class')).toContain('selected');
-    expect(btn.getAttribute('aria-checked')).not.toBeNull();
-    expect(btn.getAttribute('aria-checked')).not.toBe('false');
+    expect(btn.getAttribute('aria-checked')).toBe('true');
   });
 });
 

--- a/src/tailwind/mx-button/index.scss
+++ b/src/tailwind/mx-button/index.scss
@@ -18,7 +18,7 @@
         background: var(--mds-bg-btn-contained-active);
       }
 
-      &[aria-disabled] {
+      &[aria-disabled='true'] {
         background: var(--mds-bg-btn-contained-disabled);
         color: var(--mds-text-btn-contained-disabled);
       }
@@ -30,19 +30,19 @@
       color: var(--mds-text-btn-outlined);
       --ripple-color: var(--mds-ripple-btn-outlined);
 
-      &:focus:not([aria-disabled]) {
+      &:focus:not([aria-disabled='true']) {
         background: var(--mds-bg-btn-outlined-focus);
       }
 
-      &:hover:not([aria-disabled]) {
+      &:hover:not([aria-disabled='true']) {
         background: var(--mds-bg-btn-outlined-hover);
       }
 
-      &:active:not([aria-disabled]) {
+      &:active:not([aria-disabled='true']) {
         background: var(--mds-bg-btn-outlined-active);
       }
 
-      &[aria-disabled] {
+      &[aria-disabled='true'] {
         background: var(--mds-bg-btn-outlined-disabled);
         border-color: var(--mds-border-btn-outlined-disabled);
         color: var(--mds-text-btn-outlined-disabled);
@@ -55,19 +55,19 @@
       border-color: var(--mds-border-btn-action);
       --ripple-color: var(--mds-ripple-btn-action);
 
-      &:focus:not([aria-disabled]) {
+      &:focus:not([aria-disabled='true']) {
         background: var(--mds-bg-btn-action-focus);
       }
 
-      &:hover:not([aria-disabled]) {
+      &:hover:not([aria-disabled='true']) {
         background: var(--mds-bg-btn-action-hover);
       }
 
-      &:active:not([aria-disabled]) {
+      &:active:not([aria-disabled='true']) {
         background: var(--mds-bg-btn-action-active);
       }
 
-      &[aria-disabled] {
+      &[aria-disabled='true'] {
         background: var(--mds-bg-btn-action-disabled);
         border-color: var(--mds-border-btn-action-disabled);
         color: var(--mds-text-btn-action-disabled);
@@ -83,30 +83,30 @@
         background: var(--mds-bg-btn-text-dropdown-separator);
       }
 
-      &:focus:not([aria-disabled]) {
+      &:focus:not([aria-disabled='true']) {
         background: var(--mds-bg-btn-text-focus);
         .separator {
           background: var(--mds-bg-btn-text-dropdown-separator-focus);
         }
       }
 
-      &:hover:not([aria-disabled]) {
+      &:hover:not([aria-disabled='true']) {
         background: var(--mds-bg-btn-text-hover);
         .separator {
           background: var(--mds-bg-btn-text-dropdown-separator-hover);
         }
       }
 
-      &:active:not([aria-disabled]) {
+      &:active:not([aria-disabled='true']) {
         background: var(--mds-bg-btn-text-active);
       }
 
-      &[aria-disabled] {
+      &[aria-disabled='true'] {
         color: var(--mds-text-btn-text-disabled);
         background: var(--mds-bg-btn-text-disabled);
       }
 
-      &.dropdown:not([aria-disabled]) {
+      &.dropdown:not([aria-disabled='true']) {
         .slot-content,
         .chevron-icon {
           color: var(--mds-text-btn-text-dropdown);

--- a/src/tailwind/mx-chip/index.scss
+++ b/src/tailwind/mx-chip/index.scss
@@ -4,7 +4,7 @@
   --ripple-color: var(--mds-ripple-chip);
   transform: translateZ(0); /* HACK: Fix Safari ripple extending outside border radius */
 
-  &[aria-checked] {
+  &[aria-checked='true'] {
     background: var(--mds-bg-chip-selected);
     &.choice {
       color: var(--mds-text-chip-choice-selected);
@@ -23,21 +23,21 @@
   }
 
   &.clickable {
-    &:focus:not([aria-disabled], [aria-checked]) {
+    &:focus:not([aria-disabled='true'], [aria-checked='true']) {
       background: var(--mds-bg-chip-focus);
     }
 
-    &:hover:not([aria-disabled]) {
+    &:hover:not([aria-disabled='true']) {
       background: var(--mds-bg-chip-hover);
     }
 
-    &:active:not([aria-disabled]) {
+    &:active:not([aria-disabled='true']) {
       background: var(--mds-bg-chip-active);
       @apply shadow-8 -translate-y-1;
     }
   }
 
-  &[aria-disabled] {
+  &[aria-disabled='true'] {
     background: var(--mds-bg-chip-disabled);
     color: var(--mds-text-chip-disabled);
     .left-icon,
@@ -76,7 +76,7 @@
     border-color: var(--mds-border-chip-outlined);
     --ripple-color: var(--mds-ripple-chip-outlined);
 
-    &[aria-checked] {
+    &[aria-checked='true'] {
       background: var(--mds-bg-chip-outlined-selected);
       &.choice {
         background: var(--mds-bg-chip-choice-selected);
@@ -88,20 +88,20 @@
     }
 
     &.clickable {
-      &:focus:not([aria-disabled], [aria-checked]) {
+      &:focus:not([aria-disabled='true'], [aria-checked='true']) {
         background: var(--mds-bg-chip-outlined-focus);
       }
 
-      &:hover:not([aria-disabled]) {
+      &:hover:not([aria-disabled='true']) {
         background: var(--mds-bg-chip-outlined-hover);
       }
 
-      &:active:not([aria-disabled]) {
+      &:active:not([aria-disabled='true']) {
         background: var(--mds-bg-chip-outlined-active);
       }
     }
 
-    &[aria-disabled] {
+    &[aria-disabled='true'] {
       background: var(--mds-bg-chip-outlined-disabled);
       border-color: var(--mds-border-chip-outlined-disabled);
       color: var(--mds-text-chip-outlined-disabled);

--- a/src/tailwind/mx-icon-button/index.scss
+++ b/src/tailwind/mx-icon-button/index.scss
@@ -6,28 +6,28 @@
     background: var(--mds-bg-btn-icon-chevron);
   }
 
-  &:focus:not([aria-disabled]) {
+  &:focus:not([aria-disabled='true']) {
     background: var(--mds-bg-btn-icon-focus);
     .chevron-wrapper {
       background: var(--mds-bg-btn-icon-chevron-focus);
     }
   }
 
-  &:hover:not([aria-disabled]) {
+  &:hover:not([aria-disabled='true']) {
     background: var(--mds-bg-btn-icon-hover);
     .chevron-wrapper {
       background: var(--mds-bg-btn-icon-chevron-hover);
     }
   }
 
-  &:active:not([aria-disabled]) {
+  &:active:not([aria-disabled='true']) {
     background: var(--mds-bg-btn-icon-active);
     .chevron-wrapper {
       background: var(--mds-bg-btn-icon-chevron-active);
     }
   }
 
-  &[aria-disabled] {
+  &[aria-disabled='true'] {
     color: var(--mds-text-btn-icon-disabled);
     background: var(--mds-bg-btn-icon-disabled);
   }

--- a/src/tailwind/mx-menu-item/index.scss
+++ b/src/tailwind/mx-menu-item/index.scss
@@ -21,7 +21,7 @@
       background: var(--mds-bg-menu-item-focus);
     }
 
-    &[aria-disabled] {
+    &[aria-disabled='true'] {
       color: var(--mds-text-menu-item-disabled);
     }
   }
@@ -32,7 +32,7 @@
   }
 }
 
-.mx-menu.autocomplete-only:not(:focus-within) .mx-menu-item:not([aria-disabled]):first-child > div {
+.mx-menu.autocomplete-only:not(:focus-within) .mx-menu-item:not([aria-disabled='true']):first-child > div {
   /* Add focused background to first enabled menu item for autocomplete-only menus */
   background: var(--mds-bg-menu-item-focus);
 }

--- a/src/tailwind/mx-tab/index.scss
+++ b/src/tailwind/mx-tab/index.scss
@@ -13,11 +13,11 @@
     color: var(--mds-text-tab);
     --ripple-color: var(--mds-ripple-tab);
 
-    &[aria-selected] {
+    &[aria-selected='true'] {
       color: var(--mds-text-tab-selected);
     }
 
-    &:not([aria-selected], :active) i {
+    &:not([aria-selected='true'], :active) i {
       color: var(--mds-text-tab-icon);
       &.icon-only {
         color: var(--mds-text-tab-icon-only);
@@ -27,7 +27,7 @@
     &:focus-visible {
       background: var(--mds-bg-tab-focus);
       border-bottom-color: var(--mds-border-tab-focus);
-      &[aria-selected] {
+      &[aria-selected='true'] {
         background: var(--mds-bg-tab-selected-focus);
       }
     }
@@ -35,7 +35,7 @@
     &:hover {
       background: var(--mds-bg-tab-hover);
       border-bottom-color: var(--mds-border-tab-hover);
-      &[aria-selected] {
+      &[aria-selected='true'] {
         background: var(--mds-bg-tab-selected-hover);
       }
     }

--- a/src/tailwind/mx-toggle-button/index.scss
+++ b/src/tailwind/mx-toggle-button/index.scss
@@ -7,20 +7,20 @@
     background: var(--mds-bg-btn-toggle);
     outline-offset: -1px;
 
-    &:focus:not([aria-disabled]) {
+    &:focus:not([aria-disabled='true']) {
       background: var(--mds-bg-btn-toggle-focus);
     }
 
-    &:hover:not([aria-disabled]) {
+    &:hover:not([aria-disabled='true']) {
       background: var(--mds-bg-btn-toggle-hover);
     }
 
-    &:active:not([aria-disabled]) {
+    &:active:not([aria-disabled='true']) {
       background: var(--mds-bg-btn-toggle-active);
       color: var(--mds-text-btn-toggle-active);
     }
 
-    &[aria-disabled] {
+    &[aria-disabled='true'] {
       color: var(--mds-text-btn-toggle-disabled);
       background: var(--mds-bg-btn-toggle-disabled);
     }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -122,7 +122,7 @@ const config = {
         modifySelectors(({ className }) => {
           return `.${e(`disabled${separator}${className}`)}:disabled, .${e(
             `disabled${separator}${className}`,
-          )}[aria-disabled]`;
+          )}[aria-disabled='true']`;
         });
       });
       addVariant('first-of-type', ({ modifySelectors, separator }) => {

--- a/vuepress/components/menus.md
+++ b/vuepress/components/menus.md
@@ -180,6 +180,8 @@ selected on <kbd>Enter</kbd>.
 | `icon`        | `icon`         | The class name of the icon to display on the left. This is sometimes automatically set to `null` to add an empty icon for alignment purposes (when a sibling menu item has an icon).                 | `string`  | `undefined` |
 | `label`       | `label`        | A label to display above the menu item                                                                                                                                                               | `string`  | `undefined` |
 | `multiSelect` | `multi-select` | Render a checkbox as part of the menu item. On small screens, the checkbox will appear on the left; otherwise, it will be on the right.                                                              | `boolean` | `false`     |
+| `selected`    | `selected`     | This is automatically set by a parent Dropdown Menu.                                                                                                                                                 | `boolean` | `false`     |
+| `subtitle`    | `subtitle`     | A subtitle to display below the menu item text                                                                                                                                                       | `string`  | `undefined` |
 
 ### Menu Events
 


### PR DESCRIPTION
This addresses some ARIA issues:
- Unlike attributes like `required`, boolean _ARIA attributes_ like `aria-disabled` and `aria-selected` should be explicitly set to `'true'` per the spec, so I've fixed that in a bunch of components/CSS selectors.
- Updated `mx-menu` and `mx-menu-item` to use the `listbox` and `option` roles respectively when they are inside an `mx-dropdown-menu`.  Otherwise, they still use the `menu` and `menuitem` roles.  I've also corrected the use of `aria-selected` vs. `aria-checked` so that `aria-selected` is used for the selected option in an `mx-dropdown-menu`, and `aria-checked` is used for a `checked` menu item.