### PR TITLE
ENG-140616 - Set page header slotted button `xl` prop automatically

### DIFF
--- a/src/components/mx-page-header/mx-page-header.tsx
+++ b/src/components/mx-page-header/mx-page-header.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Element, State, Method } from '@stencil/core';
+import { Component, Host, h, Prop, Element, State, Method, Watch } from '@stencil/core';
 import { minWidthSync, MinWidths } from '../../utils/minWidthSync';
 import { ResizeObserver } from '@juggle/resize-observer';
 import { IMxButtonProps } from '../mx-button/mx-button';
@@ -49,9 +49,16 @@ export class MxPageHeader {
     requestAnimationFrame(this.updateRenderTertiaryButtonAsMenu.bind(this));
   }
 
+  @Watch('minWidths')
+  updateSlottedButtonSize() {
+    const slottedButtons = this.element.querySelectorAll('[slot="buttons"] > mx-button');
+    slottedButtons.forEach((button: HTMLMxButtonElement) => (button.xl = this.minWidths.lg));
+  }
+
   componentWillLoad() {
     this.hasTabs = !!this.element.querySelector('[slot="tabs"]');
     this.hasModalHeaderCenter = !!this.element.querySelector('[slot="modal-header-center"]');
+    this.updateSlottedButtonSize();
   }
 
   connectedCallback() {

--- a/src/tailwind/mx-page-header/index.scss
+++ b/src/tailwind/mx-page-header/index.scss
@@ -3,6 +3,6 @@
   color: var(--mds-text-page-header);
 
   [slot='buttons'] {
-    @apply flex space-x-8 md:space-x-24 md:justify-end md:flex-row-reverse md:space-x-reverse items-center;
+    @apply py-1 flex space-x-8 md:space-x-24 md:justify-end md:flex-row-reverse md:space-x-reverse items-center max-w-full;
   }
 }

--- a/src/tailwind/mx-page-header/index.scss
+++ b/src/tailwind/mx-page-header/index.scss
@@ -1,4 +1,8 @@
 .mx-page-header {
   background-color: var(--mds-bg-page-header);
   color: var(--mds-text-page-header);
+
+  [slot='buttons'] {
+    @apply flex space-x-8 md:space-x-24 md:justify-end md:flex-row-reverse md:space-x-reverse items-center;
+  }
 }


### PR DESCRIPTION
This change makes it so `mx-page-header` will automatically set the `xl` prop for slotted buttons based on the viewport width.  Buttons rendered via the `buttons` prop already have this behavior, so it makes sense to extend it to the slotted buttons, especially since this behavior would be a pain to implement in the host app.

I've also added some additional styling for the `[slot='buttons']` container so the button order will reverse on mobile (just like the buttons rendered via the `buttons` prop), and the button spacing should also be consistent now.

Corresponding PR in nucleus: https://github.com/moxiworks/nucleus/pull/70