### PR TITLE
ENG-141230 - Stretch large modals to fill screen

### DIFF
--- a/src/components/mx-modal/mx-modal.tsx
+++ b/src/components/mx-modal/mx-modal.tsx
@@ -152,7 +152,7 @@ export class MxModal {
     else {
       str += ' pt-24 md:pt-0 md:items-center justify-center';
       if (this.minWidths.md) {
-        str += this.large ? ' modal-large flex-grow h-full' : ' modal-medium';
+        str += this.large ? ' modal-large' : ' modal-medium';
       }
     }
     return str;

--- a/src/components/mx-modal/mx-modal.tsx
+++ b/src/components/mx-modal/mx-modal.tsx
@@ -152,7 +152,7 @@ export class MxModal {
     else {
       str += ' pt-24 md:pt-0 md:items-center justify-center';
       if (this.minWidths.md) {
-        str += this.large ? ' modal-large' : ' modal-medium';
+        str += this.large ? ' modal-large flex-grow h-full' : ' modal-medium';
       }
     }
     return str;

--- a/src/tailwind/mx-modal/index.scss
+++ b/src/tailwind/mx-modal/index.scss
@@ -31,6 +31,7 @@
   }
 
   &.modal-large > .modal {
+    @apply flex-grow h-full;
     /* 40px margin around modal */
     max-width: calc(100vw - 5rem);
     max-height: calc(100vh - 5rem);


### PR DESCRIPTION
This fixes the `large` prop on `mx-modal` so that it always fills the screen (minus a 40px margin) regardless if the modal content is small.

