### PR TITLE
ENG-141900 - Preserve hyphens when propagating data attributes

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -98,7 +98,10 @@ function isScrollable(el: HTMLElement) {
  * so they can be applied to the native element in the render function. */
 export function propagateDataAttributes() {
   Object.keys(this.element.dataset).forEach(key => {
+    key = camelToKebab(key);
     this.dataAttributes['data-' + key] = this.element.dataset[key];
     this.element.removeAttribute(`data-${key}`);
   });
 }
+
+const camelToKebab = str => str.replace(/[A-Z]+(?![a-z])|[A-Z]/g, ($, ofs) => (ofs ? '-' : '') + $.toLowerCase());


### PR DESCRIPTION
This updates the data attribute propagation (for components that wrap form elements) so that hyphens are not lost.