### PR TITLE
ENG-141282 - Add min-width to dropdown/select components

### DIFF
--- a/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
+++ b/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
@@ -86,7 +86,7 @@ export class MxDropdownMenu {
 
   render() {
     return (
-      <Host class="mx-dropdown-menu">
+      <Host class="mx-dropdown-menu block">
         <div ref={el => (this.dropdownWrapper = el)} class={this.dropdownWrapperClass}>
           <input
             aria-label={this.ariaLabel || this.label}

--- a/src/components/mx-select/mx-select.tsx
+++ b/src/components/mx-select/mx-select.tsx
@@ -118,7 +118,7 @@ export class MxSelect {
       </label>
     );
     return (
-      <Host class={'mx-select' + (this.disabled ? ' disabled' : '')}>
+      <Host class={'mx-select block' + (this.disabled ? ' disabled' : '')}>
         {this.label && !this.floatLabel && labelJsx}
 
         <div data-testid="select-wrapper" class={this.selectWrapperClass}>

--- a/src/tailwind/mx-dropdown-menu/index.scss
+++ b/src/tailwind/mx-dropdown-menu/index.scss
@@ -1,4 +1,5 @@
 .mx-dropdown-menu > .dropdown-wrapper {
+  min-width: 20.5rem;
   color: var(--mds-text-dropdown);
   background: var(--mds-bg-dropdown);
   border-color: var(--mds-border-dropdown);

--- a/src/tailwind/mx-select/index.scss
+++ b/src/tailwind/mx-select/index.scss
@@ -7,6 +7,7 @@
   }
 
   .mx-select-wrapper {
+    min-width: 20.5rem;
     color: var(--mds-text-select);
     background: var(--mds-bg-select);
     border-color: var(--mds-border-select);


### PR DESCRIPTION
Adding a 328px `min-width` to the `mx-dropdown-menu` and `mx-select` components.  This will ensure the components have a reasonable amount of width when they are not allowed to stretch otherwise.

Before:

![image](https://user-images.githubusercontent.com/3342530/148601144-5dc1b7bc-8cdb-49b5-a457-e8ad6b5b3423.png)


After:

![image](https://user-images.githubusercontent.com/3342530/148601090-d99265d9-6d72-4055-b732-6a94515bd951.png)
