### PR TITLE
ENG-141095 - Fix row toggle always animating

### DIFF
--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -86,14 +86,8 @@ export class MxTableRow {
   async toggle(hideRow: boolean, skipTransition: boolean) {
     this.isHidden = hideRow;
     const children = await this.getChildren();
-    if (skipTransition) {
-      children.forEach(child => {
-        child.style.maxHeight = this.isHidden ? '0' : '';
-      });
-    } else {
-      const transition = this.isHidden ? collapse : expand;
-      await Promise.all(children.map(child => transition(child)));
-    }
+    const transition = this.isHidden ? collapse : expand;
+    await Promise.all(children.map(child => transition(child, skipTransition ? 0 : undefined)));
     children.forEach(child => (child.style.border = this.isHidden ? '0' : ''));
     this.element.setAttribute('aria-hidden', this.isHidden ? 'true' : 'false');
   }


### PR DESCRIPTION
This changes the `MxTableRow.toggle` method to just set the collapse/expand duration to `0` if `skipTransition` is set to `true`.

This should fix the nucleus page variant rows doing the collapse animation every time the pages admin list loads.