### PR TITLE
ENG-141282 - Add `dropdownClass` and `selectClass` props

### DIFF
--- a/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
+++ b/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
@@ -16,6 +16,8 @@ export class MxDropdownMenu {
   /** Style as a filter dropdown with a "flat" border color */
   @Prop() flat: boolean = false;
   @Prop() label: string;
+  /** Additional classes for the dropdown wrapper (e.g. `min-w-0` to override the default `min-width`) */
+  @Prop() dropdownClass: string;
   /** The `id` attribute for the internal input element */
   @Prop() dropdownId: string;
   @Prop() name: string;
@@ -68,6 +70,7 @@ export class MxDropdownMenu {
     if (this.elevated) str += ' elevated shadow-1';
     if (this.flat) str += ' flat';
     str += this.isFocused ? ' focused border-2' : ' border';
+    if (this.dropdownClass) str += ' ' + this.dropdownClass;
     return str;
   }
 

--- a/src/components/mx-dropdown-menu/test/mx-dropdown-menu.spec.tsx
+++ b/src/components/mx-dropdown-menu/test/mx-dropdown-menu.spec.tsx
@@ -106,6 +106,12 @@ describe('mx-dropdown-menu', () => {
     expect(dropdownWrapper.getAttribute('class')).toContain('h-36');
   });
 
+  it('appends the dropdownClass value to the dropdown wrapper class list', async () => {
+    root.dropdownClass = 'test-class';
+    await page.waitForChanges();
+    expect(dropdownWrapper.classList.contains('test-class')).toBe(true);
+  });
+
   it('sets the mx-menu and mx-menu-item roles to "listbox" and "option"', async () => {
     expect(root.querySelector('mx-menu').getAttribute('role')).toBe('listbox');
     expect(Array.from(menuItems).every(m => m.children[0].getAttribute('role') === 'option')).toBe(true);

--- a/src/components/mx-select/mx-select.tsx
+++ b/src/components/mx-select/mx-select.tsx
@@ -22,6 +22,8 @@ export class MxSelect {
   @Prop() label: string;
   @Prop() floatLabel: boolean = false;
   @Prop() ariaLabel: string;
+  /** Additional classes for the select wrapper (e.g. `min-w-0` to override the default `min-width`) */
+  @Prop() selectClass: string;
   /** The `id` attribute for the select element */
   @Prop() selectId: string;
   @Prop() name: string;
@@ -76,10 +78,11 @@ export class MxSelect {
     str += this.error || this.isFocused ? ' border-2' : ' border';
     if (this.error) str += ' error';
     if (this.disabled) str += ' disabled';
+    if (this.selectClass) str += ' ' + this.selectClass;
     return str;
   }
 
-  get selectClass() {
+  get selectElClass() {
     let str =
       'absolute inset-0 w-full pl-16 overflow-hidden outline-none appearance-none bg-transparent cursor-pointer disabled:cursor-auto';
     if (this.isFocused) str += ' -m-1'; // prevent shifting due to border-width change
@@ -124,7 +127,7 @@ export class MxSelect {
         <div data-testid="select-wrapper" class={this.selectWrapperClass}>
           <select
             aria-label={this.label || this.ariaLabel}
-            class={this.selectClass}
+            class={this.selectElClass}
             disabled={this.disabled}
             id={this.selectId || this.uuid}
             name={this.name}

--- a/src/components/mx-select/test/mx-select.spec.tsx
+++ b/src/components/mx-select/test/mx-select.spec.tsx
@@ -110,6 +110,12 @@ describe('mx-select', () => {
     expect(selectWrapper.getAttribute('class')).toContain('flat');
   });
 
+  it('appends the dropdownClass value to the dropdown wrapper class list', async () => {
+    root.selectClass = 'test-class';
+    await page.waitForChanges();
+    expect(selectWrapper.classList.contains('test-class')).toBe(true);
+  });
+
   it('disables the select when the disabled prop is set', async () => {
     root.disabled = true;
     await page.waitForChanges();

--- a/src/tailwind/mx-dropdown-menu/index.scss
+++ b/src/tailwind/mx-dropdown-menu/index.scss
@@ -1,8 +1,11 @@
 .mx-dropdown-menu > .dropdown-wrapper {
-  min-width: 20.5rem;
   color: var(--mds-text-dropdown);
   background: var(--mds-bg-dropdown);
   border-color: var(--mds-border-dropdown);
+
+  &:not([class*='min-w-']) {
+    min-width: 20.5rem;
+  }
 
   &::placeholder {
     color: var(--mds-text-dropdown-label);

--- a/src/tailwind/mx-select/index.scss
+++ b/src/tailwind/mx-select/index.scss
@@ -7,10 +7,12 @@
   }
 
   .mx-select-wrapper {
-    min-width: 20.5rem;
     color: var(--mds-text-select);
     background: var(--mds-bg-select);
     border-color: var(--mds-border-select);
+    &:not([class*='min-w-']) {
+      min-width: 20.5rem;
+    }
     &.no-value {
       color: var(--mds-text-select-label);
     }

--- a/vuepress/components/dropdowns.md
+++ b/vuepress/components/dropdowns.md
@@ -153,17 +153,18 @@ The options in the menu are represented by [Menu Items](/components/menus.html).
 
 ### Dropdown Menu Properties
 
-| Property     | Attribute     | Description                                           | Type      | Default     |
-| ------------ | ------------- | ----------------------------------------------------- | --------- | ----------- |
-| `ariaLabel`  | `aria-label`  |                                                       | `string`  | `undefined` |
-| `dense`      | `dense`       |                                                       | `boolean` | `false`     |
-| `dropdownId` | `dropdown-id` | The `id` attribute for the internal input element     | `string`  | `undefined` |
-| `elevated`   | `elevated`    | Style as a filter dropdown with a 1dp elevation       | `boolean` | `false`     |
-| `flat`       | `flat`        | Style as a filter dropdown with a "flat" border color | `boolean` | `false`     |
-| `label`      | `label`       |                                                       | `string`  | `undefined` |
-| `name`       | `name`        |                                                       | `string`  | `undefined` |
-| `suffix`     | `suffix`      | Text shown to the left of the arrow                   | `string`  | `undefined` |
-| `value`      | `value`       |                                                       | `any`     | `undefined` |
+| Property        | Attribute        | Description                                                                                      | Type      | Default     |
+| --------------- | ---------------- | ------------------------------------------------------------------------------------------------ | --------- | ----------- |
+| `ariaLabel`     | `aria-label`     |                                                                                                  | `string`  | `undefined` |
+| `dense`         | `dense`          |                                                                                                  | `boolean` | `false`     |
+| `dropdownClass` | `dropdown-class` | Additional classes for the dropdown wrapper (e.g. `min-w-0` to override the default `min-width`) | `string`  | `undefined` |
+| `dropdownId`    | `dropdown-id`    | The `id` attribute for the internal input element                                                | `string`  | `undefined` |
+| `elevated`      | `elevated`       | Style as a filter dropdown with a 1dp elevation                                                  | `boolean` | `false`     |
+| `flat`          | `flat`           | Style as a filter dropdown with a "flat" border color                                            | `boolean` | `false`     |
+| `label`         | `label`          |                                                                                                  | `string`  | `undefined` |
+| `name`          | `name`           |                                                                                                  | `string`  | `undefined` |
+| `suffix`        | `suffix`         | Text shown to the left of the arrow                                                              | `string`  | `undefined` |
+| `value`         | `value`          |                                                                                                  | `any`     | `undefined` |
 
 ## Selects
 
@@ -418,22 +419,23 @@ Like the [Dropdown Menu](#dropdown-menus), the Select component also has `flat` 
 
 ### Select Properties
 
-| Property        | Attribute        | Description                               | Type      | Default     |
-| --------------- | ---------------- | ----------------------------------------- | --------- | ----------- |
-| `ariaLabel`     | `aria-label`     |                                           | `string`  | `undefined` |
-| `assistiveText` | `assistive-text` | Helpful text to show below the select     | `string`  | `undefined` |
-| `dense`         | `dense`          |                                           | `boolean` | `false`     |
-| `disabled`      | `disabled`       |                                           | `boolean` | `false`     |
-| `elevated`      | `elevated`       | Style with a 1dp elevation                | `boolean` | `false`     |
-| `error`         | `error`          |                                           | `boolean` | `false`     |
-| `flat`          | `flat`           | Style with a "flat" border color          | `boolean` | `false`     |
-| `floatLabel`    | `float-label`    |                                           | `boolean` | `false`     |
-| `label`         | `label`          |                                           | `string`  | `undefined` |
-| `labelClass`    | `label-class`    | Additional classes for the label          | `string`  | `''`        |
-| `name`          | `name`           |                                           | `string`  | `undefined` |
-| `selectId`      | `select-id`      | The `id` attribute for the select element | `string`  | `undefined` |
-| `suffix`        | `suffix`         | Text shown to the left of the arrow       | `string`  | `undefined` |
-| `value`         | `value`          |                                           | `any`     | `undefined` |
+| Property        | Attribute        | Description                                                                                    | Type      | Default     |
+| --------------- | ---------------- | ---------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `ariaLabel`     | `aria-label`     |                                                                                                | `string`  | `undefined` |
+| `assistiveText` | `assistive-text` | Helpful text to show below the select                                                          | `string`  | `undefined` |
+| `dense`         | `dense`          |                                                                                                | `boolean` | `false`     |
+| `disabled`      | `disabled`       |                                                                                                | `boolean` | `false`     |
+| `elevated`      | `elevated`       | Style with a 1dp elevation                                                                     | `boolean` | `false`     |
+| `error`         | `error`          |                                                                                                | `boolean` | `false`     |
+| `flat`          | `flat`           | Style with a "flat" border color                                                               | `boolean` | `false`     |
+| `floatLabel`    | `float-label`    |                                                                                                | `boolean` | `false`     |
+| `label`         | `label`          |                                                                                                | `string`  | `undefined` |
+| `labelClass`    | `label-class`    | Additional classes for the label                                                               | `string`  | `''`        |
+| `name`          | `name`           |                                                                                                | `string`  | `undefined` |
+| `selectClass`   | `select-class`   | Additional classes for the select wrapper (e.g. `min-w-0` to override the default `min-width`) | `string`  | `undefined` |
+| `selectId`      | `select-id`      | The `id` attribute for the select element                                                      | `string`  | `undefined` |
+| `suffix`        | `suffix`         | Text shown to the left of the arrow                                                            | `string`  | `undefined` |
+| `value`         | `value`          |                                                                                                | `any`     | `undefined` |
 
 ### CSS Variables
 


### PR DESCRIPTION
These props add additional classes to the inner wrapper elements.  These will be especially useful for overriding the `min-width` of those elements (see https://github.com/moxiworks/mds/pull/110 and https://github.com/moxiworks/nucleus/pull/112/commits/63e24bfc01c1eddf5530a6adaab4397198da1341).