### PR TITLE
ENG-142335 - Set large modal max width to 1200px

### DIFF
--- a/src/tailwind/mx-modal/index.scss
+++ b/src/tailwind/mx-modal/index.scss
@@ -33,7 +33,7 @@
   &.modal-large > .modal {
     @apply flex-grow h-full;
     /* 40px margin around modal */
-    max-width: calc(100vw - 5rem);
+    max-width: min(calc(100vw - 5rem), 75rem); /* True max width is 1200px */
     max-height: calc(100vh - 5rem);
   }
 }

--- a/vuepress/components/modals.md
+++ b/vuepress/components/modals.md
@@ -15,7 +15,7 @@ The modal component uses a [Page Header](/page-headers.html) internally. The `pr
 - &bull; `footer-left` - This slot contains the previous page link (if the `previousPageUrl` prop is provided).
 - &bull; `footer-right` - If the `buttons` prop is provided, this slot contains those buttons by default.
 
-On small screens, the modal will fill the screen, except for a 24-px margin at the top. On larger screens, the max dimensions are based on whether the `large` prop is set. If `large` is `true`, the modal will stretch to nearly fill the entire page (with a 40px margin); otherwise, the max dimensions are 800x600px.
+On small screens, the modal will fill the screen, except for a 24-px margin at the top. On larger screens, the max dimensions are based on whether the `large` prop is set. If `large` is `true`, the modal will stretch to nearly fill the entire page (with a 40px margin) up to 1200px; otherwise, the max dimensions are 800x600px.
 
 If `fromLeft` or `fromRight` are set, then the modal will appear fixed to one side of the window, and it will stretch the entire height.
 


### PR DESCRIPTION
Large modals will now have a max width of 1200px.  This is needed for the program info modals in nucleus.