### PR TITLE
ENG-141837 - Allow icon buttons to be links (via new `href` prop)

### DIFF
--- a/src/components/mx-icon-button/mx-icon-button.tsx
+++ b/src/components/mx-icon-button/mx-icon-button.tsx
@@ -13,6 +13,7 @@ export class MxIconButton {
   @Prop() type: 'button' | 'submit' | 'reset' = 'button';
   @Prop() formaction: string;
   @Prop() value: string;
+  @Prop() href: string;
   @Prop({ reflect: true }) disabled: boolean = false;
   /** The aria-label attribute for the inner button element. */
   @Prop() elAriaLabel: string;
@@ -42,6 +43,8 @@ export class MxIconButton {
   }
 
   render() {
+    const Tag = this.href ? 'a' : 'button';
+
     const buttonContent = (
       <div class="flex justify-center items-center content-center relative">
         {this.icon && <i class={['text-icon', this.icon].join(' ')}></i>}
@@ -63,11 +66,12 @@ export class MxIconButton {
 
     return (
       <Host class="mx-icon-button inline-block appearance-none">
-        <button
-          type={this.type}
+        <Tag
+          type={this.href ? null : this.type}
           formaction={this.formaction}
           value={this.value}
-          class="flex appearance-none items-center w-48 h-48 rounded-full justify-center relative overflow-hidden cursor-pointer disabled:cursor-auto"
+          href={this.href}
+          class="flex text-current appearance-none items-center w-48 h-48 rounded-full justify-center relative overflow-hidden cursor-pointer disabled:cursor-auto"
           ref={el => (this.btnElem = el as HTMLButtonElement)}
           onClick={this.onClick.bind(this)}
           aria-disabled={this.disabled ? 'true' : null}
@@ -75,7 +79,7 @@ export class MxIconButton {
           {...this.dataAttributes}
         >
           {buttonContent}
-        </button>
+        </Tag>
       </Host>
     );
   }

--- a/src/components/mx-icon-button/mx-icon-button.tsx
+++ b/src/components/mx-icon-button/mx-icon-button.tsx
@@ -13,6 +13,7 @@ export class MxIconButton {
   @Prop() type: 'button' | 'submit' | 'reset' = 'button';
   @Prop() formaction: string;
   @Prop() value: string;
+  /** Create button as link */
   @Prop() href: string;
   @Prop({ reflect: true }) disabled: boolean = false;
   /** The aria-label attribute for the inner button element. */

--- a/src/components/mx-icon-button/test/mx-icon-button.spec.tsx
+++ b/src/components/mx-icon-button/test/mx-icon-button.spec.tsx
@@ -84,3 +84,24 @@ describe('mx-icon-button', () => {
     expect(button.getAttribute('data-test')).toBe('test');
   });
 });
+
+describe('mx-icon-button (as link)', () => {
+  let page;
+  let root: HTMLMxIconButtonElement;
+  let button: HTMLAnchorElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxIconButton],
+      html: `<mx-icon-button href="/" icon="icon"></mx-icon-button>`,
+    });
+    root = page.root;
+    button = root.querySelector('a');
+  });
+
+  it('renders an <a>', async () => {
+    expect(button).not.toBeNull();
+    expect(button.getAttribute('class')).toContain('w-48');
+    expect(button.getAttribute('class')).toContain('h-48');
+    expect(button.getAttribute('class')).toContain('rounded-full');
+  });
+});

--- a/src/tailwind/mx-icon-button/index.scss
+++ b/src/tailwind/mx-icon-button/index.scss
@@ -1,4 +1,4 @@
-.mx-icon-button > button {
+.mx-icon-button > * {
   color: var(--mds-text-btn-icon);
   background: var(--mds-bg-btn-icon);
 

--- a/vuepress/components/buttons.md
+++ b/vuepress/components/buttons.md
@@ -183,6 +183,7 @@ Icon buttons are round buttons that only contain an icon. The icon can be set th
 | `disabled`     | `disabled`      |                                                        | `boolean`                         | `false`     |
 | `elAriaLabel`  | `el-aria-label` | The aria-label attribute for the inner button element. | `string`                          | `undefined` |
 | `formaction`   | `formaction`    |                                                        | `string`                          | `undefined` |
+| `href`         | `href`          | Create button as link                                  | `string`                          | `undefined` |
 | `icon`         | `icon`          | Class name of icon (for icon font)                     | `string`                          | `undefined` |
 | `type`         | `type`          |                                                        | `"button" \| "reset" \| "submit"` | `'button'`  |
 | `value`        | `value`         |                                                        | `string`                          | `undefined` |

--- a/vuepress/components/buttons.md
+++ b/vuepress/components/buttons.md
@@ -149,6 +149,7 @@ Icon buttons are round buttons that only contain an icon. The icon can be set th
         <mx-icon-button chevron-down el-aria-label="Down" />
         <mx-icon-button chevron-left el-aria-label="Left" />
         <mx-icon-button chevron-right el-aria-label="Right" />
+        <mx-icon-button icon="ph-link" href="/" el-aria-label="Link" />
       </div>
     </div>
     <div>
@@ -163,6 +164,7 @@ Icon buttons are round buttons that only contain an icon. The icon can be set th
         <mx-icon-button chevron-down disabled el-aria-label="Down" />
         <mx-icon-button chevron-left disabled el-aria-label="Left" />
         <mx-icon-button chevron-right disabled el-aria-label="Right" />
+        <mx-icon-button icon="ph-link" href="/" disabled el-aria-label="Link" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Similar to `mx-button`, this updates `mx-icon-button` to support rendering as an `<a>` instead of `<button>` if the new `href` prop is set.  This will be needed to make nucleus more compliant to accessibility standards.