### PR TITLE
ENG-141438 - Action buttons are now called Simple buttons

### DIFF
--- a/src/components/mx-button/mx-button.tsx
+++ b/src/components/mx-button/mx-button.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Prop, Element } from '@stencil/core';
 import ripple from '../../utils/ripple';
 import { propagateDataAttributes } from '../../utils/utils';
 
-export type BtnType = 'contained' | 'outlined' | 'action' | 'text';
+export type BtnType = 'contained' | 'outlined' | 'simple' | 'text' | 'action'; // 'action' is deprecated in favor of 'simple'
 export type ButtonTypeAttribute = 'button' | 'submit' | 'reset';
 
 export interface IMxButtonProps {
@@ -27,7 +27,7 @@ export class MxButton implements IMxButtonProps {
   anchorElem!: HTMLAnchorElement;
   dataAttributes = {};
 
-  @Prop() btnType: BtnType = 'contained';
+  @Prop({ mutable: true }) btnType: BtnType = 'contained';
   @Prop() type: ButtonTypeAttribute = 'button';
   @Prop() value: string;
   @Prop() formaction: string;
@@ -75,8 +75,8 @@ export class MxButton implements IMxButtonProps {
       else str += ' min-h-36 px-16 text-4 tracking tracking-1-25';
     }
 
-    // Action Button
-    if (this.btnType === 'action') {
+    // Simple Button
+    if (this.btnType === 'simple') {
       str += ' w-full min-h-36 px-16 border rounded-3xl text-4';
     }
 
@@ -87,6 +87,11 @@ export class MxButton implements IMxButtonProps {
     }
 
     return str;
+  }
+
+  connectedCallback() {
+    // The 'action' type has been renamed to 'simple'
+    if (this.btnType === 'action') this.btnType = 'simple';
   }
 
   render() {

--- a/src/components/mx-button/test/mx-button.spec.tsx
+++ b/src/components/mx-button/test/mx-button.spec.tsx
@@ -107,13 +107,13 @@ describe('mx-button as outlined', () => {
   });
 });
 
-describe('mx-button as an action button', () => {
+describe('mx-button as a simple button', () => {
   let page;
   let root;
   beforeEach(async () => {
     page = await newSpecPage({
       components: [MxButton],
-      html: `<mx-button btn-type="action" value="foo" dropdown>button</mx-button>`,
+      html: `<mx-button btn-type="simple" value="foo" dropdown>button</mx-button>`,
     });
     root = page.root;
   });

--- a/src/components/mx-image-upload/test/mx-image-upload.spec.tsx
+++ b/src/components/mx-image-upload/test/mx-image-upload.spec.tsx
@@ -48,14 +48,14 @@ describe('mx-image-upload', () => {
     root.width = '50%';
     root.height = '50px';
     await page.waitForChanges();
-    expect(root.style.width).toBe('50%');
+    expect(dropzoneWrapper.style.width).toBe('50%');
     expect(dropzoneWrapper.style.height).toBe('50px');
   });
 
   it('sets the width and height to 80px and changes the icon if the avatar prop is set', async () => {
     root.avatar = true;
     await page.waitForChanges();
-    expect(root.style.width).toBe('80px');
+    expect(dropzoneWrapper.style.width).toBe('80px');
     expect(dropzoneWrapper.style.height).toBe('80px');
     expect(root.querySelector('[data-testid="avatar-icon"]')).not.toBeNull();
   });

--- a/src/tailwind/mx-button/index.scss
+++ b/src/tailwind/mx-button/index.scss
@@ -49,28 +49,28 @@
       }
     }
 
-    &.action {
-      color: var(--mds-text-btn-action);
-      background: var(--mds-bg-btn-action);
-      border-color: var(--mds-border-btn-action);
-      --ripple-color: var(--mds-ripple-btn-action);
+    &.simple {
+      color: var(--mds-text-btn-simple);
+      background: var(--mds-bg-btn-simple);
+      border-color: var(--mds-border-btn-simple);
+      --ripple-color: var(--mds-ripple-btn-simple);
 
       &:focus:not([aria-disabled='true']) {
-        background: var(--mds-bg-btn-action-focus);
+        background: var(--mds-bg-btn-simple-focus);
       }
 
       &:hover:not([aria-disabled='true']) {
-        background: var(--mds-bg-btn-action-hover);
+        background: var(--mds-bg-btn-simple-hover);
       }
 
       &:active:not([aria-disabled='true']) {
-        background: var(--mds-bg-btn-action-active);
+        background: var(--mds-bg-btn-simple-active);
       }
 
       &[aria-disabled='true'] {
-        background: var(--mds-bg-btn-action-disabled);
-        border-color: var(--mds-border-btn-action-disabled);
-        color: var(--mds-text-btn-action-disabled);
+        background: var(--mds-bg-btn-simple-disabled);
+        border-color: var(--mds-border-btn-simple-disabled);
+        color: var(--mds-text-btn-simple-disabled);
       }
     }
 

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -48,17 +48,17 @@
   --mds-text-btn-outlined-disabled: #a7a7a7;
   --mds-text-btn-outlined: #2d2d2d;
 
-  /* Action Buttons */
-  --mds-bg-btn-action-active: #fff;
-  --mds-bg-btn-action-disabled: #fcfcfc;
-  --mds-bg-btn-action-focus: #d7d7d7;
-  --mds-bg-btn-action-hover: #eeeeee;
-  --mds-bg-btn-action: #fff;
-  --mds-border-btn-action-disabled: #f2f2f2;
-  --mds-border-btn-action: #e7e7e7;
-  --mds-ripple-btn-action: rgba(0, 0, 0, 0.12);
-  --mds-text-btn-action-disabled: #909090;
-  --mds-text-btn-action: #2d2d2d;
+  /* Simple Buttons */
+  --mds-bg-btn-simple-active: #fff;
+  --mds-bg-btn-simple-disabled: #fcfcfc;
+  --mds-bg-btn-simple-focus: #d7d7d7;
+  --mds-bg-btn-simple-hover: #eeeeee;
+  --mds-bg-btn-simple: #fff;
+  --mds-border-btn-simple-disabled: #f2f2f2;
+  --mds-border-btn-simple: #e7e7e7;
+  --mds-ripple-btn-simple: rgba(0, 0, 0, 0.12);
+  --mds-text-btn-simple-disabled: #909090;
+  --mds-text-btn-simple: #2d2d2d;
 
   /* Text Buttons */
   --mds-bg-btn-text-active: transparent;

--- a/vuepress/components/badges.md
+++ b/vuepress/components/badges.md
@@ -22,13 +22,13 @@ itelf in a corner of that element.
     <strong>Anchored Badges</strong>
     <div class="flex items-center my-20 space-x-20">
       <mx-badge badge-class="bg-purple-500 text-white" value="237">
-        <mx-button btn-type="action" icon="ph-bell">Notifications</mx-button>
+        <mx-button btn-type="simple" icon="ph-bell">Notifications</mx-button>
       </mx-badge>
       <mx-badge badge-class="bg-red-500 text-white" icon="mds-x" bottom offset="10">
         <mx-icon-button icon="ph-video-camera" />
       </mx-badge>
       <mx-badge badge-class="text-red-600" indicator offset="4">
-        <mx-button btn-type="action">Announcements</mx-button>
+        <mx-button btn-type="simple">Announcements</mx-button>
       </mx-badge>
       <mx-badge badge-class="text-yellow-300" indicator="star" top left offset="12">
         <mx-icon-button icon="mds-user-circle" />

--- a/vuepress/components/buttons.md
+++ b/vuepress/components/buttons.md
@@ -62,29 +62,29 @@
 
 <<< @/vuepress/components/buttons.md#standard-buttons
 
-## Action Buttons
+## Simple Buttons
 
-<!-- #region action-buttons -->
+<!-- #region simple-buttons -->
 <section class="mds">
   <div class="my-20">
-    <mx-button btn-type="action">Button</mx-button>
+    <mx-button btn-type="simple">Button</mx-button>
   </div>
   <div class="my-20">
-    <mx-button btn-type="action" icon="ph-apple-logo">Button with Icon</mx-button>
+    <mx-button btn-type="simple" icon="ph-apple-logo">Button with Icon</mx-button>
   </div>
   <div class="my-20">
-    <mx-button btn-type="action" disabled>Disabled</mx-button>
+    <mx-button btn-type="simple" disabled>Disabled</mx-button>
   </div>
   <div class="my-20">
-    <mx-button btn-type="action" dropdown>Dropdown</mx-button>
+    <mx-button btn-type="simple" dropdown>Dropdown</mx-button>
   </div>
   <div class="my-20">
-    <mx-button btn-type="action" dropdown disabled>Disabled</mx-button>
+    <mx-button btn-type="simple" dropdown disabled>Disabled</mx-button>
   </div>
 </section>
-<!-- #endregion action-buttons -->
+<!-- #endregion simple-buttons -->
 
-<<< @/vuepress/components/buttons.md#action-buttons
+<<< @/vuepress/components/buttons.md#simple-buttons
 
 ## Text Buttons
 
@@ -114,7 +114,7 @@
 
 | Property   | Attribute  | Description                                 | Type                                           | Default       |
 | ---------- | ---------- | ------------------------------------------- | ---------------------------------------------- | ------------- |
-| `btnType`  | `btn-type` |                                             | `"action" | "contained" | "outlined" | "text"` | `'contained'` |
+| `btnType`  | `btn-type` |                                             | `"simple" | "contained" | "outlined" | "text"` | `'contained'` |
 | `disabled` | `disabled` |                                             | `boolean`                                      | `false`       |
 | `dropdown` | `dropdown` | Show chevron icon                           | `boolean`                                      | `false`       |
 | `full`     | `full`     | Sets display to flex instead of inline-flex | `boolean`                                      | `false`       |

--- a/vuepress/components/menus.md
+++ b/vuepress/components/menus.md
@@ -13,7 +13,7 @@ To nest a Menu inside a Menu Item, add `slot="submenu"` to the child Menu compon
   <div class="mt-20">
     <div class="flex items-center mt-20 space-x-20">
       <div>
-        <mx-button ref="editButton" btn-type="action" dropdown>Edit</mx-button>
+        <mx-button ref="editButton" btn-type="simple" dropdown>Edit</mx-button>
         <mx-menu ref="editMenu">
           <mx-menu-item @click="clickHandler">Undo</mx-menu-item>
           <mx-menu-item @click="clickHandler" disabled>Redo</mx-menu-item>

--- a/vuepress/components/snackbars.md
+++ b/vuepress/components/snackbars.md
@@ -10,20 +10,20 @@ If multiple snackbars are triggered, they will be queued and displayed consecuti
 <!-- #region snackbars -->
 <section class="mds">
   <div class="my-20">
-    <mx-button btn-type="action" @click="isOpen1 = true">Trigger Simple Snackbar</mx-button>
+    <mx-button btn-type="simple" @click="isOpen1 = true">Trigger Simple Snackbar</mx-button>
     <mx-snackbar :is-open="isOpen1" @mxClose="isOpen1 = false">
       Page has been published
     </mx-snackbar>
   </div>
   <div class="my-20">
-    <mx-button btn-type="action" @click="isOpen2 = true">Trigger Snackbar with Action</mx-button>
+    <mx-button btn-type="simple" @click="isOpen2 = true">Trigger Snackbar with Action</mx-button>
     <mx-snackbar :is-open="isOpen2" duration="5000" @mxClose="isOpen2 = false">
       Page has been published
       <mx-button slot="action" btn-type="text">Undo</mx-button>
     </mx-snackbar>
   </div>
   <div class="my-20">
-    <mx-button btn-type="action" @click="isOpen3 = true">Trigger Multi-Line Snackbar with Action</mx-button>
+    <mx-button btn-type="simple" @click="isOpen3 = true">Trigger Multi-Line Snackbar with Action</mx-button>
     <mx-snackbar :is-open="isOpen3" @mxClose="isOpen3 = false">
       The <strong>Hello World</strong> page has been successfully published
       <mx-button slot="action" btn-type="text">Dismiss</mx-button>

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -328,7 +328,7 @@ The `mx-table` component has both a `search` slot to accomodate a Search field, 
         @input="albumSearch = $event.target.value"
       />
       <div slot="filter">
-        <mx-button ref="labelMenuButton" btn-type="action" dropdown>
+        <mx-button ref="labelMenuButton" btn-type="simple" dropdown>
           {{ (this.albumLabelFilters.length || 'All') +
           (this.albumLabelFilters.length === 1 ? ' Label' : ' Labels') }}
         </mx-button>
@@ -708,7 +708,7 @@ The following example combines checkable, slotted table rows with pagination, ro
         @input="albumSearch2 = $event.target.value"
       />
       <div slot="filter">
-        <mx-button ref="labelMenuButton2" class="whitespace-nowrap" btn-type="action" dropdown>
+        <mx-button ref="labelMenuButton2" class="whitespace-nowrap" btn-type="simple" dropdown>
           {{ (this.albumLabelFilters2.length || 'All') +
           (this.albumLabelFilters2.length === 1 ? ' Label' : ' Labels') }}
         </mx-button>

--- a/vuepress/components/uploads.md
+++ b/vuepress/components/uploads.md
@@ -108,7 +108,7 @@ Set the `showButton` prop to `false` if you want to leverage the `selectFile` an
 <!-- #region external-button -->
     <mx-image-upload ref="upload" show-button="false" @change="onChange" />
     <mx-button
-      btn-type="action"
+      btn-type="simple"
       :icon="hasFile ? 'ph-trash-simple' : 'ph-arrow-fat-line-up'"
       @click="onButtonClick"
     >


### PR DESCRIPTION
This renames the "action" `btnType` to "simple".  However, "action" is still treated as an alias for "simple" in order to not break anything.

https://www.figma.com/file/b36oTkOP6vI6uzLnc7Zd3T/Design-System-(Shirley)?node-id=15124%3A73

I'm also sneaking in fixes for a couple broken `mx-image-upload` unit tests (caused by #101).