### PR TITLE
ENG-141053 - Add `labelClass` prop to `mx-switch`

### DIFF
--- a/src/components/mx-switch/mx-switch.tsx
+++ b/src/components/mx-switch/mx-switch.tsx
@@ -10,6 +10,7 @@ export class MxSwitch {
 
   @Prop() name: string = '';
   @Prop() value: string = '';
+  @Prop() labelClass: string = '';
   @Prop() labelName: string = '';
   @Prop({ mutable: true }) checked: boolean = false;
 
@@ -25,7 +26,12 @@ export class MxSwitch {
   render() {
     return (
       <Host class="mx-switch">
-        <label class="relative inline-flex flex-nowrap align-center items-center cursor-pointer text-4">
+        <label
+          class={[
+            'relative inline-flex flex-nowrap align-center items-center cursor-pointer text-4',
+            this.labelClass,
+          ].join(' ')}
+        >
           <input
             class="absolute h-0 w-0 opacity-0"
             role="switch"

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -76,12 +76,13 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
 
 ### Properties
 
-| Property    | Attribute    | Description | Type      | Default |
-| ----------- | ------------ | ----------- | --------- | ------- |
-| `checked`   | `checked`    |             | `boolean` | `false` |
-| `labelName` | `label-name` |             | `string`  | `''`    |
-| `name`      | `name`       |             | `string`  | `''`    |
-| `value`     | `value`      |             | `string`  | `''`    |
+| Property     | Attribute     | Description | Type      | Default |
+| ------------ | ------------- | ----------- | --------- | ------- |
+| `checked`    | `checked`     |             | `boolean` | `false` |
+| `labelClass` | `label-class` |             | `string`  | `''`    |
+| `labelName`  | `label-name`  |             | `string`  | `''`    |
+| `name`       | `name`        |             | `string`  | `''`    |
+| `value`      | `value`       |             | `string`  | `''`    |
 
 ## CSS Variables
 


### PR DESCRIPTION
This is needed in nucleus for the "Agreement Options" switch.  Plus. `mx-checkbox` has this prop, so it only makes sense for the switch to have it as well.

I will also update the rails view component.