### PR TITLE
ENG-141185 - Fix Safari button appearance

### DIFF
--- a/src/components/mx-button/mx-button.tsx
+++ b/src/components/mx-button/mx-button.tsx
@@ -65,7 +65,7 @@ export class MxButton implements IMxButtonProps {
 
     // Common classes
     str +=
-      ' flex items-center justify-center relative overflow-hidden cursor-pointer disabled:cursor-auto hover:no-underline';
+      ' flex items-center justify-center relative overflow-hidden cursor-pointer appearance-none disabled:cursor-auto hover:no-underline';
 
     // Contained & Outlined Buttons
     if (['contained', 'outlined'].includes(this.btnType)) {
@@ -107,7 +107,7 @@ export class MxButton implements IMxButtonProps {
     );
 
     return (
-      <Host class={'mx-button' + (this.full ? ' flex' : ' inline-flex')}>
+      <Host class={'mx-button appearance-none' + (this.full ? ' flex' : ' inline-flex')}>
         {this.href ? (
           <a
             href={this.href}

--- a/src/components/mx-icon-button/mx-icon-button.tsx
+++ b/src/components/mx-icon-button/mx-icon-button.tsx
@@ -62,7 +62,7 @@ export class MxIconButton {
     );
 
     return (
-      <Host class="mx-icon-button inline-block">
+      <Host class="mx-icon-button inline-block appearance-none">
         <button
           type={this.type}
           formaction={this.formaction}


### PR DESCRIPTION
I partially fixed this before by adding `.appearance-none` to the `button` element inside `mx-icon-button`.

However, the tailwind reset rules apply `appearance: button` to `[type=button], [type=reset], [type=submit], button`.  This means the host elements for `mx-icon-button` and `mx-button` will get that styling if you explicitly set the `type` prop (i.e. `<mx-icon-button type="button">`).

None of the mds examples set the `type` explicitly, which is why this problem was only showing up in nucleus (and why I thought I had fixed it before).

Before:

![image](https://user-images.githubusercontent.com/3342530/148292251-a53e532e-3573-44aa-95a1-ca277d3ce072.png)


After:

![image](https://user-images.githubusercontent.com/3342530/148292161-4a953671-01bb-432c-9aa7-2b8d55d12749.png)
