### PR TITLE
ENG-143238 - Use fixed popovers instead of absolute

### DIFF
--- a/src/utils/popover.ts
+++ b/src/utils/popover.ts
@@ -20,6 +20,7 @@ export async function createPopover(
   const instance = createPopper(anchorEl, popoverEl, {
     placement,
     modifiers: getModifiers(placement, offset),
+    strategy: 'fixed',
   });
   return new Promise(resolve => {
     // Wait a frame for the element's width and height to be accurate and then update


### PR DESCRIPTION
This changes the positioning for popovers from `absolute` to `fixed`.  This affects menus, tooltips, and the date picker's calendar popover.  The issue with using `absolute` was that if a parent container is set to `overflow: hidden`, the menu would sometimes be clipped.  For `overflow: auto`, the menu might cause unwanted scrolling.

I have not found any downsides to switching the positioning strategy.  Everything seems to work just fine. 🤞

@iamjpg This should fix that issue you had at one time when you were working on the filter dropdowns.