### PR TITLE
ENG-140025 - Charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@juggle/resize-observer": "^3.3.1",
     "@popperjs/core": "^2.9.2",
     "@stencil/core": "^2.0.1",
+    "chart.js": "^3.6.2",
     "js-datepicker": "^5.18.0",
     "nanoid": "^3.1.22",
     "postcss-custom-properties": "^11.0.0",

--- a/src/components/mx-chart/mx-chart.tsx
+++ b/src/components/mx-chart/mx-chart.tsx
@@ -3,6 +3,10 @@ import { Chart, ChartType, ChartData, ChartOptions, registerables } from 'chart.
 
 Chart.register(...registerables);
 
+// These interfaces prevent the Stencil documentation generator from expanding these type aliases (resulting in realllly long type definitions)
+export interface ChartJsData extends ChartData {}
+export interface ChartJsOptions extends ChartOptions {}
+
 @Component({
   tag: 'mx-chart',
   shadow: false,
@@ -11,11 +15,16 @@ export class MxChart {
   canvasEl: HTMLCanvasElement;
   chart: Chart;
 
-  @Prop() type: ChartType = 'line';
-  @Prop() data: ChartData;
-  @Prop() options: ChartOptions;
-  @Prop() width: number;
+  /** The labels and datasets to render. See the [Chart.js documentation](https://www.chartjs.org/docs/3.6.2/). */
+  @Prop() data: ChartJsData;
+  /** Explicit height in pixels */
   @Prop() height: number;
+  /** See the [Chart.js documentation](https://www.chartjs.org/docs/3.6.2/). */
+  @Prop() options: ChartJsOptions;
+  /** The type of chart to render. For mixed charts, set the `type` in the dataset instead. */
+  @Prop() type: ChartType;
+  /** Explicit width in pixels */
+  @Prop() width: number;
 
   @Element() element: HTMLMxChartElement;
 

--- a/src/components/mx-chart/mx-chart.tsx
+++ b/src/components/mx-chart/mx-chart.tsx
@@ -1,0 +1,40 @@
+import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { Chart, ChartType, ChartData, ChartOptions, registerables } from 'chart.js';
+
+Chart.register(...registerables);
+
+@Component({
+  tag: 'mx-chart',
+  shadow: false,
+})
+export class MxChart {
+  canvasEl: HTMLCanvasElement;
+  chart: Chart;
+
+  @Prop() type: ChartType = 'line';
+  @Prop() data: ChartData;
+  @Prop() options: ChartOptions;
+
+  @Element() element: HTMLMxChartElement;
+
+  componentDidRender() {
+    this.canvasEl.width = this.element.scrollWidth;
+    this.canvasEl.height = this.element.scrollHeight;
+  }
+
+  componentDidLoad() {
+    this.chart = new Chart(this.canvasEl, {
+      type: this.type,
+      data: this.data,
+      options: this.options,
+    });
+  }
+
+  render() {
+    return (
+      <Host class="mx-chart relative block">
+        <canvas ref={el => (this.canvasEl = el)} role="img" class="w-full h-full" />
+      </Host>
+    );
+  }
+}

--- a/src/components/mx-chart/mx-chart.tsx
+++ b/src/components/mx-chart/mx-chart.tsx
@@ -1,7 +1,7 @@
-import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { Component, Host, h, Prop, Element, Watch, Method } from '@stencil/core';
 import { Chart, ChartType, ChartData, ChartOptions, registerables } from 'chart.js';
 
-Chart.register(...registerables);
+Chart.register(...(registerables || []));
 
 // These interfaces prevent the Stencil documentation generator from expanding these type aliases (resulting in realllly long type definitions)
 export interface ChartJsData extends ChartData {}
@@ -28,7 +28,22 @@ export class MxChart {
 
   @Element() element: HTMLMxChartElement;
 
+  @Watch('data')
+  @Watch('options')
+  @Watch('type')
+  onDataChange() {
+    this.update();
+  }
+
   componentDidLoad() {
+    this.update();
+  }
+
+  /** Force the chart to rerender. */
+  @Method()
+  async update() {
+    if (!this.canvasEl) return;
+    if (this.chart) this.chart.destroy();
     this.chart = new Chart(this.canvasEl, {
       type: this.type,
       data: this.data,

--- a/src/components/mx-chart/mx-chart.tsx
+++ b/src/components/mx-chart/mx-chart.tsx
@@ -14,13 +14,10 @@ export class MxChart {
   @Prop() type: ChartType = 'line';
   @Prop() data: ChartData;
   @Prop() options: ChartOptions;
+  @Prop() width: number;
+  @Prop() height: number;
 
   @Element() element: HTMLMxChartElement;
-
-  componentDidRender() {
-    this.canvasEl.width = this.element.scrollWidth;
-    this.canvasEl.height = this.element.scrollHeight;
-  }
 
   componentDidLoad() {
     this.chart = new Chart(this.canvasEl, {
@@ -30,10 +27,14 @@ export class MxChart {
     });
   }
 
+  get chartStyle() {
+    return { width: this.width && this.width + 'px', height: this.height && this.height + 'px' };
+  }
+
   render() {
     return (
-      <Host class="mx-chart relative block">
-        <canvas ref={el => (this.canvasEl = el)} role="img" class="w-full h-full" />
+      <Host class="mx-chart relative block" style={this.chartStyle}>
+        <canvas ref={el => (this.canvasEl = el)} role="img" style={this.chartStyle} />
       </Host>
     );
   }

--- a/src/components/mx-chart/test/mx-chart.spec.tsx
+++ b/src/components/mx-chart/test/mx-chart.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { MxChart } from '../mx-chart';
+
+describe('mx-chart', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [MxChart],
+      html: `<mx-chart></mx-chart>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <mx-chart>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </mx-chart>
+    `);
+  });
+});

--- a/src/components/mx-chart/test/mx-chart.spec.tsx
+++ b/src/components/mx-chart/test/mx-chart.spec.tsx
@@ -1,18 +1,51 @@
-import { newSpecPage } from '@stencil/core/testing';
+jest.mock('chart.js');
+import ChartJs from 'chart.js';
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { MxChart } from '../mx-chart';
 
-describe('mx-chart', () => {
-  it('renders', async () => {
-    const page = await newSpecPage({
+describe('mx-chart (code prop)', () => {
+  let page: SpecPage;
+  let root: HTMLMxChartElement;
+  let canvas: HTMLCanvasElement;
+  const chartData = {
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+    datasets: [
+      {
+        label: 'Example data',
+        data: [435, 321, 532, 801, 1231, 1098, 732, 321, 451, 482, 513, 397],
+        borderColor: '#d93b65',
+      },
+    ],
+  };
+  const chartOptions = {
+    maintainAspectRatio: false,
+  };
+
+  beforeEach(async () => {
+    page = await newSpecPage({
       components: [MxChart],
-      html: `<mx-chart></mx-chart>`,
+      html: `<mx-chart type="line" width="640" height="320" />`,
     });
-    expect(page.root).toEqualHtml(`
-      <mx-chart>
-        <mock:shadow-root>
-          <slot></slot>
-        </mock:shadow-root>
-      </mx-chart>
-    `);
+    root = page.root as HTMLMxChartElement;
+    root.data = chartData;
+    root.options = chartOptions;
+    await page.waitForChanges();
+    await page.waitForChanges();
+    canvas = root.querySelector('canvas');
+  });
+
+  it('renders a canvas element', () => {
+    expect(canvas).not.toBeNull();
+  });
+
+  it('sets the width and height on the root and canvas elements', async () => {
+    expect(root.style.width).toBe('640px');
+    expect(root.style.height).toBe('320px');
+    expect(canvas.style.width).toBe('640px');
+    expect(canvas.style.height).toBe('320px');
+  });
+
+  it('creates a new Chart of the provided type', async () => {
+    expect((ChartJs as any).mock.calls[0][1].type).toBe('line');
   });
 });

--- a/vuepress/.vuepress/config.js
+++ b/vuepress/.vuepress/config.js
@@ -157,6 +157,7 @@ module.exports = {
         'snackbars',
         'uploads',
         'code',
+        'charts',
       ],
     },
   },

--- a/vuepress/components/charts.md
+++ b/vuepress/components/charts.md
@@ -1,0 +1,132 @@
+# Charts
+
+The `mx-chart` component provides chart generation via Chart.js.
+
+## Line charts
+
+<section class="mds">
+  <div>
+    <!-- #region line -->
+    <mx-chart class="h-240 sm:h-320" type="line" :data.prop="lineData" />
+    <!-- #endregion line -->
+  </div>
+  <div class="my-40">
+    <strong class="block mb-20">Sparkline</strong>
+    <!-- #region sparkline -->
+    <mx-chart class="w-128 h-48" type="line" :data.prop="lineData" :options.prop="sparklineOptions" />
+    <!-- #endregion sparkline -->
+  </div>
+</section>
+
+<<< @/vuepress/components/charts.md#line
+<<< @/vuepress/components/charts.md#sparkline
+<<< @/vuepress/components/charts.md#line-data
+<<< @/vuepress/components/charts.md#sparkline-options
+
+## Bar charts
+
+<section class="mds">
+  <!-- #region bar -->
+  <mx-chart class="h-320" type="bar" :data.prop="barData" />
+  <!-- #endregion bar -->
+</section>
+
+<<< @/vuepress/components/charts.md#bar
+<<< @/vuepress/components/charts.md#bar-data
+
+## Pie and doughnut charts
+
+<section class="mds">
+  <!-- #region pie -->
+  <mx-chart class="h-320" type="pie" :data.prop="pieData" />
+  <mx-chart class="h-128" type="doughnut" :data.prop="pieData" />
+  <!-- #endregion -->
+</section>
+
+<script>
+export default {
+  data() {
+    return {
+      // #region line-data
+      lineData: {
+        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+        datasets: [
+          {
+            label: 'Example data',
+            data: [435, 321, 532, 801, 1231, 1098, 732, 321, 451, 482, 513, 397],
+            fill: true,
+          },
+        ]
+      },
+      // #endregion line-data
+      // #region sparkline-options
+      sparklineOptions: {
+        responsive: false,
+        legend: {
+          display: false,
+        },
+        elements: {
+          point: {
+            radius: 0
+          },
+          line: {
+            borderWidth: 2,
+            borderColor: "#6a9"
+          }
+        },
+        scales: {
+          x: {
+            display: false,
+          },
+          y: {
+            display: false
+          }
+        },
+        plugins: {
+          legend: false,
+          title: false,
+          tooltip: false
+        },
+      },
+      // #endregion sparkline-options
+      // #region bar-data
+      barData: {
+        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul'],
+        datasets: [
+          {
+            label: 'Example data',
+            data: [65, 59, 80, 81, 56, 55, 40],
+            backgroundColor: [
+              'rgba(255, 99, 132, 0.2)',
+              'rgba(255, 159, 64, 0.2)',
+              'rgba(255, 205, 86, 0.2)',
+              'rgba(75, 192, 192, 0.2)',
+              'rgba(54, 162, 235, 0.2)',
+              'rgba(153, 102, 255, 0.2)',
+              'rgba(201, 203, 207, 0.2)'
+            ],
+          },
+        ]
+      },
+      // #endregion bar-data
+      // #region pie-data
+      pieData: {
+        labels: [
+          'Red',
+          'Blue',
+          'Yellow'
+        ],
+        datasets: [{
+          label: 'Example data',
+          data: [300, 50, 100],
+          backgroundColor: [
+            'rgb(255, 99, 132)',
+            'rgb(54, 162, 235)',
+            'rgb(255, 205, 86)'
+          ],
+        }]
+      },
+    }
+  }
+}
+</script>

--- a/vuepress/components/charts.md
+++ b/vuepress/components/charts.md
@@ -46,9 +46,36 @@ set the `maintainAspectRatio` option to `false` if necessary when setting an exp
     <!-- #region pie -->
     <mx-chart width="320" type="pie" :data.prop="pieData" />
     <mx-chart width="320" type="doughnut" :data.prop="pieData" />
-    <!-- #endregion -->
+    <!-- #endregion pie -->
   </div>
 </section>
+
+<<< @/vuepress/components/charts.md#pie
+<<< @/vuepress/components/charts.md#pie-data
+
+## Mixed charts
+
+It is possible to combine chart types. Instead of setting the `type` prop, set the `type` within each
+dataset individually.
+
+<section class="mds">
+  <!-- #region mixed -->
+  <mx-chart :data.prop="mixedData" />
+  <!-- #endregion mixed -->
+</section>
+
+<<< @/vuepress/components/charts.md#mixed
+<<< @/vuepress/components/charts.md#mixed-data
+
+### Properties
+
+| Property  | Attribute | Description                                                                                               | Type                                                                                        | Default     |
+| --------- | --------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ----------- |
+| `data`    | --        | The labels and datasets to render. See the [Chart.js documentation](https://www.chartjs.org/docs/3.6.2/). | `ChartJsData`                                                                               | `undefined` |
+| `height`  | `height`  | Explicit height in pixels                                                                                 | `number`                                                                                    | `undefined` |
+| `options` | --        | See the [Chart.js documentation](https://www.chartjs.org/docs/3.6.2/).                                    | `ChartJsOptions`                                                                            | `undefined` |
+| `type`    | `type`    | The type of chart to render. For mixed charts, set the `type` in the dataset instead.                     | `"bar" \| "bubble" \| "doughnut" \| "line" \| "pie" \| "polarArea" \| "radar" \| "scatter"` | `undefined` |
+| `width`   | `width`   | Explicit width in pixels                                                                                  | `number`                                                                                    | `undefined` |
 
 <script>
 export default {
@@ -126,6 +153,27 @@ export default {
           ],
         }]
       },
+      // #endregion pie-data
+      // #region mixed-data
+      mixedData: {
+        labels: ['January', 'Febrary', 'March', 'April'],
+        datasets: [{
+          type: 'line',
+          label: 'Line data',
+          data: [10, 15, 55, 40],
+        }, {
+          type: 'bar',
+          label: 'Bar data',
+          data: [10, 30, 60, 40],
+          backgroundColor: [
+            'rgba(255, 99, 132, 0.2)',
+            'rgba(54, 162, 235, 0.2)',
+            'rgba(255, 205, 86, 0.2)',
+            'rgba(20, 205, 86, 0.2)',
+          ]
+        }]
+      }
+      // #endregion mixed-data
     }
   }
 }

--- a/vuepress/components/charts.md
+++ b/vuepress/components/charts.md
@@ -1,19 +1,24 @@
 # Charts
 
-The `mx-chart` component provides chart generation via Chart.js.
+The `mx-chart` component provides chart generation via [Chart.js](https://www.chartjs.org/docs/3.6.2/).
+The `type`, `data`, and `options` are all passed via three props of the same name.
+
+By default, the charts are sized to the container width, and the chart's height is determined by its
+aspect ratio. The `width` and `height` props may be used to set an explicit size in pixels. Be sure to
+set the `maintainAspectRatio` option to `false` if necessary when setting an explicit height.
 
 ## Line charts
 
 <section class="mds">
   <div>
     <!-- #region line -->
-    <mx-chart class="h-240 sm:h-320" type="line" :data.prop="lineData" />
+    <mx-chart type="line" :data.prop="lineData" />
     <!-- #endregion line -->
   </div>
   <div class="my-40">
     <strong class="block mb-20">Sparkline</strong>
     <!-- #region sparkline -->
-    <mx-chart class="w-128 h-48" type="line" :data.prop="lineData" :options.prop="sparklineOptions" />
+    <mx-chart width="128" height="48" type="line" :data.prop="lineData" :options.prop="sparklineOptions" />
     <!-- #endregion sparkline -->
   </div>
 </section>
@@ -27,7 +32,7 @@ The `mx-chart` component provides chart generation via Chart.js.
 
 <section class="mds">
   <!-- #region bar -->
-  <mx-chart class="h-320" type="bar" :data.prop="barData" />
+  <mx-chart type="bar" :data.prop="barData" />
   <!-- #endregion bar -->
 </section>
 
@@ -37,10 +42,12 @@ The `mx-chart` component provides chart generation via Chart.js.
 ## Pie and doughnut charts
 
 <section class="mds">
-  <!-- #region pie -->
-  <mx-chart class="h-320" type="pie" :data.prop="pieData" />
-  <mx-chart class="h-128" type="doughnut" :data.prop="pieData" />
-  <!-- #endregion -->
+  <div class="grid grid-cols-1 lg:grid-cols-2 my-40">
+    <!-- #region pie -->
+    <mx-chart width="320" type="pie" :data.prop="pieData" />
+    <mx-chart width="320" type="doughnut" :data.prop="pieData" />
+    <!-- #endregion -->
+  </div>
 </section>
 
 <script>
@@ -54,25 +61,18 @@ export default {
           {
             label: 'Example data',
             data: [435, 321, 532, 801, 1231, 1098, 732, 321, 451, 482, 513, 397],
-            fill: true,
+            borderColor: '#d93b65'
           },
         ]
       },
       // #endregion line-data
       // #region sparkline-options
       sparklineOptions: {
-        responsive: false,
-        legend: {
-          display: false,
-        },
+        maintainAspectRactio: false,
         elements: {
           point: {
             radius: 0
           },
-          line: {
-            borderWidth: 2,
-            borderColor: "#6a9"
-          }
         },
         scales: {
           x: {

--- a/vuepress/components/charts.md
+++ b/vuepress/components/charts.md
@@ -12,9 +12,10 @@ set the `maintainAspectRatio` option to `false` if necessary when setting an exp
 <section class="mds">
   <div>
     <!-- #region line -->
-    <mx-chart type="line" :data.prop="lineData" />
+    <mx-chart ref="lineChart" type="line" :data.prop="lineData" />
     <!-- #endregion line -->
   </div>
+  <mx-button btn-type="outlined" class="mt-20" @click="randomizeLineData">Randomize</mx-button>
   <div class="my-40">
     <strong class="block mb-20">Sparkline</strong>
     <!-- #region sparkline -->
@@ -76,6 +77,12 @@ dataset individually.
 | `options` | --        | See the [Chart.js documentation](https://www.chartjs.org/docs/3.6.2/).                                    | `ChartJsOptions`                                                                            | `undefined` |
 | `type`    | `type`    | The type of chart to render. For mixed charts, set the `type` in the dataset instead.                     | `"bar" \| "bubble" \| "doughnut" \| "line" \| "pie" \| "polarArea" \| "radar" \| "scatter"` | `undefined` |
 | `width`   | `width`   | Explicit width in pixels                                                                                  | `number`                                                                                    | `undefined` |
+
+### Methods
+
+#### `update() => Promise<void>`
+
+Force the chart to rerender.
 
 <script>
 export default {
@@ -174,6 +181,18 @@ export default {
         }]
       }
       // #endregion mixed-data
+    }
+  },
+  methods: {
+    randomizeLineData() {
+      const randomDataPoints = Array.from({length: 12}, () => (Math.floor(Math.random() * 700) + 300))
+      this.lineData = {
+        ...this.lineData,
+        datasets: [{
+          ...this.lineData.datasets[0],
+          data: randomDataPoints
+        }]
+      }
     }
   }
 }

--- a/vuepress/components/charts.md
+++ b/vuepress/components/charts.md
@@ -95,7 +95,7 @@ export default {
       // #endregion line-data
       // #region sparkline-options
       sparklineOptions: {
-        maintainAspectRactio: false,
+        maintainAspectRatio: false,
         elements: {
           point: {
             radius: 0


### PR DESCRIPTION
This adds an `mx-chart` component that serves as a wrapper for [Chart.js](https://www.chartjs.org/).  I left it very unopinionated for now.  We can always bake in some default options/colors if we want as we flesh those out.

![image](https://user-images.githubusercontent.com/3342530/145875077-a2e0ead4-bd8c-4fef-9268-6e774895fc4c.png)
