### PR TITLE
ENG-141903 - Ensure chip-group chip selected value persists

### DIFF
--- a/src/components/mx-chip/mx-chip.tsx
+++ b/src/components/mx-chip/mx-chip.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Event, EventEmitter } from '@stencil/core';
+import { Component, Host, h, Prop, Event, EventEmitter, Element } from '@stencil/core';
 import ripple from '../../utils/ripple';
 import { uuidv4 } from '../../utils/utils';
 
@@ -13,7 +13,7 @@ export class MxChip {
   @Prop() outlined: boolean = false;
   @Prop() disabled: boolean = false;
   /** Display a checkmark on the left side of the chip */
-  @Prop({ reflect: true }) selected: boolean = false;
+  @Prop({ mutable: true, reflect: true }) selected: boolean = false;
   /** Use the pointer cursor and show a ripple animation.
    * This does not need to be explicitly set for `choice` or `filter` chips. */
   @Prop() clickable: boolean = false;
@@ -31,8 +31,16 @@ export class MxChip {
   /** Style as a filter chip when selected */
   @Prop() filter: boolean = false;
 
+  @Element() element: HTMLMxChipElement;
+
   /** Emitted when the remove icon is clicked */
   @Event() mxRemove: EventEmitter<MouseEvent>;
+
+  componentWillRender() {
+    const chipGroup = this.element.closest('mx-chip-group') as HTMLMxChipGroupElement;
+    if (!chipGroup) return;
+    this.selected = chipGroup.value === this.value;
+  }
 
   onClick(e: MouseEvent) {
     if (this.disabled) {


### PR DESCRIPTION
This ensures that if a choice chip re-renders independently of its parent chip group, it will have the correct `selected` value.

This happens in nucleus right now for the Type chip group on the Product admin form.  It only happens when you first open the form from the product list (but not if you refresh the page).