### PR TITLE
ENG-143467 / ENG-143471 - Fix mobile table rendering in Safari/iOS

### DIFF
--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -412,7 +412,7 @@ export class MxTableRow {
   }
 
   get indentClass(): string {
-    let str = 'table-row-indent h-full';
+    let str = 'table-row-indent';
     if (this.minWidths.sm) return str;
     str += ' col-start-1 row-start-1';
     return (str += ' row-span-' + this.columnCount);


### PR DESCRIPTION
The `.h-full` class on the `.table-row-indent` was causing the exposed cell's grid row to expand beyond the `max-height` of the parent table row.

Before:

![image](https://user-images.githubusercontent.com/3342530/156235622-2c632833-4399-4100-86c5-cf3a45734175.png)


After:

![image](https://user-images.githubusercontent.com/3342530/156235676-e47915a1-2cc3-48ca-98ce-2b04484f5961.png)
