### PR TITLE
ENG-140937 - Remove `mds-` prefix from portal class

### DIFF
--- a/src/utils/portal.ts
+++ b/src/utils/portal.ts
@@ -4,10 +4,10 @@ export function moveToPortal(overlayEl) {
 }
 
 function getPortal() {
-  let portal = document.querySelector('.mds-portal') as HTMLElement;
+  let portal = document.querySelector('.mds.portal') as HTMLElement;
   if (!portal) {
     portal = document.createElement('div');
-    portal.classList.add('mds', 'mds-portal');
+    portal.classList.add('mds', 'portal');
     portal.style.position = 'relative';
     portal.style.zIndex = '9999';
     document.body.appendChild(portal);

--- a/src/utils/test/portal.spec.ts
+++ b/src/utils/test/portal.spec.ts
@@ -3,17 +3,17 @@ import { moveToPortal } from '../portal';
 describe('moveToPortal', () => {
   it('creates a portal element', () => {
     moveToPortal(document.createElement('div'));
-    expect(document.querySelector('.mds-portal')).not.toBeNull();
+    expect(document.querySelector('.mds.portal')).not.toBeNull();
   });
   it('only creates one portal if called more than once', () => {
     moveToPortal(document.createElement('div'));
     moveToPortal(document.createElement('div'));
-    expect(document.querySelectorAll('.mds-portal').length).toBe(1);
+    expect(document.querySelectorAll('.mds.portal').length).toBe(1);
   });
   it('moves the passed element inside the portal', () => {
     const div = document.createElement('div');
     document.body.appendChild(div);
     moveToPortal(div);
-    expect(div.parentElement.classList.contains('mds-portal'));
+    expect(div.parentElement.classList.contains('portal'));
   });
 });


### PR DESCRIPTION
This change prevents the portal from being styled as an icon, which was causing a small black square to appear.

![image](https://user-images.githubusercontent.com/3342530/147250884-39c55616-257f-4a19-bfec-5922f1f7d299.png)
