### PR TITLE
ENG-144264 - Wrap first column without extra div

### DIFF
--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -158,9 +158,9 @@ export class MxTableRow {
 
   /** Move first cell into same container as checkbox and drag handle. */
   wrapFirstColumn() {
-    const firstCell = this.element.querySelector('mx-table-cell');
-    if (this.firstCellTarget && firstCell) {
-      this.firstCellTarget.appendChild(firstCell);
+    if (this.firstCellTarget && this.firstCellTarget.parentNode) {
+      const firstCell = this.element.querySelector('mx-table-cell');
+      if (firstCell) this.firstCellTarget.parentNode.replaceChild(firstCell, this.firstCellTarget);
     }
   }
 

--- a/src/tailwind/mx-table/index.scss
+++ b/src/tailwind/mx-table/index.scss
@@ -54,6 +54,7 @@
   .mx-table-row {
     & > .table-row {
       border-color: var(--mds-border-table-cell);
+      will-change: max-height; /* Makes collapse/expand smoother. */
 
       & > :last-child:not(.pr-0, .p-0) {
         @apply sm:pr-24;


### PR DESCRIPTION
Not sure how I didn't see this when originally testing locally, but the mobile row styling broke when I added an extra `div` around the first `mx-table-cell`.

Instead of moving the first `mx-table-cell` into `this.firstCellTarget`, I'm now doing a `replaceChild` to replace `this.firstCellTarget`.  It should also be a bit more performant since it will now only happen once whenever the entire row needs re-rendering.

I also noticed that the accordion animation was laggy when there are a lot of nested rows, so I added `will-change: max-height`, which seems to help a lot.

Before:

![image](https://user-images.githubusercontent.com/3342530/158862663-aad9c0b9-ec72-4639-a6cc-1f35a35acbc3.png)


After:

![image](https://user-images.githubusercontent.com/3342530/158862348-8aea0f29-46e0-4790-b463-7ad152322c92.png)
