### PR TITLE
ENG-140813 - Force update rows when switching exposed column

### DIFF
--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -1,4 +1,17 @@
-import { Component, Host, h, Prop, Element, Event, EventEmitter, Watch, Listen, State, Method } from '@stencil/core';
+import {
+  Component,
+  Host,
+  h,
+  Prop,
+  Element,
+  Event,
+  EventEmitter,
+  Watch,
+  Listen,
+  State,
+  Method,
+  forceUpdate,
+} from '@stencil/core';
 import { minWidthSync, MinWidths } from '../../utils/minWidthSync';
 import { capitalize, getCursorCoords, getPageRect, isDateObject } from '../../utils/utils';
 import { IMxMenuItemProps } from '../mx-menu-item/mx-menu-item';
@@ -658,11 +671,15 @@ export class MxTable {
     this.mxSortChange.emit({ sortBy: this.sortBy, sortAscending: this.sortAscending });
   }
 
-  changeExposedColumnIndex(delta: number) {
+  async changeExposedColumnIndex(delta: number) {
     if (this.isPreviousColumnDisabled && delta === -1) return;
     if (this.isNextColumnDisabled && delta === 1) return;
     const navigableColumnIndex = this.navigableColumnIndexes.indexOf(this.exposedMobileColumnIndex);
     this.exposedMobileColumnIndex = this.navigableColumnIndexes[navigableColumnIndex + delta];
+    await new Promise(requestAnimationFrame);
+    const rows = this.element.querySelectorAll('mx-table-row');
+    // Force update rows since the collapsed height may have changed.
+    rows.forEach(forceUpdate);
   }
 
   onMxPageChange(e: { detail: PageChangeEventDetail }) {


### PR DESCRIPTION
Collapsed table rows on mobile use `max-height` to achieve the collapsed effect.  However, that `max-height` was not being updated when switching the exposed column, which meant taller contents would get clipped.

This change introduces a `forceUpdate` call on each row whenever the exposed column is switched.

Before:
![Kapture 2021-12-21 at 11 25 39](https://user-images.githubusercontent.com/3342530/146964383-186e8c4b-a656-47f9-be6f-fe2cb6e3d485.gif)



After:

![Kapture 2021-12-21 at 11 19 28](https://user-images.githubusercontent.com/3342530/146964122-6dae9a70-9b39-4215-926a-38470d96e425.gif)
