### PR TITLE
ENG-142019 - Add mxClear event to mx-search

### DIFF
--- a/src/components/mx-search/mx-search.tsx
+++ b/src/components/mx-search/mx-search.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { Component, Host, h, Prop, Element, Event, EventEmitter } from '@stencil/core';
 import { propagateDataAttributes } from '../../utils/utils';
 
 @Component({
@@ -21,6 +21,9 @@ export class MxSearch {
 
   @Element() element: HTMLMxSearchElement;
 
+  /** Emitted when the clear button is clicked. */
+  @Event() mxClear: EventEmitter<void>;
+
   componentWillRender = propagateDataAttributes;
 
   onInput(e: InputEvent) {
@@ -29,7 +32,8 @@ export class MxSearch {
 
   onClear() {
     this.inputEl.value = '';
-    this.inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+    this.inputEl.dispatchEvent(new window.Event('input', { bubbles: true }));
+    this.mxClear.emit();
     if (typeof jest === 'undefined') this.inputEl.focus();
   }
 

--- a/src/components/mx-search/test/mx-search.spec.tsx
+++ b/src/components/mx-search/test/mx-search.spec.tsx
@@ -79,13 +79,16 @@ describe('mx-search', () => {
     expect(button.classList.contains('hidden')).toBe(false);
   });
 
-  it('clears the value when the clear button is clicked', async () => {
+  it('clears the value and emits an mxClear event when the clear button is clicked', async () => {
     root.value = 'boo';
+    const listener = jest.fn();
+    root.addEventListener('mxClear', listener);
     await page.waitForChanges();
     const button = root.querySelector('[data-testid="clear-button"]') as HTMLButtonElement;
     button.click();
     await page.waitForChanges();
     expect(root.value).toBe('');
+    expect(listener).toHaveBeenCalled();
   });
 
   it('does not show a clear button when showClear is false', async () => {

--- a/vuepress/components/search.md
+++ b/vuepress/components/search.md
@@ -25,6 +25,12 @@
 
 <<< @/vuepress/components/search.md#search
 
+### Events
+
+| Event     | Description                               | Type                |
+| --------- | ----------------------------------------- | ------------------- |
+| `mxClear` | Emitted when the clear button is clicked. | `CustomEvent<void>` |
+
 ### Properties
 
 | Property      | Attribute       | Description                                                                                                                                                 | Type      | Default     |


### PR DESCRIPTION
This change add an `mxClear` event to the `mx-search` clear button click.