### PR TITLE
ENG-141047 - Fix badge `isStandalone`

### DIFF
--- a/src/components/mx-badge/mx-badge.tsx
+++ b/src/components/mx-badge/mx-badge.tsx
@@ -5,7 +5,7 @@ import { Component, Host, h, Prop, Element } from '@stencil/core';
   shadow: false,
 })
 export class MxBadge {
-  childElement: HTMLElement;
+  isStandalone: boolean = true;
 
   @Element() private element: HTMLElement;
 
@@ -26,8 +26,8 @@ export class MxBadge {
   /** Anchor the badge to the left of the wrapped content */
   @Prop() left: boolean = false;
 
-  get isStandalone() {
-    return !this.element.firstElementChild;
+  componentWillLoad() {
+    this.isStandalone = !this.element.firstElementChild;
   }
 
   get isIconOnly() {


### PR DESCRIPTION
This fixes badges that were being positioned as if they were anchored to a slotted element even when there was no slotted element.  This bug showed up in nucleus for the New/Updated badge on the Product tile preview.

The technical nitty gritty: When there is no slotted element, then `this.element.firstElementChild` will be `null`, but _only during the first render cycle_.  In subsequent renders, the first element in the component template will then be detected as the first child element.  Because I originally implemented `isStandalone` as a getter, that meant `isStandalone` would return `true` once the component went through more than one render cycle.  So to fix the issue, I just have to set `isStandalone` only once during `componentWillLoad`.  This issue did not show up in the documentation examples because they only ever went through one render cycle.  Fun bug!

Also, I discovered an unused `childElement` property, so I killed that.