### PR TITLE
Add labelClass prop to mx-radio

### DIFF
--- a/src/components/mx-radio/mx-radio.tsx
+++ b/src/components/mx-radio/mx-radio.tsx
@@ -33,7 +33,7 @@ export class MxRadio {
 
   render() {
     return (
-      <Host class="mx-radio">
+      <Host class="mx-radio inline-block">
         <label class={this.labelClassNames}>
           <input
             class="absolute h-0 w-0 opacity-0"

--- a/src/components/mx-radio/mx-radio.tsx
+++ b/src/components/mx-radio/mx-radio.tsx
@@ -10,6 +10,7 @@ export class MxRadio {
 
   @Prop() name: string = '';
   @Prop() value: string = '';
+  @Prop() labelClass: string = '';
   @Prop() labelName: string = '';
   @Prop({ mutable: true }) checked: boolean = false;
   @Prop() disabled: boolean = false;
@@ -23,15 +24,17 @@ export class MxRadio {
     this.checked = (e.target as HTMLInputElement).checked;
   }
 
+  get labelClassNames(): string {
+    let str = 'relative inline-flex flex-nowrap align-center items-center text-4';
+    if (!this.disabled) str += ' cursor-pointer';
+    if (this.labelClass) str += ' ' + this.labelClass;
+    return str;
+  }
+
   render() {
     return (
       <Host class="mx-radio">
-        <label
-          class={
-            'relative inline-flex flex-nowrap align-center items-center text-4' +
-            (this.disabled ? '' : ' cursor-pointer')
-          }
-        >
+        <label class={this.labelClassNames}>
           <input
             class="absolute h-0 w-0 opacity-0"
             type="radio"

--- a/src/components/mx-switch/mx-switch.tsx
+++ b/src/components/mx-switch/mx-switch.tsx
@@ -25,7 +25,7 @@ export class MxSwitch {
   }
 
   get labelClassNames(): string {
-    let str = 'elative inline-flex flex-nowrap align-center items-center text-4';
+    let str = 'relative inline-flex flex-nowrap align-center items-center text-4';
     if (!this.disabled) str += ' cursor-pointer';
     if (this.labelClass) str += ' ' + this.labelClass;
     return str;

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -53,15 +53,16 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
 
 <<< @/vuepress/components/selection-controls.md#radio-buttons
 
-### Properties
+### Radio Button Properties
 
-| Property    | Attribute    | Description | Type      | Default |
-| ----------- | ------------ | ----------- | --------- | ------- |
-| `checked`   | `checked`    |             | `boolean` | `false` |
-| `disabled`  | `disabled`   |             | `boolean` | `false` |
-| `labelName` | `label-name` |             | `string`  | `''`    |
-| `name`      | `name`       |             | `string`  | `''`    |
-| `value`     | `value`      |             | `string`  | `''`    |
+| Property     | Attribute     | Description | Type      | Default |
+| ------------ | ------------- | ----------- | --------- | ------- |
+| `checked`    | `checked`     |             | `boolean` | `false` |
+| `disabled`   | `disabled`    |             | `boolean` | `false` |
+| `labelClass` | `label-class` |             | `string`  | `''`    |
+| `labelName`  | `label-name`  |             | `string`  | `''`    |
+| `name`       | `name`        |             | `string`  | `''`    |
+| `value`      | `value`       |             | `string`  | `''`    |
 
 ## Switches
 
@@ -80,7 +81,7 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
 
 <<< @/vuepress/components/selection-controls.md#switches
 
-### Properties
+### Switch Properties
 
 | Property     | Attribute     | Description | Type      | Default |
 | ------------ | ------------- | ----------- | --------- | ------- |


### PR DESCRIPTION
This is needed for the EULA agreement options in nucleus (the radio button labels need a `.subtitle3` class).