### PR TITLE
Add npm-watch as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "jest-cli": "26.6.3",
     "minify": "^7.0.2",
     "npm-run-all": "^4.1.5",
+    "npm-watch": "^0.11.0",
     "postcss": "^8.2.9",
     "postcss-cli": "^8.3.1",
     "stencil-inline-svg": "^1.1.0",


### PR DESCRIPTION
`npm-watch` is used in our scripts, but it's not in our `package.json`.  This tripped up Michelle.