### PR TITLE
Fixes from nucleus QA

### DIFF
--- a/src/components/mx-page-header/mx-page-header.tsx
+++ b/src/components/mx-page-header/mx-page-header.tsx
@@ -15,6 +15,7 @@ export class MxPageHeader {
   buttonRow: HTMLElement;
   hasTabs: boolean = false;
   hasModalHeaderCenter: boolean = false;
+  hasModalHeaderRight: boolean = false;
   menuButton: HTMLMxIconButtonElement;
   resizeObserver: ResizeObserver;
   tabSlot: HTMLElement;
@@ -56,6 +57,7 @@ export class MxPageHeader {
   componentWillLoad() {
     this.hasTabs = !!this.element.querySelector('[slot="tabs"]');
     this.hasModalHeaderCenter = !!this.element.querySelector('[slot="modal-header-center"]');
+    this.hasModalHeaderRight = !!this.element.querySelector('[slot="modal-header-right"]');
     this.updateSlottedButtonSize();
   }
 
@@ -111,6 +113,7 @@ export class MxPageHeader {
     let str = 'my-0 pr-20 emphasis ';
     if (!this.minWidths.md) str += this.previousPageUrl ? 'text-h6' : 'text-h5';
     else str += this.previousPageUrl || this.modal ? 'text-h5' : 'text-h3';
+    if (this.hasModalHeaderRight) str += ' pr-80';
     return str;
   }
 

--- a/src/components/mx-search/mx-search.tsx
+++ b/src/components/mx-search/mx-search.tsx
@@ -66,7 +66,12 @@ export class MxSearch {
         ></input>
         <i class="absolute mds-search text-icon left-16 pointer-events-none"></i>
         {this.showClear && (
-          <button class={this.clearButtonClass} data-testid="clear-button" onClick={this.onClear.bind(this)}>
+          <button
+            aria-label="Clear search"
+            class={this.clearButtonClass}
+            data-testid="clear-button"
+            onClick={this.onClear.bind(this)}
+          >
             <i class="mds-x text-icon"></i>
           </button>
         )}

--- a/src/components/mx-toggle-button-group/mx-toggle-button-group.tsx
+++ b/src/components/mx-toggle-button-group/mx-toggle-button-group.tsx
@@ -6,6 +6,8 @@ import { Component, Host, h, Prop, Listen, Element, Event, EventEmitter, Watch }
 })
 export class MxToggleButtonGroup {
   @Prop({ mutable: true }) value: any;
+  /** Set to `true` to prevent deselecting once a selection has been made. */
+  @Prop() required: boolean = false;
 
   @Watch('value')
   onValueChange() {
@@ -31,7 +33,7 @@ export class MxToggleButtonGroup {
 
   toggleValue(value: any) {
     if (this.value !== value) this.value = value;
-    else this.value = null;
+    else if (!this.required) this.value = null;
   }
 
   updateChildButtons() {

--- a/src/components/mx-toggle-button-group/test/mx-toggle-button-group.spec.tsx
+++ b/src/components/mx-toggle-button-group/test/mx-toggle-button-group.spec.tsx
@@ -28,13 +28,30 @@ describe('mx-toggle-button-group', () => {
     expect(heartBtn.getAttribute('selected')).not.toBeNull();
   });
 
-  it('selects the correct toggle button when a button is clicked', async () => {
+  it('(de)selects the correct toggle button when a button is clicked', async () => {
     const appleBtn = root.querySelector('mx-toggle-button[value="apple"]');
     const heartBtn = root.querySelector('mx-toggle-button[value="heart"]');
     appleBtn.click();
     await page.waitForChanges();
     expect(appleBtn.getAttribute('selected')).not.toBeNull();
     expect(heartBtn.getAttribute('selected')).toBeNull();
+    appleBtn.click();
+    await page.waitForChanges();
+    expect(appleBtn.getAttribute('selected')).toBeNull();
+  });
+
+  it('does not deselect a selected button if the required prop is set', async () => {
+    root.required = true;
+    await page.waitForChanges();
+    const appleBtn = root.querySelector('mx-toggle-button[value="apple"]');
+    appleBtn.click();
+    await page.waitForChanges();
+    expect(appleBtn.getAttribute('selected')).not.toBeNull();
+    expect(root.value).toBe('apple');
+    appleBtn.click();
+    await page.waitForChanges();
+    expect(appleBtn.getAttribute('selected')).not.toBeNull();
+    expect(root.value).toBe('apple');
   });
 
   it('selects the correct toggle button when the value prop changes', async () => {

--- a/vuepress/components/buttons.md
+++ b/vuepress/components/buttons.md
@@ -282,9 +282,10 @@ emitted via a custom <code>mxInput</code> event.
 
 ### Toggle Button Group Properties
 
-| Property | Attribute | Description | Type  | Default     |
-| -------- | --------- | ----------- | ----- | ----------- |
-| `value`  | `value`   |             | `any` | `undefined` |
+| Property   | Attribute  | Description                                                          | Type      | Default     |
+| ---------- | ---------- | -------------------------------------------------------------------- | --------- | ----------- |
+| `required` | `required` | Set to `true` to prevent deselecting once a selection has been made. | `boolean` | `false`     |
+| `value`    | `value`    |                                                                      | `any`     | `undefined` |
 
 ### Toggle Button Group Events
 


### PR DESCRIPTION
- Add `required` prop to toggle button group that prevents deselecting once a selection has been made (needed for nucleus preview modal device toggles) ENG-142597
- Prevent modal heading from overlapping Close button ENG-142609
- Added a missing aria-label to the mx-search clear button