### PR TITLE
ENG-140815: Only apply `.last-row` class to visible rows

### DIFF
--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -398,13 +398,7 @@ export class MxTable {
     this.showOperationsBar = !!this.getMultiRowActions || this.hasFilter || this.hasSearch;
     this.hasActionsColumnFromSlot =
       this.hasDefaultSlot && this.getTableRows().some(row => row.actions && row.actions.length);
-    const rows = this.getTableRows();
-    if (!this.paginate) {
-      rows.forEach((row, i) => {
-        const addOrRemove = i === rows.length - 1 ? 'add' : 'remove';
-        row.classList[addOrRemove]('last-row');
-      });
-    }
+    this.setLastRowClass();
     requestAnimationFrame(this.setCellProps.bind(this));
   }
 
@@ -669,6 +663,15 @@ export class MxTable {
     if (this.serverPaginate) return;
     this.page = e.detail.page;
     this.rowsPerPage = e.detail.rowsPerPage;
+  }
+
+  setLastRowClass() {
+    if (this.paginate) return;
+    const rows = this.getTableRows().filter(row => row.getAttribute('aria-hidden') !== 'true');
+    rows.forEach((row, i) => {
+      const addOrRemove = i === rows.length - 1 ? 'add' : 'remove';
+      row.classList[addOrRemove]('last-row');
+    });
   }
 
   render() {


### PR DESCRIPTION
This fixes the bottom `border-radius` of the table when the last row is a collapsed, nested row.  I noticed this in nucleus when the last row in the Pages list was a variant.  I also moved this last-row stuff to a separate method.

Before (see the bottom non-rounded corners):

![image](https://user-images.githubusercontent.com/3342530/146970222-aa91e3f0-04e3-4ca2-99f6-9ce4a0906b50.png)



After:

![image](https://user-images.githubusercontent.com/3342530/146970066-9c9780aa-b511-48f5-9866-ff0ac616f31e.png)
