### PR TITLE
ENG-143595 - Set indent element to 100% height on non-mobile

### DIFF
--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -412,7 +412,7 @@ export class MxTableRow {
   }
 
   get indentClass(): string {
-    let str = 'table-row-indent';
+    let str = 'table-row-indent sm:h-full';
     if (this.minWidths.sm) return str;
     str += ' col-start-1 row-start-1';
     return (str += ' row-span-' + this.columnCount);


### PR DESCRIPTION
This fixes an issue with a previous fix (https://github.com/moxiworks/mds/pull/152).  Not sure how I missed this, but we do in fact need the indent elements to be `height: 100%`, but only on larger screens.

Before:

![image](https://user-images.githubusercontent.com/3342530/156803683-a334901b-7295-4474-9339-a2ccfe6eddaa.png)


After:

![image](https://user-images.githubusercontent.com/3342530/156803750-447c75c7-d643-4316-abc5-b05791c7748e.png)
