### PR TITLE
ENG-140494 - Implement advanced (slot-based) dialogs

### DIFF
--- a/src/components/mx-dialog/test/mx-dialog.spec.tsx
+++ b/src/components/mx-dialog/test/mx-dialog.spec.tsx
@@ -2,7 +2,7 @@ import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { MxButton } from '../../mx-button/mx-button';
 import { MxDialog } from '../mx-dialog';
 
-describe('mx-dialog', () => {
+describe('mx-dialog (simple)', () => {
   let page: SpecPage;
   let root: HTMLMxDialogElement;
   let modal;
@@ -97,5 +97,56 @@ describe('mx-dialog', () => {
     root.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     await page.waitForChanges();
     expect(resolved).toBe(true);
+  });
+});
+
+describe('mx-dialog (advanced)', () => {
+  let page: SpecPage;
+  let root: HTMLMxDialogElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxDialog, MxButton],
+      html: `
+      <mx-dialog>
+        <span slot="heading">Heading</span>
+        <p>Content</p>
+        <div slot="buttons">
+          <mx-button btn-type="text">Okay</mx-button>
+        </div>
+      </mx-dialog>
+      `,
+    });
+    root = page.root as HTMLMxDialogElement;
+  });
+
+  it('opens when isOpen is toggled to true', async () => {
+    expect(root.classList.contains('hidden')).toBe(true);
+    root.isOpen = true;
+    await page.waitForChanges();
+    expect(root.classList.contains('hidden')).toBe(false);
+  });
+
+  it('renders the heading slot inside the h1', () => {
+    expect((root.querySelector('[data-testid="heading"]') as HTMLElement).innerText).toBe('Heading');
+  });
+
+  it('renders the default slot content inside the modal content element', () => {
+    expect((root.querySelector('[data-testid="modal-content"]') as HTMLElement).innerText).toContain('Content');
+  });
+
+  it('renders the buttons slot inside the button tray', () => {
+    const buttonTray = root.querySelector('[data-testid="button-tray"]') as HTMLElement;
+    const button = buttonTray.children[0] as HTMLElement;
+    expect(button.innerText).toContain('Okay');
+  });
+
+  it('emits an mxClose event on close', async () => {
+    root.isOpen = true;
+    await page.waitForChanges();
+    const listener = jest.fn();
+    root.addEventListener('mxClose', listener);
+    root.isOpen = false;
+    await page.waitForChanges();
+    expect(listener).toHaveBeenCalled();
   });
 });

--- a/src/tailwind/mx-dialog/index.scss
+++ b/src/tailwind/mx-dialog/index.scss
@@ -3,6 +3,21 @@
 
   .modal {
     background: var(--mds-bg-dialog);
+
+    [slot='buttons'] > * {
+      @apply m-4;
+    }
+
+    ::-webkit-scrollbar {
+      width: 12px;
+      background: var(--mds-bg-dialog);
+    }
+
+    ::-webkit-scrollbar-thumb {
+      border-radius: 0.5rem;
+      border: 0.25rem solid var(--mds-bg-dialog);
+      background: var(--mds-bg-dialog-scroll-thumb);
+    }
   }
 
   .bg-dialog-backdrop {

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -348,6 +348,7 @@
   /* #region dialogs */
   /* Dialogs */
   --mds-bg-dialog-backdrop: rgba(0, 0, 0, 0.5);
+  --mds-bg-dialog-scroll-thumb: #d4d4d4;
   --mds-bg-dialog: #f8f8f8;
   --mds-text-dialog: #333;
   /* #endregion dialogs */

--- a/src/utils/transitions.ts
+++ b/src/utils/transitions.ts
@@ -127,6 +127,7 @@ function executeTransition(
       setStyleProperty(el, transition.property, transition.startValue);
     });
     if (transformOrigin) el.style.transformOrigin = transformOrigin;
+    await new Promise(requestAnimationFrame);
     el.style.transition = transitionOptions
       .map(transition => {
         return `${transition.property} ${duration}ms ${transition.timing}`;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -79,6 +79,7 @@ const config = {
       320: '20rem',
       360: '22.5rem',
       384: '24rem',
+      480: '30rem',
     },
     extend: {
       backgroundColor: {
@@ -102,6 +103,9 @@ const config = {
       },
       minHeight: theme => ({
         ...theme('spacing'), // Extend to include spacing values (e.g. min-h-128)
+      }),
+      maxHeight: theme => ({
+        ...theme('spacing'), // Extend to include spacing values (e.g. max-h-128)
       }),
       container: {
         center: true,

--- a/vuepress/components/dialogs.md
+++ b/vuepress/components/dialogs.md
@@ -2,26 +2,73 @@
 
 The `mx-dialog` component is used to inform users about a task and can contain critical information, require decisions, or involve multiple tasks. For more complex UI, a [Modal](/components/modals.html) may be preferrable. If user interruption is not strictly required, consider using a [Banner](/components/banners.md) or [Snackbar](/components/snackbars.html) instead.
 
+### Simple dialogs via methods
+
 Currently, `mx-dialog` exposes two methods: `alert()` and `confirm()`, which are intended to be replacements for [`Window.alert()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/alert) and [`Window.confirm()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm) respectively. The signatures for these two methods are identical, but with different default values for `confirmLabel` and `cancelLabel` (to match the behavior of the aforementioned `Window` methods).
 
-Since the Dialog component is propless, it is possible to use a single instance of the `mx-dialog` element to invoke every dialog needed for the page.
+For simple dialogs without markup, it is possible to use a single instance of the `mx-dialog` element to invoke every dialog needed for the page.
 
 <section class="mds">
   <div class="flex flex-col items-start space-y-20">
-    <!-- #region dialogs -->
+    <!-- #region simple -->
     <mx-button @click="() => $refs.dialog.alert('Greetings!')">Basic Alert Call</mx-button>
     <mx-button @click="advancedAlert">Advanced Alert Call</mx-button>
     <mx-button @click="confirmation">Basic Confirm Call</mx-button>
     <mx-button @click="advancedConfirmation">Advanced Confirm Call</mx-button>
     <mx-dialog ref="dialog" />
-    <!-- #endregion dialogs -->
+    <!-- #endregion simple -->
   </div>
 </section>
 
-<<< @/vuepress/components/dialogs.md#dialogs
+<<< @/vuepress/components/dialogs.md#simple
 <<< @/vuepress/components/dialogs.md#methods
 
-### Dialog Methods
+### Advanced dialogs via slots
+
+For more advanced dialog layouts, pass the markup into the default slot, as well as the `heading` and `buttons` slots, and use the `isOpen` prop to toggle the dialog. The dialog
+emits an `mxClose` event that may be useful to update the `isOpen` boolean in state.
+
+<section class="mds">
+  <div class="flex flex-col items-start space-y-20">
+    <!-- #region advanced -->
+    <mx-button @click="isDialogOpen = !isDialogOpen">Open Dialog</mx-button>
+    <mx-dialog
+      :is-open.prop="isDialogOpen"
+      modal-class="w-320 sm:w-480 max-h-480"
+      @mxClose="isDialogOpen = false"
+    >
+      <span slot="heading">Create new audience with selected</span>
+      <mx-input label="Audience Name" />
+      <p class="my-16">4,800 contacts will be added to this audience.</p>
+      <p>
+        We only wear jeans or track pants on Friday. You can’t wear a tank top two days in a row. You can only wear your hair in a ponytail once a week. So, I guess, you picked today. And if you break any of these rules you can’t sit with us at lunch. I mean, not just you, any of us. Like, if I was wearing jeans today, I would be sitting over there with the art freaks.
+      </p>
+      <p>
+        We always vote before we ask someone to eat lunch with us, because you have to be considerate of the rest of the group. I mean, you wouldn’t buy a skirt without asking your friends first if it looks good on you. It’s the same with guys. You may think you like someone, but you could be wrong.
+      </p>
+      <div slot="buttons">
+        <mx-button btn-type="text" @click="isDialogOpen = false">
+          Cancel
+        </mx-button>
+        <mx-button btn-type="text" @click="isDialogOpen = false">
+          Save &amp; Add
+        </mx-button>
+      </div>
+    </mx-dialog>
+    <!-- #endregion advanced -->
+  </div>
+</section>
+
+<<< @/vuepress/components/dialogs.md#advanced
+
+### Properties
+
+| Property     | Attribute     | Description                                                              | Type      | Default     |
+| ------------ | ------------- | ------------------------------------------------------------------------ | --------- | ----------- |
+| `isOpen`     | `is-open`     | Toggles the visibility of the dialog (when using the slots for content). | `boolean` | `false`     |
+| `modalClass` | `modal-class` | Additional classes to apply to the inner modal element.                  | `string`  | `undefined` |
+
+### Methods
 
 #### `alert(message: string, { confirmLabel, cancelLabel, heading }?: DialogOptions) => Promise<void>`
 
@@ -31,12 +78,23 @@ A Promise-based replacement for `Window.alert()` with some additional options
 
 A Promise-based replacement for `Window.confirm()` that resolves to a boolean
 
+### Events
+
+| Event     | Description | Type                |
+| --------- | ----------- | ------------------- |
+| `mxClose` |             | `CustomEvent<void>` |
+
 ### CSS Variables
 
 <<< @/src/tailwind/variables/index.scss#dialogs
 
 <script>
 export default {
+  data() {
+    return {
+      isDialogOpen: false
+    }
+  },
   methods: {
     // #region methods
     advancedAlert() {


### PR DESCRIPTION
This adds the ability to markup advanced dialog layouts via slots.

- Added a default slot, as well as `heading` and `buttons` slots to `mx-dialog`.
- Added an `isOpen` prop for toggling the dialog in lieu of using the existing methods.
- Added a `modalClass` prop for adding classes to the inner modal element.
- The dialog content is now scrollable.
- Added a CSS variable for the color of the dialog scroll thumb.
- An `mxClose` event is now emitted after the dialog closes.
- Updated the tailwind config to generate `max-h-*` classes for all the spacing values and added a 480px/30rem value.
- Added back a previously removed `requestAnimationFrame` call in `executeTransition` that is needed for these dialogs to fade in consistently.

![Kapture 2021-12-13 at 10 07 08](https://user-images.githubusercontent.com/3342530/145836823-6f22d2e2-f0d7-4f9d-880e-158a98ba8675.gif)
