### PR TITLE
ENG-143624 - Collapse/expand grouped rows under subheaders

### DIFF
--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -349,10 +349,12 @@ export class MxTableRow {
         if (!child.offsetParent) children.push(...(Array.from(child.children) as HTMLElement[]));
         else children.push(child);
       });
-    const nestedRows = Array.from(this.childRowWrapper.children) as HTMLMxTableRowElement[];
-    await Promise.all(
-      nestedRows.map(childRow => childRow.getChildren().then(grandchildren => children.push(...grandchildren))),
-    );
+    if (!this.collapseNestedRows) {
+      const nestedRows = Array.from(this.childRowWrapper.children) as HTMLMxTableRowElement[];
+      await Promise.all(
+        nestedRows.map(childRow => childRow.getChildren().then(grandchildren => children.push(...grandchildren))),
+      );
+    }
     return children as HTMLElement[];
   }
 

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -709,6 +709,7 @@ export class MxTable {
     this.rowsPerPage = e.detail.rowsPerPage;
   }
 
+  @Listen('mxRowAccordion')
   setLastRowClass() {
     if (this.paginate || this.hasFooter) return;
     const rows = this.getTableRows().filter(row => row.getAttribute('aria-hidden') !== 'true');

--- a/src/tailwind/mx-table/index.scss
+++ b/src/tailwind/mx-table/index.scss
@@ -75,8 +75,9 @@
       .first-column-wrapper > :nth-child(2).mx-table-cell > div {
         @apply pl-24;
       }
-      .mobile-row-chevron {
-        color: var(--mds-text-table-mobile-row-chevron);
+      .mobile-row-chevron,
+      .subheader-chevron {
+        color: var(--mds-text-table-row-chevron);
         transition: transform 0.15s ease;
       }
       &.mobile-collapsed {

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -352,7 +352,7 @@
   --mds-border-table-header: #eaeaea;
   --mds-border-table-cell: #e8e8e8;
   --mds-text-table: #333;
-  --mds-text-table-mobile-row-chevron: #0457af;
+  --mds-text-table-row-chevron: #0457af;
   --mds-text-table-drag-handle: #c5c5c5;
   --mds-text-table-subheader: #0457af;
   /* #endregion tables */

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -853,6 +853,7 @@ The `ITableColumn` interface describes the objects passed to the `columns` prop.
 | Event            | Description                                                                                      | Type                                                |
 | ---------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
 | `mxCheck`        | Emits the `rowId` and `checked` state (via `Event.detail`) of the row whenever it is (un)checked | `CustomEvent<{ rowId: string; checked: boolean; }>` |
+| `mxRowAccordion` | Emitted when a row is collapsed or expanded. Handled by the parent table.                        | `CustomEvent<void>`                                 |
 | `mxRowDragEnd`   | Emits the `rowId` when row dragging ends                                                         | `CustomEvent<string>`                               |
 | `mxRowDragStart` | Emits the `rowId` when dragging starts                                                           | `CustomEvent<string>`                               |
 


### PR DESCRIPTION
This adds a button to subheader rows for collapsing/expanding the grouped rows.  This will make it easier to reorder categories in nucleus when there are a lot of products in each category.

![Mar-15-2022 09-02-23](https://user-images.githubusercontent.com/3342530/158383432-3ce23185-c6d4-44cc-a6b5-aa3502c31d8b.gif)
