### PR TITLE
ENG-140761 - Fix page header and date picker exceptions

### DIFF
--- a/src/components/mx-date-picker/mx-date-picker.tsx
+++ b/src/components/mx-date-picker/mx-date-picker.tsx
@@ -72,6 +72,7 @@ export class MxDatePicker {
   componentWillRender = propagateDataAttributes;
 
   componentDidLoad() {
+    if (!this.inputEl) return;
     this.isDateInputSupported = this.inputEl.type === 'date';
     this.datepicker = datepicker(this.inputEl, {
       alwaysShow: true,
@@ -245,7 +246,6 @@ export class MxDatePicker {
             id={this.inputId || this.uuid}
             name={this.name}
             type="date"
-            required
             onBlur={this.onBlur.bind(this)}
             onClick={e => e.preventDefault() /* Prevent browser's native calender */}
             onKeyDown={this.onKeyDown.bind(this)}

--- a/src/components/mx-page-header/mx-page-header.tsx
+++ b/src/components/mx-page-header/mx-page-header.tsx
@@ -65,7 +65,7 @@ export class MxPageHeader {
 
   disconnectedCallback() {
     minWidthSync.unsubscribeComponent(this);
-    this.resizeObserver.disconnect();
+    this.resetResizeObserver && this.resizeObserver.disconnect();
   }
 
   updateRenderTertiaryButtonAsMenu() {

--- a/src/components/mx-page-header/mx-page-header.tsx
+++ b/src/components/mx-page-header/mx-page-header.tsx
@@ -65,7 +65,6 @@ export class MxPageHeader {
 
   disconnectedCallback() {
     minWidthSync.unsubscribeComponent(this);
-    this.resetResizeObserver && this.resizeObserver.disconnect();
   }
 
   updateRenderTertiaryButtonAsMenu() {

--- a/src/components/mx-time-picker/mx-time-picker.tsx
+++ b/src/components/mx-time-picker/mx-time-picker.tsx
@@ -203,7 +203,6 @@ export class MxTimePicker {
             tabindex="0"
             type="time"
             disabled={this.disabled}
-            required
             {...this.dataAttributes}
           />
           {this.label && this.floatLabel && labelJsx}


### PR DESCRIPTION
Exception 1: Disconnecting the ResizeObserver isn't necessary since the only observed element is being removed, so I can just kill this line that is causing exceptions.

Exception 2: I couldn't reproduce, but the exception is from the `datepicker()` call, and the only node we're passing in is `this.inputEl`, so I'm fairly certain that adding a check for `inputEl` before calling `datepicker()` will prevent this.  Probably a timing thing when switching views.

I'm also removing the `required` attributes from the pickers in this PR.  This means Firefox will show clear buttons, but it's a necessary trade-off for functionality.

[ENG-140761](https://moxiworks.atlassian.net/browse/ENG-140761)