### PR TITLE
Always show `mx-confirm-input` edit icon on mobile

### DIFF
--- a/src/components/mx-confirm-input/mx-confirm-input.tsx
+++ b/src/components/mx-confirm-input/mx-confirm-input.tsx
@@ -52,7 +52,8 @@ export class MxConfirmInput implements IMxInputProps {
       ];
     }
     const canEdit = this.value != null && this.value !== '' && !this.readonly && !this.disabled;
-    if (this.isHovered && canEdit) return 'mds-edit';
+    const canHover = window.matchMedia('(hover: hover)');
+    if ((this.isHovered || !canHover.matches) && canEdit) return 'mds-edit';
   }
 
   onCancel(e?: MouseEvent) {


### PR DESCRIPTION
On mobile devices (that cannot hover), there is no way to tell that an `mx-confirm-input` is editable, so we need to show the edit icon even if the element isn't hovered.

The [design for the Categories modal in nucleus](https://www.figma.com/file/ZQCgBp9weynQ7981oseA6s/ENG-134945-%7C-Apps-Admin-Page?node-id=196%3A145675) implies this behavior.

![image](https://user-images.githubusercontent.com/3342530/148429456-80e9b5bb-fbfd-464b-9032-abf0ea316c98.png)
