### PR TITLE
Move explicit width to dropzone wrapper

### DIFF
--- a/src/components/mx-image-upload/mx-image-upload.tsx
+++ b/src/components/mx-image-upload/mx-image-upload.tsx
@@ -187,11 +187,11 @@ export class MxImageUpload {
     }
 
     return (
-      <Host class="mx-image-upload inline-block" style={{ width: this.dropzoneWidth }}>
+      <Host class="mx-image-upload inline-block">
         <div
           data-testid="dropzone-wrapper"
           class="dropzone-wrapper flex w-full items-center justify-center relative rounded-2xl text-3 overflow-hidden"
-          style={{ height: this.dropzoneHeight }}
+          style={{ height: this.dropzoneHeight, width: this.dropzoneWidth }}
         >
           <div class={this.dropzoneClass}>
             <div class="flex flex-col items-center justify-center w-full h-full">


### PR DESCRIPTION
Not sure how I missed this earlier, but this fix puts the dropzone width on the actual dropzone wrapper.  This allows the assistive text to be wider than the dropzone/thumbnail.

Before

![image](https://user-images.githubusercontent.com/3342530/148072817-138b8dc5-a67d-4233-b611-77b6201ee3d8.png)


After

![image](https://user-images.githubusercontent.com/3342530/148072792-4a0d4f7f-3c7a-4de2-ba71-cad81c9732ed.png)
