### PR TITLE
ENG-141045 - Replace mx-tab explicit width with horizontal padding

### DIFF
--- a/src/components/mx-tab/mx-tab.tsx
+++ b/src/components/mx-tab/mx-tab.tsx
@@ -43,7 +43,6 @@ export class MxTab implements IMxTabProps {
   get tabClass() {
     let str = 'mx-tab relative inline-flex items-center justify-center min-w-full';
     str += this.label && this.icon ? ' h-72' : ' h-48';
-    if (this.badge && this.label) str += ' wider';
     return str;
   }
 
@@ -64,7 +63,7 @@ export class MxTab implements IMxTabProps {
           type="button"
           aria-selected={this.selected ? 'true' : null}
           aria-label={this.label || this.ariaLabel}
-          class="relative overflow-hidden w-full h-full border border-transparent"
+          class="relative overflow-hidden w-full h-full border border-transparent px-44"
           onClick={this.onClick.bind(this)}
         >
           <div class="relative flex flex-col items-center justify-center space-y-6 pointer-events-none">

--- a/src/components/mx-tabs/mx-tabs.tsx
+++ b/src/components/mx-tabs/mx-tabs.tsx
@@ -36,14 +36,16 @@ export class MxTabs {
     const newSelectedTab = tabEls[tabIndex] as HTMLElement;
     if (!previousSelectedTab || !newSelectedTab) return;
     const distance = previousSelectedTab.offsetLeft - newSelectedTab.offsetLeft;
+    const scaleX = previousSelectedTab.offsetWidth / newSelectedTab.offsetWidth;
     const indicator = newSelectedTab.querySelector('.active-tab-indicator') as HTMLElement;
     if (!indicator) return;
     // Position clicked tab's indicator under the tab that is being deselected
-    indicator.style.transform = `translateX(${distance}px)`;
+    indicator.style.transform = `translateX(${distance}px) scale3d(${scaleX}, 1, 1)`;
+    indicator.style.transformOrigin = 'left';
     indicator.style.transition = `none`;
     // Transition the indicator back to the clicked tab
     setTimeout(() => {
-      indicator.style.transform = `translateX(0)`;
+      indicator.style.transform = `translateX(0) scale3d(1, 1, 1)`;
       indicator.style.transition = `transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)`;
     }, 0);
   }
@@ -74,7 +76,7 @@ export class MxTabs {
 
   get gridClass() {
     let str = this.fill ? 'grid' : 'inline-grid';
-    str += ' grid-flow-col auto-cols-fr';
+    str += ' grid-flow-col auto-cols-auto';
     return str;
   }
 

--- a/src/tailwind/mx-tab/index.scss
+++ b/src/tailwind/mx-tab/index.scss
@@ -11,7 +11,7 @@
       color: var(--mds-text-tab-selected);
     }
 
-    &:not([aria-selected='true'], :active) i {
+    &:not([aria-selected='true'], :active) i:not(.mx-badge i) {
       color: var(--mds-text-tab-icon);
       &.icon-only {
         color: var(--mds-text-tab-icon-only);

--- a/src/tailwind/mx-tab/index.scss
+++ b/src/tailwind/mx-tab/index.scss
@@ -1,10 +1,4 @@
 .mx-tab {
-  width: 7.5rem; /* 120px */
-
-  &.wider {
-    width: 8.313rem; /* 133px when there is both a badge and a label */
-  }
-
   .active-tab-indicator {
     background: var(--mds-bg-tab-indicator);
   }


### PR DESCRIPTION
The tabs in the design system originally looked like they had explicit widths in Figma (because the example labels were all the same width), but they actually should have horizontal padding and varying widths.  This should fix the tabs in nucleus being too tight.

I also noticed that the `--mds-text-tab-icon` color was being applied to the tab badge (because it is now an `<i>` element), so I fixed that as well.