### PR TITLE
ENG-142283 & ENG-143125 - Add `mobileSearchOnTop` alternate layout for table operations bar

### DIFF
--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -84,60 +84,60 @@ export class MxTable {
   dragRowElHeight: number;
   dragMoveHandler: (e: MouseEvent) => any;
 
-  /** An array of objects that defines the table's dataset. */
-  @Prop({ mutable: true }) rows: Object[] = [];
-  /** An array of column definitions.  If not specified, a column will be generated for each property on the row object. */
-  @Prop() columns: ITableColumn[] = [];
-  /** A function that returns the `rowId` prop for each generated `mx-table-row`.
-   * This is only required if the table is `checkable` and is auto-generating rows (not using the default slot). */
-  @Prop() getRowId: (row: Object) => string;
+  /** Set to `true` to allow smaller tables to shrink to less than 100% width on larger screens */
+  @Prop() autoWidth: boolean = false;
   /** Make rows checkable.  You must either provide a `getRowId` getter (for generated rows), or
    * provide a `rowId` for every `mx-table-row` if creating the rows manually in the table's slot. */
   @Prop() checkable: boolean = false;
   /** Set to `true` to allow checking rows by clicking on any dead space inside the row. */
   @Prop() checkOnRowClick: boolean = false;
-  /** Set to `false` to hide the (un)check all checkbox at the top of the table. */
-  @Prop() showCheckAll: boolean = true;
+  /** An array of column definitions.  If not specified, a column will be generated for each property on the row object. */
+  @Prop() columns: ITableColumn[] = [];
+  /** Disable the next-page button.  Useful when using server-side pagination and the total number of rows is unknown. */
+  @Prop() disableNextPage: boolean = false;
+  /** Disable the pagination buttons (i.e. while loading results) */
+  @Prop() disablePagination: boolean = false;
   /** Enables reordering of rows via drag and drop. */
   @Prop() draggableRows: boolean = false;
-  /** Set to `false` to not mutate the `rows` prop when rows are reordered via drag and drop. */
-  @Prop() mutateOnDrag: boolean = true;
-  /** The row property to use for grouping rows.  The `rows` prop must be provided as well. */
-  @Prop() groupBy: string = null;
   /** A function that returns the subheader text for a `groupBy` value.  If not provided, the `row[groupBy]` value will be shown in the subheader rows. */
   @Prop() getGroupByHeading: (row: Object) => string;
+  @Prop() getMultiRowActions: (rows: string[]) => ITableRowAction[];
+  @Prop() getRowActions: (row: Object) => ITableRowAction[];
+  /** A function that returns the `rowId` prop for each generated `mx-table-row`.
+   * This is only required if the table is `checkable` and is auto-generating rows (not using the default slot). */
+  @Prop() getRowId: (row: Object) => string;
+  /** The row property to use for grouping rows.  The `rows` prop must be provided as well. */
+  @Prop() groupBy: string = null;
   @Prop() hoverable: boolean = true;
-  /** Set to `true` to allow smaller tables to shrink to less than 100% width on larger screens */
-  @Prop() autoWidth: boolean = false;
-  /** The property on the row objects that will be used for sorting */
-  @Prop({ mutable: true }) sortBy: string;
-  @Prop({ mutable: true }) sortAscending: boolean = true;
-  /** Show the pagination component.  Setting this to `false` will show all rows. */
-  @Prop() paginate: boolean = true;
+  /** Set to `false` to not mutate the `rows` prop when rows are reordered via drag and drop. */
+  @Prop() mutateOnDrag: boolean = true;
+  /** Additional class names for the operation bar grid */
+  @Prop() operationsBarClass: string = '';
   /** The page to display */
   @Prop({ mutable: true }) page: number = 1;
+  /** Show the pagination component.  Setting this to `false` will show all rows. */
+  @Prop() paginate: boolean = true;
+  /** Delay the appearance of the progress bar for this many milliseconds */
+  @Prop() progressAppearDelay: number = 0;
+  /** The progress bar percentage from 0 to 100. If not provided (or set to `null`), an indeterminate progress bar will be displayed. */
+  @Prop() progressValue: number = null;
+  /** An array of objects that defines the table's dataset. */
+  @Prop({ mutable: true }) rows: Object[] = [];
   @Prop({ mutable: true }) rowsPerPage: number = 10;
+  @Prop() rowsPerPageOptions: number[];
+  /** Do not sort or paginate client-side. Use events to send server requests instead. */
+  @Prop() serverPaginate: boolean = false;
+  /** Set to `false` to hide the (un)check all checkbox at the top of the table. */
+  @Prop() showCheckAll: boolean = true;
+  /** Show a progress bar below the header row */
+  @Prop() showProgressBar: boolean = false;
+  @Prop({ mutable: true }) sortAscending: boolean = true;
+  /** The property on the row objects that will be used for sorting */
+  @Prop({ mutable: true }) sortBy: string;
   /** The total number of unpaginated rows.  This is ignored for client-side pagination.
    * For server-side pagination, omitting this prop will remove the last-page button.
    */
   @Prop() totalRows: number;
-  /** Disable the next-page button.  Useful when using server-side pagination and the total number of rows is unknown. */
-  @Prop() disableNextPage: boolean = false;
-  @Prop() rowsPerPageOptions: number[];
-  /** Do not sort or paginate client-side. Use events to send server requests instead. */
-  @Prop() serverPaginate: boolean = false;
-  @Prop() getRowActions: (row: Object) => ITableRowAction[];
-  @Prop() getMultiRowActions: (rows: string[]) => ITableRowAction[];
-  /** Show a progress bar below the header row */
-  @Prop() showProgressBar: boolean = false;
-  /** Disable the pagination buttons (i.e. while loading results) */
-  @Prop() disablePagination: boolean = false;
-  /** The progress bar percentage from 0 to 100. If not provided (or set to `null`), an indeterminate progress bar will be displayed. */
-  @Prop() progressValue: number = null;
-  /** Delay the appearance of the progress bar for this many milliseconds */
-  @Prop() progressAppearDelay: number = 0;
-  /** Additional class names for the operation bar grid */
-  @Prop() operationsBarClass: string = '';
 
   @State() minWidths = new MinWidths();
   @State() checkedRowIds: string[] = [];

--- a/src/components/mx-table/test/mx-table-mobile.spec.tsx
+++ b/src/components/mx-table/test/mx-table-mobile.spec.tsx
@@ -12,10 +12,16 @@ describe('mx-table (mobile)', () => {
     page = await newSpecPage({
       components: [MxTable, MxTableRow, MxTableCell, MxCheckbox],
       html: `
-      <mx-table />
+      <mx-table checkable>
+        <input type="text" slot="search">
+        <div slot="filter">
+          <button>Filters</button>
+        </div>
+      </mx-table>
       `,
     });
     root = page.root as HTMLMxTableElement;
+    root.getRowId = (row: any) => row.id;
     root.rows = [
       { id: 0, name: 'Alvin', age: 4 },
       { id: 1, name: 'Simon', age: 3 },
@@ -78,5 +84,20 @@ describe('mx-table (mobile)', () => {
     await page.waitForChanges();
     const actionMenus = root.querySelectorAll('[data-testid="action-menu"]');
     expect(actionMenus.length).toBe(3);
+  });
+
+  it('changes the operations bar grid layout if mobileSearchOnTop is set', async () => {
+    const search = root.querySelector('[data-testid="search-grid-item"]') as HTMLElement;
+    const filter = root.querySelector('[data-testid="filter-grid-item"]') as HTMLElement;
+    const checkAll = root.querySelector('[data-testid="check-all-grid-item"]') as HTMLElement;
+    expect(search.style.gridColumnStart).toBe('2');
+    expect(filter.classList.contains('col-span-full')).toBe(true);
+    expect(checkAll.classList.contains('row-start-2')).toBe(false);
+    root.mobileSearchOnTop = true;
+    await page.waitForChanges();
+    expect(search.style.gridColumnStart).toBe('1');
+    expect(search.style.gridColumnEnd).toBe('-1');
+    expect(filter.classList.contains('col-start-2')).toBe(true);
+    expect(checkAll.classList.contains('row-start-2')).toBe(true);
   });
 });

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -697,12 +697,15 @@ Adding the `subheader` prop to a row styles it as a subheader. Only one `mx-tabl
 ## Advanced usage
 
 The following example combines checkable, slotted table rows with pagination, row actions, multi-row actions, searching, and filtering.
+It also uses an alternate mobile layout for the operations bar where the `search` slot is on the first row and the `filter` slot is on
+the second row (via the `mobileSearchOnTop` prop).
 
 <section class="mds">
   <div class="mt-20"></div>
     <!-- #region advanced -->
     <mx-table
       checkable
+      mobile-search-on-top
       :rows.prop="filteredAlbums2"
       :columns.prop="[
         { property: 'entertainer', heading: 'Artist', sortable: false },
@@ -788,6 +791,7 @@ The following example combines checkable, slotted table rows with pagination, ro
 | `getRowId`            | --                      | A function that returns the `rowId` prop for each generated `mx-table-row`. This is only required if the table is `checkable` and is auto-generating rows (not using the default slot). | `(row: Object) => string`               | `undefined` |
 | `groupBy`             | `group-by`              | The row property to use for grouping rows. The `rows` prop must be provided as well.                                                                                                    | `string`                                | `null`      |
 | `hoverable`           | `hoverable`             |                                                                                                                                                                                         | `boolean`                               | `true`      |
+| `mobileSearchOnTop`   | `mobile-search-on-top`  | Set to `true` to use an alternate mobile layout for the operations bar where the filter slot is next to the (un)check-all checkbox and the search slot is in a row above.               | `boolean`                               | `false`     |
 | `mutateOnDrag`        | `mutate-on-drag`        | Set to `false` to not mutate the `rows` prop when rows are reordered via drag and drop.                                                                                                 | `boolean`                               | `true`      |
 | `operationsBarClass`  | `operations-bar-class`  | Additional class names for the operation bar grid                                                                                                                                       | `string`                                | `''`        |
 | `page`                | `page`                  | The page to display                                                                                                                                                                     | `number`                                | `1`         |


### PR DESCRIPTION
A couple of the tables in nucleus use an alternate layout on mobile for the search and filter slots.  I've added a new prop to enable this layout called `mobileSearchOnTop`.  The search slot is moved to the top row by itself, and the filter slot then shares the second row with the (un)check-all checkbox if present.

I debated about adding more granular props to control the grid layout of the operations bar, but it would have been pretty complex because we only want to affect small viewports and all of these grid items are optional.  Plus, the whole point of having the operations bar in the table component is for it to be somewhat consistent and opinionated.

I also reordered the prop definitions in `mx-table.tsx` so they're alphabetized since we're now up to 29(!) props.

Default mobile layout:

![image](https://user-images.githubusercontent.com/3342530/155742237-9af7fced-54cb-407d-922d-8f21467ad97f.png)

With `mobileSearchOnTop`:

![image](https://user-images.githubusercontent.com/3342530/155742149-3123afe1-88cb-4fba-980d-2cd83438e89e.png)

