### PR TITLE
ENG-141095 - Do not animate row nesting when min-width changes

### DIFF
--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -70,7 +70,7 @@ export class MxTableRow {
     if (!this.collapseNestedRows) return;
     // Ensure that collapsed, nested rows are hidden after switching to/from mobile UI
     await new Promise(requestAnimationFrame);
-    this.toggleNestedRows();
+    this.toggleNestedRows(true);
   }
 
   /** Apply a CSS transform to translate the row by `x` and `y` pixels */

--- a/src/components/mx-tooltip/mx-tooltip.tsx
+++ b/src/components/mx-tooltip/mx-tooltip.tsx
@@ -89,7 +89,7 @@ export class MxTooltip {
 
   render() {
     return (
-      <Host class="inline-block">
+      <Host class="inline-flex">
         <slot></slot>
         <div
           ref={el => (this.tooltipElem = el)}


### PR DESCRIPTION
In addition to the previous changes merged with #102, this should finally fix the page variant rows animating on page load in nucleus.

I'm also changing `mx-tooltip`'s host element to `inline-flex` so it doesn't add line height to the wrapped element and mess up vertical centering for those elements.