### PR TITLE
ENG-141043 - Hide collapsed nested rows when `minWidths` changes

### DIFF
--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -61,7 +61,15 @@ export class MxTableRow {
   @Event() mxDragKeyDown: EventEmitter<string>;
 
   @Watch('collapseNestedRows')
-  async onCollapseNestedRowsChange() {
+  onCollapseNestedRowsChange() {
+    this.toggleNestedRows();
+  }
+
+  @Watch('minWidths')
+  async onMinWidthsChange() {
+    if (!this.collapseNestedRows) return;
+    // Ensure that collapsed, nested rows are hidden after switching to/from mobile UI
+    await new Promise(requestAnimationFrame);
     this.toggleNestedRows();
   }
 


### PR DESCRIPTION
This fixes a bug where collapsed, nested rows are visible after switching to/from the mobile UI (resizing the window).