### PR TITLE
ENG-143561 - Address menu/menuitem role issues

### DIFF
--- a/src/components/mx-dropdown-menu/test/mx-dropdown-menu.spec.tsx
+++ b/src/components/mx-dropdown-menu/test/mx-dropdown-menu.spec.tsx
@@ -141,7 +141,7 @@ describe('mx-dropdown-menu', () => {
   });
 
   it('sets the mx-menu and mx-menu-item roles to "listbox" and "option"', async () => {
-    expect(root.querySelector('mx-menu').getAttribute('role')).toBe('listbox');
+    expect(root.querySelector('[role="listbox"]')).not.toBeNull();
     expect(Array.from(menuItems).every(m => m.children[0].getAttribute('role') === 'option')).toBe(true);
   });
 });

--- a/src/components/mx-menu-item/mx-menu-item.tsx
+++ b/src/components/mx-menu-item/mx-menu-item.tsx
@@ -155,7 +155,7 @@ export class MxMenuItem implements IMxMenuItemProps {
   openSubMenu() {
     if (this.submenu) {
       this.submenu.placement = 'right-start';
-      this.submenu.anchorEl = this.element;
+      this.submenu.anchorEl = this.menuItemElem;
       return this.submenu.openMenu();
     }
   }

--- a/src/components/mx-menu-item/mx-menu-item.tsx
+++ b/src/components/mx-menu-item/mx-menu-item.tsx
@@ -81,7 +81,12 @@ export class MxMenuItem implements IMxMenuItemProps {
   }
 
   connectedCallback() {
-    this.role = !!this.element.closest('mx-dropdown-menu') ? 'option' : 'menuitem';
+    const parentLink = this.element.closest('a');
+    if (!!parentLink) {
+      parentLink.setAttribute('role', 'menuitem');
+    } else {
+      this.role = !!this.element.closest('mx-dropdown-menu') ? 'option' : 'menuitem';
+    }
     minWidthSync.subscribeComponent(this);
   }
 
@@ -172,12 +177,13 @@ export class MxMenuItem implements IMxMenuItemProps {
 
   render() {
     return (
-      <Host class={'mx-menu-item block' + (!!this.submenu ? ' has-submenu' : '')}>
+      <Host role="none" class={'mx-menu-item block' + (!!this.submenu ? ' has-submenu' : '')}>
         <div
           ref={el => (this.menuItemElem = el)}
           role={this.role}
-          aria-checked={this.role === 'menuitem' ? null : this.checked ? 'true' : 'false'}
+          aria-checked={this.role === 'option' ? (this.checked ? 'true' : 'false') : null}
           aria-disabled={this.disabled ? 'true' : null}
+          aria-haspopup={!!this.submenu ? 'true' : null}
           aria-selected={this.selected ? 'true' : null}
           tabindex={this.disabled || this.multiSelect ? '-1' : '0'}
           class="block w-full cursor-pointer select-none text-4 outline-none"

--- a/src/components/mx-menu-item/test/mx-menu-item.spec.tsx
+++ b/src/components/mx-menu-item/test/mx-menu-item.spec.tsx
@@ -147,10 +147,36 @@ describe('mx-menu-item (with submenu)', () => {
     expect(submenu.isOpen).toBe(false);
   });
 
+  it('has an aria-haspopup attribute', () => {
+    expect(menuItem.getAttribute('aria-haspopup')).toBe('true');
+  });
+
   it('opens the submenu on Enter', async () => {
     const enter = new KeyboardEvent('keydown', { key: 'Enter' });
     root.dispatchEvent(enter);
     await page.waitForChanges();
     expect(submenu.isOpen).toBe(true);
+  });
+});
+
+describe('mx-menu-item (wrapped in link)', () => {
+  let page: SpecPage;
+  let root: HTMLMxMenuItemElement;
+  let menuItem: HTMLElement;
+  let doc: Document;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxMenuItem],
+      html: `<a href="#"><mx-menu-item>Open</mx-menu-item></a>`,
+    });
+    doc = page.doc as Document;
+    root = page.root as HTMLMxMenuItemElement;
+    menuItem = root.querySelector('div');
+  });
+
+  it('applies a role of menuitem to the parent <a>', () => {
+    const link = doc.querySelector('a');
+    expect(link.getAttribute('role')).toBe('menuitem');
+    expect(menuItem.getAttribute('role')).toBeNull();
   });
 });

--- a/src/components/mx-menu-item/test/mx-menu-item.spec.tsx
+++ b/src/components/mx-menu-item/test/mx-menu-item.spec.tsx
@@ -156,6 +156,7 @@ describe('mx-menu-item (with submenu)', () => {
     root.dispatchEvent(enter);
     await page.waitForChanges();
     expect(submenu.isOpen).toBe(true);
+    expect(menuItem.getAttribute('aria-expanded')).toBe('true');
   });
 });
 

--- a/src/components/mx-menu/mx-menu.tsx
+++ b/src/components/mx-menu/mx-menu.tsx
@@ -180,6 +180,9 @@ export class MxMenu {
 
   componentWillUpdate() {
     this.setInputEl();
+    this.anchorEl &&
+      this.anchorEl.getAttribute('role') === 'menuitem' &&
+      this.anchorEl.setAttribute('aria-expanded', this.isOpen ? 'true' : 'false');
     if (this.inputEl && this.anchorEl) this.element.style.width = this.anchorEl.getBoundingClientRect().width + 'px';
     // If any menu item has an icon, ensure that all menu items at least have a null icon.
     // This will ensure the inner text of all the menu items is aligned.

--- a/src/components/mx-menu/mx-menu.tsx
+++ b/src/components/mx-menu/mx-menu.tsx
@@ -171,14 +171,11 @@ export class MxMenu {
     return true;
   }
 
-  connectedCallback() {
-    const role = !!this.element.querySelector('[role="option"]') ? 'listbox' : 'menu';
-    this.element.setAttribute('role', role);
-    this.anchorEl && this.anchorEl.setAttribute('aria-haspopup', 'true');
-  }
-
   componentDidLoad() {
     this.setInputEl();
+    const role = !!this.element.querySelector('[role="option"]') ? 'listbox' : 'menu';
+    this.scrollElem.setAttribute('role', role);
+    this.anchorEl && this.anchorEl.setAttribute('aria-haspopup', 'true');
   }
 
   componentWillUpdate() {

--- a/src/components/mx-menu/test/mx-menu.spec.tsx
+++ b/src/components/mx-menu/test/mx-menu.spec.tsx
@@ -33,7 +33,7 @@ describe('mx-menu', () => {
   });
 
   it('has a role of menu', () => {
-    expect(root.getAttribute('role')).toBe('menu');
+    expect(root.querySelector('[role="menu"]')).not.toBeNull();
   });
 
   it('opens when the anchorEl is clicked', async () => {


### PR DESCRIPTION
This updates `mx-menu` and `mx-menu-item` to apply the `menu` and `menuitem` ARIA roles to the most appropriate elements.  Ideally, the `menu` and `menuitem` should be immediately related, but may be separated by an element with `role="none"` or `role="presentation"`.

For this reason, the scrolling element that wraps the `mx-menu`'s slot now has the `menu` role, and the `mx-menu-item` host element now has `role="none"`.  One exception I've added is when the `mx-menu-item` is wrapped in an `<a>`, then the `role="menuitem"` is applied to the link.

I've also fixed the `aria-haspopup` attribute that wasn't always getting applied, and I added `aria-expanded` to menu items that open sub-menus.