### PR TITLE
ENG-140024 - Dashboard Grid

### DIFF
--- a/vuepress/examples/grid.md
+++ b/vuepress/examples/grid.md
@@ -79,7 +79,8 @@ viewport width, as does the grid gap and padding around the grid.
     <mx-page-header pattern class="shadow-2">Dashboard</mx-page-header>
     <div class="p-24 md:p-40 xl:p-72">
       <div class="grid grid-cols-1 gap-16 md:grid-cols-2 md:gap-24 2xl:grid-cols-3 2xl:gap-40">
-        <div class="elevation8 min-w-full p-24" v-for="n in 5" :key="'chart-' + n">
+        <div class="shadow-8 rounded-3xl min-w-full px-24 pb-24 bg-white" v-for="n in 5" :key="'chart-' + n">
+          <h5 class="emphasis">Chart</h5>
           <mx-chart type="line" :data.prop="chartData" :options.prop="chartOptions" />
         </div>
       </div>

--- a/vuepress/examples/grid.md
+++ b/vuepress/examples/grid.md
@@ -2,150 +2,125 @@
 
 Example of how the grid system works. The examples use rows, but they coould just as easily be interchanged or mixed with `.grid-rows-{n}`. For more information on rows and columns, visit [the grid definition](/css-documentation/grid/grid-template-columns.html).
 
-<div class="mds">
-  <div class="container">
-    <h4 class="my-10">Non-Responsive Grid</h4>
-    <div class="grid grid-flow-row grid-cols-3 gap-4 text-center">
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        1
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        2
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        3
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        4
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        5
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        6
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        7
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        8
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        9
-      </div>
-    </div>
+## Non-Responsive Grid
+
+<section class="mds">
+  <!-- #region non-responsive -->
+  <div class="grid grid-flow-row grid-cols-3 gap-4 text-center mt-20">
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">1</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">2</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">3</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">4</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">5</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">6</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">7</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">8</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">9</div>
   </div>
-</div>
+  <!-- #endregion non-responsive -->
+</section>
 
 Below is the code example of the above non-responsive grid above.
 
-```html
-<div class="grid grid-flow-row grid-cols-3 gap-4 text-center">
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">1</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">2</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">3</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">4</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">5</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">6</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">7</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">8</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">9</div>
-</div>
-```
+<<< @/vuepress/examples/grid.md#non-responsive
 
-<div class="mds">
-  <div class="container">
-    <h4 class="my-10">Responsive Grid</h4>
-    <div
-      class="grid grid-flow-row grid-cols-1 gap-4 text-center sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 2xl:grid-cols-12"
-    >
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        1
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        2
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        3
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        4
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        5
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        6
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        7
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        8
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        9
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        10
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        11
-      </div>
-      <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">
-        12
-      </div>
-    </div>
+## Responsive Grid
+
+<section class="mds">
+  <!-- #region responsive -->
+  <div
+    class="grid grid-flow-row grid-cols-1 gap-4 text-center sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 mt-20"
+  >
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">1</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">2</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">3</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">4</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">5</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">6</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">7</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">8</div>
+    <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">9</div>
   </div>
-</div>
+  <!-- #endregion responsive -->
+</section>
 
 Below is the code example of a responsive grid system. The grid system works in a "mobile first" paradigm. This means that the initial defenition is the base behavior for the grid. In this instance that base bahavior is `grid-cols-1` or one column grid by default which will work on a phone. From there, you will define the column count using the responsive prefix of `sm:`, `md:`, `lg:`, `xl:` and `2xl` respectivly. This example goes from 1 column to 6 depending on the screen size.
 
-```html
-<div
-  class="grid grid-flow-row grid-cols-1 gap-4 text-center sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
->
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">1</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">2</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">3</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">4</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">5</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">6</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">7</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">8</div>
-  <div class="rounded py-4 text-center bg-primary-inverted text-primary-inverted">9</div>
-</div>
-```
+<<< @/vuepress/examples/grid.md#responsive
 
-### Example of a 2 column grid system with responsive
+### Example of a 2-column responsive grid system
 
-<div class="mds">
-  <div class="mt-56 grid grid-cols-1 gap-0 sm:grid-cols-5 sm:gap-56">
-    <div class="col-span-2 py-56 border-b-2 mb-56 text-center border-primary-bg-dark sm:border-2 sm:p-56 sm:rounded">
-      Something Here
+<section class="mds">
+  <div class="mt-40">
+    <!-- #region two-column -->
+    <div class="grid grid-cols-1 gap-0 sm:grid-cols-5 sm:gap-56">
+      <div class="col-span-2 border-b-2 mb-20 text-center border-primary-bg-dark bg-white sm:border-2 sm:rounded">
+        <img src="https://picsum.photos/320" class="w-full h-full object-cover">
+      </div>
+      <div class="col-span-3">
+        <h2 class="mt-0">Another Thing</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. </p>
+      </div>
     </div>
-    <div class="col-span-3">
-      <h2 class="mt-2">Another Thing</h2>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. </p>
-    </div>
+    <!-- #endregion two-column -->
   </div>
-</div>
+</section>
 
-```html
-<div class="mds">
-  <div class="mt-56 grid grid-cols-1 gap-0 sm:grid-cols-5 sm:gap-56">
-    <div class="col-span-2 py-56 border-b-2 mb-56 text-center border-primary-bg-dark sm:border-2 sm:p-56 sm:rounded">
-      Something Here
+<<< @/vuepress/examples/grid.md#two-column
+
+### Dashboard Grid Example
+
+This is an example of a full page layout for a dashboard. The number of columns increases with the
+viewport width, as does the grid gap and padding around the grid.
+
+<section class="mds full-width">
+  <div class="mt-40 shadow-24 w-screen">
+    <!-- #region dashboard-grid -->
+    <mx-page-header pattern class="shadow-2">Dashboard</mx-page-header>
+    <div class="p-24 md:p-40 xl:p-72">
+      <div class="grid grid-cols-1 gap-16 md:grid-cols-2 md:gap-24 2xl:grid-cols-3 2xl:gap-40">
+        <div class="elevation8 min-w-full p-24" v-for="n in 5" :key="'chart-' + n">
+          <mx-chart type="line" :data.prop="chartData" :options.prop="chartOptions" />
+        </div>
+      </div>
     </div>
-    <div class="col-span-3">
-      <h2 class="mt-2">Another Thing</h2>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante
-        dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce
-        nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti
-        sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
-      </p>
-    </div>
+    <!-- #endregion dashboard-grid -->
   </div>
-</div>
-```
+</section>
+
+<<< @/vuepress/examples/grid.md#dashboard-grid
+
+<script>
+export default {
+  data() {
+    return {
+      chartData: {
+        labels: ['May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+        datasets: [
+          {
+            label: 'Example data',
+            data: [340, 930, 732, 321, 451, 482, 513, 397],
+            borderColor: '#0457af'
+          },
+        ]
+      },
+      chartOptions: {
+        plugins: {
+          legend: {
+            display: false
+          }
+        }
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+div.theme-default-content:not(.custom) {
+    max-width: 100%;
+}
+div.theme-default-content:not(.custom) > *:not(.full-width) {
+    max-width: 920px;
+}
+</style>

--- a/vuepress/examples/grid.md
+++ b/vuepress/examples/grid.md
@@ -74,7 +74,7 @@ This is an example of a full page layout for a dashboard. The number of columns 
 viewport width, as does the grid gap and padding around the grid.
 
 <section class="mds full-width">
-  <div class="mt-40 shadow-24 w-screen">
+  <div class="my-40 shadow-24 w-screen">
     <!-- #region dashboard-grid -->
     <mx-page-header pattern class="shadow-2">Dashboard</mx-page-header>
     <div class="p-24 md:p-40 xl:p-72">

--- a/vuepress/examples/grid.md
+++ b/vuepress/examples/grid.md
@@ -79,7 +79,7 @@ viewport width, as does the grid gap and padding around the grid.
     <mx-page-header pattern class="shadow-2">Dashboard</mx-page-header>
     <div class="p-24 md:p-40 xl:p-72">
       <div class="grid grid-cols-1 gap-16 md:grid-cols-2 md:gap-24 2xl:grid-cols-3 2xl:gap-40">
-        <div class="shadow-8 rounded-3xl min-w-full px-24 pb-24 bg-white" v-for="n in 5" :key="'chart-' + n">
+        <div class="shadow-8 rounded-3xl px-24 pb-24 bg-white" v-for="n in 5" :key="'chart-' + n">
           <h5 class="emphasis">Chart</h5>
           <mx-chart type="line" :data.prop="chartData" :options.prop="chartOptions" />
         </div>


### PR DESCRIPTION
This adds the [Dashboard Grid example](https://www.figma.com/file/b36oTkOP6vI6uzLnc7Zd3T/Design-System-(Shirley)?node-id=22817%3A102452) from Figma to the responsive grid examples page.

I also updated the other examples on the page to use the vuepress region code snippet magic.

![image](https://user-images.githubusercontent.com/3342530/146207045-0222252d-100c-4589-a8e1-427956d7340b.png)
