### PR TITLE
Don't emit `mxClose` event from components that wrap menus

### DIFF
--- a/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
+++ b/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
@@ -57,7 +57,8 @@ export class MxDropdownMenu {
     this.isFocused = true;
   }
 
-  onMenuClose() {
+  onMenuClose(e) {
+    e.stopPropagation();
     if (!this.inputElem.contains(document.activeElement)) this.isFocused = false;
   }
 

--- a/src/components/mx-page-header/mx-page-header.tsx
+++ b/src/components/mx-page-header/mx-page-header.tsx
@@ -141,7 +141,11 @@ export class MxPageHeader {
               {isTertiary && this.renderTertiaryButtonAsMenu && (
                 <div class="absolute -top-6">
                   <mx-icon-button ref={el => (this.menuButton = el)} icon="mds-dots-vertical"></mx-icon-button>
-                  <mx-menu ref={el => (this.tertiaryMenu = el)} anchor-el={this.menuButton}>
+                  <mx-menu
+                    ref={el => (this.tertiaryMenu = el)}
+                    anchor-el={this.menuButton}
+                    onMxClose={e => e.stopPropagation()}
+                  >
                     <mx-menu-item {...menuItemProps}>{button.label}</mx-menu-item>
                   </mx-menu>
                 </div>

--- a/src/components/mx-pagination/mx-pagination.tsx
+++ b/src/components/mx-pagination/mx-pagination.tsx
@@ -167,7 +167,7 @@ export class MxPagination {
                     {this.rowsPerPage}
                     <i class="mds-arrow-triangle-down ml-12 text-icon"></i>
                   </div>
-                  <mx-menu ref={el => (this.rowsMenu = el)}>
+                  <mx-menu ref={el => (this.rowsMenu = el)} onMxClose={e => e.stopPropagation()}>
                     {this.rowsPerPageOptions.map(option => (
                       <mx-menu-item disabled={this.disabled} onClick={this.onChangeRowsPerPage.bind(this, option)}>
                         {option}

--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -525,7 +525,11 @@ export class MxTableRow {
                 el-aria-label="Row Actions"
                 icon="mds-dots-vertical"
               ></mx-icon-button>
-              <mx-menu data-testid="action-menu" ref={el => (this.actionMenu = el)}>
+              <mx-menu
+                data-testid="action-menu"
+                ref={el => (this.actionMenu = el)}
+                onMxClose={e => e.stopPropagation()}
+              >
                 {this.actions.map(action => (
                   <mx-menu-item {...action}>{action.value}</mx-menu-item>
                 ))}

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -735,7 +735,11 @@ export class MxTable {
                 <span class="sr-only">Action Menu</span>
               </span>
             </mx-button>
-            <mx-menu data-testid="multi-action-menu" ref={el => (this.actionMenu = el)}>
+            <mx-menu
+              data-testid="multi-action-menu"
+              ref={el => (this.actionMenu = el)}
+              onMxClose={e => e.stopPropagation()}
+            >
               {this.multiRowActions.map(action => (
                 <mx-menu-item {...action}>{action.value}</mx-menu-item>
               ))}

--- a/src/components/mx-time-picker/mx-time-picker.tsx
+++ b/src/components/mx-time-picker/mx-time-picker.tsx
@@ -100,7 +100,8 @@ export class MxTimePicker {
     this.inputElem.focus();
   }
 
-  onMenuClose() {
+  onMenuClose(e) {
+    e.stopPropagation();
     if (!this.inputElem.contains(document.activeElement)) this.isFocused = false;
   }
 


### PR DESCRIPTION
Fixes #130

Updated `mx-dropdown-menu`, `mx-time-picker`, `mx-page-header`, `mx-table`, and `mx-table-row`.