### PR TITLE
ENG-141233 - Automatically set `xl` for slotted footer buttons

### DIFF
--- a/src/components/mx-modal/mx-modal.tsx
+++ b/src/components/mx-modal/mx-modal.tsx
@@ -62,6 +62,12 @@ export class MxModal {
     this.isOpen ? this.openModal() : this.closeModal();
   }
 
+  @Watch('minWidths')
+  updateSlottedButtonSize() {
+    const slottedButtons = this.element.querySelectorAll('[slot*="footer-"] mx-button');
+    slottedButtons.forEach((button: HTMLMxButtonElement) => (button.xl = this.minWidths.lg));
+  }
+
   @Listen('keydown')
   onKeyDown(e: KeyboardEvent) {
     if (!this.isOpen) return;


### PR DESCRIPTION
Buttons in the modal footer should now automatically become `xl` on larger screens, even if they're passed in via the `footer-right` slot instead of the `buttons` prop.