### PR TITLE
ENG-142086 - Add form prop to buttons

### DIFF
--- a/src/components/mx-button/mx-button.tsx
+++ b/src/components/mx-button/mx-button.tsx
@@ -9,6 +9,7 @@ export interface IMxButtonProps {
   btnType?: BtnType;
   type?: ButtonTypeAttribute;
   value?: string;
+  form?: string;
   formaction?: string;
   disabled?: boolean;
   xl?: boolean;
@@ -34,6 +35,7 @@ export class MxButton implements IMxButtonProps {
   @Prop() elAriaLabel: string;
   @Prop() type: ButtonTypeAttribute = 'button';
   @Prop() value: string;
+  @Prop() form: string;
   @Prop() formaction: string;
   @Prop() disabled: boolean = false;
   @Prop() xl: boolean = false;
@@ -130,6 +132,7 @@ export class MxButton implements IMxButtonProps {
         ) : (
           <button
             type={this.type}
+            form={this.form}
             formaction={this.formaction}
             value={this.value}
             class={this.buttonClass}

--- a/src/components/mx-button/test/mx-button.spec.tsx
+++ b/src/components/mx-button/test/mx-button.spec.tsx
@@ -14,6 +14,7 @@ describe('mx-button', () => {
         icon="ph-apple-logo"
         btn-type="contained"
         value="foo"
+        form="bar"
         formaction="/foo"
         data-test="test"
       >
@@ -37,8 +38,9 @@ describe('mx-button', () => {
     expect(innerText.trim()).toBe('button');
   });
 
-  it('has the correct value and formaction', async () => {
+  it('has the correct value, form, and formaction', async () => {
     expect(btn.getAttribute('value')).toBe('foo');
+    expect(btn.getAttribute('form')).toBe('bar');
     expect(btn.getAttribute('formaction')).toBe('/foo');
   });
 

--- a/src/components/mx-icon-button/mx-icon-button.tsx
+++ b/src/components/mx-icon-button/mx-icon-button.tsx
@@ -11,6 +11,7 @@ export class MxIconButton {
   dataAttributes = {};
 
   @Prop() type: 'button' | 'submit' | 'reset' = 'button';
+  @Prop() form: string;
   @Prop() formaction: string;
   @Prop() value: string;
   /** Create button as link */
@@ -69,6 +70,7 @@ export class MxIconButton {
       <Host class="mx-icon-button inline-block appearance-none">
         <Tag
           type={this.href ? null : this.type}
+          form={this.form}
           formaction={this.formaction}
           value={this.value}
           href={this.href}

--- a/src/components/mx-icon-button/test/mx-icon-button.spec.tsx
+++ b/src/components/mx-icon-button/test/mx-icon-button.spec.tsx
@@ -68,9 +68,11 @@ describe('mx-icon-button', () => {
     expect(button.getAttribute('value')).toBe('Open');
   });
 
-  it('uses the formaction prop as an attribute on the button', async () => {
+  it('uses the form and formaction props as attributes on the button', async () => {
+    root.form = 'the-form';
     root.formaction = '/login';
     await page.waitForChanges();
+    expect(button.getAttribute('form')).toBe('the-form');
     expect(button.getAttribute('formaction')).toBe('/login');
   });
 

--- a/vuepress/components/buttons.md
+++ b/vuepress/components/buttons.md
@@ -118,6 +118,7 @@
 | `disabled`    | `disabled`      |                                                        | `boolean`                                                     | `false`       |
 | `dropdown`    | `dropdown`      | Show chevron icon                                      | `boolean`                                                     | `false`       |
 | `elAriaLabel` | `el-aria-label` | The aria-label attribute for the inner button element. | `string`                                                      | `undefined`   |
+| `form`        | `form`          |                                                        | `string`                                                      | `undefined`   |
 | `formaction`  | `formaction`    |                                                        | `string`                                                      | `undefined`   |
 | `full`        | `full`          | Sets display to flex instead of inline-flex            | `boolean`                                                     | `false`       |
 | `href`        | `href`          | Create button as link                                  | `string`                                                      | `undefined`   |
@@ -182,6 +183,7 @@ Icon buttons are round buttons that only contain an icon. The icon can be set th
 | `chevronRight` | `chevron-right` | Show right-pointing chevron icon                       | `boolean`                         | `false`     |
 | `disabled`     | `disabled`      |                                                        | `boolean`                         | `false`     |
 | `elAriaLabel`  | `el-aria-label` | The aria-label attribute for the inner button element. | `string`                          | `undefined` |
+| `form`         | `form`          |                                                        | `string`                          | `undefined` |
 | `formaction`   | `formaction`    |                                                        | `string`                          | `undefined` |
 | `href`         | `href`          | Create button as link                                  | `string`                          | `undefined` |
 | `icon`         | `icon`          | Class name of icon (for icon font)                     | `string`                          | `undefined` |


### PR DESCRIPTION
This adds a `form` prop that sets the `form` attribute on the inner `button`.  This will allow us to have submit buttons in modal footers, for example, that are outside the `form` element.