### PR TITLE
ENG-141239 - Change Image Upload to `display: block`

### DIFF
--- a/src/components/mx-image-upload/mx-image-upload.tsx
+++ b/src/components/mx-image-upload/mx-image-upload.tsx
@@ -187,7 +187,7 @@ export class MxImageUpload {
     }
 
     return (
-      <Host class="mx-image-upload inline-block">
+      <Host class="mx-image-upload block">
         <div
           data-testid="dropzone-wrapper"
           class="dropzone-wrapper flex w-full items-center justify-center relative rounded-2xl text-3 overflow-hidden"


### PR DESCRIPTION
Changing `mx-image-upload` to `display: block` so that setting the dropzone `width` to a percentage works correctly even if the parent container is not a flexbox.


Before (`width` prop is set to 100%):

![image](https://user-images.githubusercontent.com/3342530/148453524-5e2bdc33-a320-44da-9606-887d425b5f44.png)

After:
![image](https://user-images.githubusercontent.com/3342530/148453494-e69ecf3e-dbee-4b50-b5d6-a3be5d33cccd.png)
