### PR TITLE
ENG-140950 - Add `uploadBtnType` prop to `mx-image-upload`

### DIFF
--- a/src/components/mx-image-upload/mx-image-upload.tsx
+++ b/src/components/mx-image-upload/mx-image-upload.tsx
@@ -1,4 +1,5 @@
 import { Component, Host, h, Prop, Element, State, Method, Watch } from '@stencil/core';
+import { BtnType } from '../mx-button/mx-button';
 
 @Component({
   tag: 'mx-image-upload',
@@ -18,6 +19,8 @@ export class MxImageUpload {
   @Prop() assetName = 'image';
   /** Sets the width and height to 80px and changes the icon. */
   @Prop() avatar = false;
+  /** The [`btnType` prop](/components/buttons.html) for the Upload button. */
+  @Prop() uploadBtnType: BtnType = 'contained';
   /** Sets the thumbnail sizing strategy relative to the container. */
   @Prop() thumbnailSize: 'cover' | 'stretch' | 'contain' | 'auto' = 'cover';
   /** The height of the dropzone / thumbnail container (e.g. "400px" or "50%"). */
@@ -241,7 +244,7 @@ export class MxImageUpload {
           <mx-button
             data-testid="upload-button"
             class="mt-16"
-            btnType={this.hasFile && !this.isUploading ? 'outlined' : 'contained'}
+            btnType={this.hasFile && !this.isUploading ? 'outlined' : this.uploadBtnType}
             onClick={this.onButtonClick.bind(this)}
             disabled={this.isUploading}
           >

--- a/src/components/mx-image-upload/test/mx-image-upload.spec.tsx
+++ b/src/components/mx-image-upload/test/mx-image-upload.spec.tsx
@@ -1,4 +1,5 @@
 import { newSpecPage } from '@stencil/core/testing';
+import { MxButton } from '../../mx-button/mx-button';
 import { MxImageUpload } from '../mx-image-upload';
 
 describe('mx-image-upload', () => {
@@ -9,7 +10,7 @@ describe('mx-image-upload', () => {
   let button: HTMLMxButtonElement;
   beforeEach(async () => {
     page = await newSpecPage({
-      components: [MxImageUpload],
+      components: [MxImageUpload, MxButton],
       html: `
       <mx-image-upload>
         <span slot="uploaded">File uploaded!</span>
@@ -19,7 +20,7 @@ describe('mx-image-upload', () => {
     root = page.root;
     input = root.querySelector('input[type="file"]');
     dropzoneWrapper = root.querySelector('[data-testid="dropzone-wrapper"]');
-    button = root.querySelector('[data-testid="upload-button"]');
+    button = root.querySelector('[data-testid="upload-button"]').closest('mx-button');
   });
 
   it('renders an input[type="file"]', async () => {
@@ -95,6 +96,12 @@ describe('mx-image-upload', () => {
     expect(input.getAttribute('name')).toBe('abc');
   });
 
+  it('sets the upload button btnType prop to the uploadBtnType prop value', async () => {
+    root.uploadBtnType = 'outlined';
+    await page.waitForChanges();
+    expect(button.btnType).toBe('outlined');
+  });
+
   it('hides the button if showButton is false', async () => {
     expect(button).not.toBeNull();
     root.showButton = false;
@@ -128,11 +135,10 @@ describe('mx-image-upload', () => {
 
   it('disables the button and shows a progress indicator if isUploading is true', async () => {
     expect(button.disabled).toBeFalsy();
-    expect(button.attributes.getNamedItem('disabled')).toBeNull();
     expect(root.querySelector('[data-testid="progress"]')).toBeNull();
     root.isUploading = true;
     await page.waitForChanges();
-    expect(button.attributes.getNamedItem('disabled')).not.toBeNull();
+    expect(button.disabled).toBe(true);
     expect(root.querySelector('[data-testid="progress"]')).not.toBeNull();
   });
 

--- a/vuepress/components/uploads.md
+++ b/vuepress/components/uploads.md
@@ -17,7 +17,7 @@ The component wraps an [`<input type="file">`](https://developer.mozilla.org/en-
         The <code>assetName</code> prop is set to "logo" in this example.
       </span>
     </mx-image-upload>
-    <mx-image-upload show-dropzone-text="false" upload-button-label="Attach" @input="onInput" />
+    <mx-image-upload show-dropzone-text="false" upload-btn-type="outlined" upload-button-label="Attach" @input="onInput" />
     <mx-image-upload accept-pdf accept-image="false" icon="ph-file-arrow-up" @input="onInput">
       <span slot="dropzone-text" class="mt-8">
         Upload PDF &hellip;
@@ -125,26 +125,27 @@ Set the `showButton` prop to `false` if you want to leverage the `selectFile` an
 
 ### Image Upload Properties
 
-| Property            | Attribute             | Description                                                                                                              | Type                                       | Default     |
-| ------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ | ----------- |
-| `acceptImage`       | `accept-image`        | Set `acceptImage` to `false` and `acceptPdf` to `true` to only accept PDF files. Set both to `false` to accept any file. | `boolean`                                  | `true`      |
-| `acceptPdf`         | `accept-pdf`          | Set `acceptImage` to `false` and `acceptPdf` to `true` to only accept PDF files. Set both to `false` to accept any file. | `boolean`                                  | `false`     |
-| `assetName`         | `asset-name`          | Replaces the word "image" in the default dropzone text (i.e. "No image to show").                                        | `string`                                   | `'image'`   |
-| `avatar`            | `avatar`              | Sets the width and height to 80px and changes the icon.                                                                  | `boolean`                                  | `false`     |
-| `height`            | `height`              | The height of the dropzone / thumbnail container (e.g. "400px" or "50%").                                                | `string`                                   | `undefined` |
-| `icon`              | `icon`                | The class name of the icon to use instead of the default icon.                                                           | `string`                                   | `undefined` |
-| `inputId`           | `input-id`            | The `id` attribute to apply to the input element.                                                                        | `string`                                   | `undefined` |
-| `isUploaded`        | `is-uploaded`         | Set to `true` to show the Remove button, thumbnail, and `uploaded` slot content.                                         | `boolean`                                  | `false`     |
-| `isUploading`       | `is-uploading`        | Set to `true` to disable the button and show the circular progress indicator.                                            | `boolean`                                  | `false`     |
-| `name`              | `name`                | The `name` attribute for the `input` element.                                                                            | `string`                                   | `undefined` |
-| `removeButtonLabel` | `remove-button-label` | The text to display on the Remove button                                                                                 | `string`                                   | `'Remove'`  |
-| `showButton`        | `show-button`         | Set to `false` to hide the default Upload/Remove button.                                                                 | `boolean`                                  | `true`      |
-| `showDropzoneText`  | `show-dropzone-text`  | Set to `false` to hide the dropzone text.                                                                                | `boolean`                                  | `true`      |
-| `showIcon`          | `show-icon`           | Set to `false` to hide the dropzone icon.                                                                                | `boolean`                                  | `true`      |
-| `thumbnailSize`     | `thumbnail-size`      | Sets the thumbnail sizing strategy relative to the container.                                                            | `"auto" | "contain" | "cover" | "stretch"` | `'cover'`   |
-| `thumbnailUrl`      | `thumbnail-url`       | The URL for the thumbnail of the currently selected image.                                                               | `string`                                   | `undefined` |
-| `uploadButtonLabel` | `upload-button-label` | The text to display on the Upload button                                                                                 | `string`                                   | `'Upload'`  |
-| `width`             | `width`               | The width of the dropzone / thumbnail container (e.g. "400px" or "50%").                                                 | `string`                                   | `undefined` |
+| Property            | Attribute             | Description                                                                                                              | Type                                              | Default       |
+| ------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- | ------------- |
+| `acceptImage`       | `accept-image`        | Set `acceptImage` to `false` and `acceptPdf` to `true` to only accept PDF files. Set both to `false` to accept any file. | `boolean`                                         | `true`        |
+| `acceptPdf`         | `accept-pdf`          | Set `acceptImage` to `false` and `acceptPdf` to `true` to only accept PDF files. Set both to `false` to accept any file. | `boolean`                                         | `false`       |
+| `assetName`         | `asset-name`          | Replaces the word "image" in the default dropzone text (i.e. "No image to show").                                        | `string`                                          | `'image'`     |
+| `avatar`            | `avatar`              | Sets the width and height to 80px and changes the icon.                                                                  | `boolean`                                         | `false`       |
+| `height`            | `height`              | The height of the dropzone / thumbnail container (e.g. "400px" or "50%").                                                | `string`                                          | `undefined`   |
+| `icon`              | `icon`                | The class name of the icon to use instead of the default icon.                                                           | `string`                                          | `undefined`   |
+| `inputId`           | `input-id`            | The `id` attribute to apply to the input element.                                                                        | `string`                                          | `undefined`   |
+| `isUploaded`        | `is-uploaded`         | Set to `true` to show the Remove button, thumbnail, and `uploaded` slot content.                                         | `boolean`                                         | `false`       |
+| `isUploading`       | `is-uploading`        | Set to `true` to disable the button and show the circular progress indicator.                                            | `boolean`                                         | `false`       |
+| `name`              | `name`                | The `name` attribute for the `input` element.                                                                            | `string`                                          | `undefined`   |
+| `removeButtonLabel` | `remove-button-label` | The text to display on the Remove button                                                                                 | `string`                                          | `'Remove'`    |
+| `showButton`        | `show-button`         | Set to `false` to hide the default Upload/Remove button.                                                                 | `boolean`                                         | `true`        |
+| `showDropzoneText`  | `show-dropzone-text`  | Set to `false` to hide the dropzone text.                                                                                | `boolean`                                         | `true`        |
+| `showIcon`          | `show-icon`           | Set to `false` to hide the dropzone icon.                                                                                | `boolean`                                         | `true`        |
+| `thumbnailSize`     | `thumbnail-size`      | Sets the thumbnail sizing strategy relative to the container.                                                            | `"auto" | "contain" | "cover" | "stretch"`        | `'cover'`     |
+| `thumbnailUrl`      | `thumbnail-url`       | The URL for the thumbnail of the currently selected image.                                                               | `string`                                          | `undefined`   |
+| `uploadBtnType`     | `upload-btn-type`     | The [`btnType` prop](/components/buttons.html) for the Upload button.                                                    | `"action" \| "contained" \| "outlined" \| "text"` | `'contained'` |
+| `uploadButtonLabel` | `upload-button-label` | The text to display on the Upload button                                                                                 | `string`                                          | `'Upload'`    |
+| `width`             | `width`               | The width of the dropzone / thumbnail container (e.g. "400px" or "50%").                                                 | `string`                                          | `undefined`   |
 
 ### Image Upload Methods
 


### PR DESCRIPTION
In some designs, we don't want the `mx-image-upload`'s Upload button to be a "contained" type (which looks like a primary button), so this change adds an `uploadBtnType` prop for changing the `btnType` prop of that inner `mx-button`.