### PR TITLE
ENG-140938 - Add `.bg-error` and `.text-error` utility classes

### DIFF
--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -7,10 +7,12 @@
   --mds-bg-secondary: #00696b;
   --mds-bg-gray-inverted: #e8e8e8;
   --mds-bg-gray: #fafafa;
+  --mds-bg-error: #fbd6de;
 
   --mds-text-primary: #111827;
   --mds-text-primary-inverted: #fff;
   --mds-text-link: #0457af;
+  --mds-text-error: #ff0c3e;
 
   /* #region patterns */
   /* Patterns */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -89,10 +89,12 @@ const config = {
         'secondary-inverted': 'var(--mds-bg-secondary-inverted)',
         'gray': 'var(--mds-bg-gray)',
         'gray-inverted': 'var(--mds-bg-gray-inverted)',
+        'error': 'var(--mds-bg-error)',
       },
       textColor: {
         'primary': 'var(--mds-text-primary)',
         'primary-inverted': 'var(--mds-text-primary-inverted)',
+        'error': 'var(--mds-text-error)',
       },
       borderColor: {
         'primary': 'var(--mds-border-primary)',


### PR DESCRIPTION
Adding a couple utility classes around the error colors defined in the design system.  The `.text-error` class will be needed in nucleus for sure.

![image](https://user-images.githubusercontent.com/3342530/147252678-85777bb1-2a39-459c-b96f-df4ee1b45fb7.png)

