### PR TITLE
ENG-141481 - Change search slot width to min-width

### DIFF
--- a/src/tailwind/mx-table/index.scss
+++ b/src/tailwind/mx-table/index.scss
@@ -2,7 +2,9 @@
   color: var(--mds-text-table);
 
   [slot='search'] {
-    @apply sm:w-240;
+    @media (min-width: 640px) {
+      min-width: 15rem;
+    }
   }
 
   .table-grid > *:not(.hidden) {


### PR DESCRIPTION
This allows multiple controls to be placed inside the table's search slot.  This will eliminate the need for putting a negative margin on the Roster admin dropdown next to the search input, which is causing some extra horizontal scrolling.