### PR TITLE
Propagate mx-button data attributes to <a> as well

### DIFF
--- a/src/components/mx-button/mx-button.tsx
+++ b/src/components/mx-button/mx-button.tsx
@@ -127,6 +127,7 @@ export class MxButton implements IMxButtonProps {
             class={this.buttonClass}
             ref={el => (this.anchorElem = el as HTMLAnchorElement)}
             onClick={this.onClick.bind(this)}
+            {...this.dataAttributes}
           >
             {buttonContent}
           </a>

--- a/src/components/mx-button/test/mx-button.spec.tsx
+++ b/src/components/mx-button/test/mx-button.spec.tsx
@@ -169,7 +169,7 @@ describe('mx-button as an anchor tag', () => {
   beforeEach(async () => {
     page = await newSpecPage({
       components: [MxButton],
-      html: `<mx-button href="https://google./com" target="_blank" btn-type="text" value="foo">button</mx-button>`,
+      html: `<mx-button href="https://google./com" target="_blank" btn-type="text" value="foo" data-admin--a--b-c="test">button</mx-button>`,
     });
     root = page.root;
   });
@@ -178,5 +178,10 @@ describe('mx-button as an anchor tag', () => {
     const btn = root.querySelector('a');
     expect(btn).not.toBeNull();
     expect(btn.getAttribute('target')).toBeDefined();
+  });
+
+  it('applies any data attributes to the <a> element', async () => {
+    const btn = root.querySelector('a');
+    expect(btn.getAttribute('data-admin--a--b-c')).toBe('test');
   });
 });


### PR DESCRIPTION
Data attributes on the `<mx-button>` host element are applied to the inner `<button>` element, but they're currently not applied to the `<a>` element for buttons that are links.  This is why @aroop had trouble with [these Add buttons](https://github.com/moxiworks/nucleus/commit/5eda2cf60e1c087e1714a6dd846e04598291f5f4#diff-acc6fce6424cae9cf9fef07bcf9210bfa4aec4309bc75a18a78fae846b301312R46-R47).