### PR TITLE
ENG-140807 - Add `doNotDrag` prop to `mx-table-row`

### DIFF
--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -31,6 +31,8 @@ export class MxTableRow {
   @Prop() actions: ITableRowAction[] = [];
   /** Do not collapse this row if the parent row's `collapseNestedRows` prop is set to `true`. */
   @Prop({ reflect: true }) doNotCollapse: boolean = false;
+  /** Do not allow dragging of this row even if the parent table's `draggableRows` prop is set to `true`. */
+  @Prop() doNotDrag: boolean = false;
   /** This row's index in the `HTMLMxTableElement.rows` array.  This is set internally by the table component. */
   @Prop() rowIndex: number;
   @Prop({ mutable: true }) checked: boolean = false;
@@ -104,7 +106,7 @@ export class MxTableRow {
     // default slot.
     const table = this.element.closest('mx-table') as HTMLMxTableElement;
     this.checkable = table && table.checkable;
-    this.isDraggable = table && table.draggableRows;
+    this.isDraggable = table && table.draggableRows && !this.doNotDrag;
     this.columnCount = (table && table.columns.length) + (this.actions.length ? 1 : 0);
     if (this.checkable && this.rowId == null)
       throw new Error('Checkable rows require either a getRowId prop on the table, or a rowId on the row!');

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -526,7 +526,7 @@ The example below combines nested rows with the `draggableRows` prop. For the sa
             <mx-table-cell>-</mx-table-cell>
             <mx-table-cell>-</mx-table-cell>
             <mx-table-cell>$5.90</mx-table-cell>
-            <mx-table-row row-id="5">
+            <mx-table-row row-id="5" do-not-drag>
               <mx-table-cell>English Cucumber</mx-table-cell>
               <mx-table-cell>$2.59</mx-table-cell>
               <mx-table-cell>10</mx-table-cell>
@@ -804,6 +804,7 @@ The `ITableColumn` interface describes the objects passed to the `columns` prop.
 | `checked`            | `checked`              |                                                                                                                       | `boolean`           | `false`     |
 | `collapseNestedRows` | `collapse-nested-rows` | Toggles the visibility of all nested rows (except those set to `doNotCollapse`)                                       | `boolean`           | `false`     |
 | `doNotCollapse`      | `do-not-collapse`      | Do not collapse this row if the parent row's `collapseNestedRows` prop is set to `true`.                              | `boolean`           | `false`     |
+| `doNotDrag`          | `do-not-drag`          | Do not allow dragging of this row even if the parent table's `draggableRows` prop is set to `true`.                   | `boolean`           | `false`     |
 | `rowId`              | `row-id`               | This is required for checkable rows in order to persist the checked state through sorting and pagination.             | `string`            | `undefined` |
 | `rowIndex`           | `row-index`            | This row's index in the `HTMLMxTableElement.rows` array. This is set internally by the table component.               | `number`            | `undefined` |
 | `subheader`          | `subheader`            | Style the row as a subheader.                                                                                         | `boolean`           | `false`     |


### PR DESCRIPTION
This will be used to remove the drag handle from the page variant rows in nucleus.