### PR TITLE
Table fixes

### DIFF
--- a/src/components/mx-table-cell/mx-table-cell.tsx
+++ b/src/components/mx-table-cell/mx-table-cell.tsx
@@ -40,7 +40,7 @@ export class MxTableCell {
         class={this.cellClass}
       >
         {/* Padding is applied to this inner div in the scss file so the <mx-table-cell> can be collapsed with max-height:0 */}
-        <div class={!this.isExposedMobileColumn && !this.minWidths.sm ? 'py-0 pb-12' : ''}>
+        <div class={!this.isExposedMobileColumn && !this.minWidths.sm ? 'py-0 pb-12' : 'overflow-hidden'}>
           <div
             class="min-h-16 max-w-full break-words"
             role={this.columnIndex == null ? 'heading' : null}

--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -501,7 +501,7 @@ export class MxTableRow {
             {this.subheader && (
               <button
                 type="button"
-                class="flex border-0 items-center h-full justify-end px-12"
+                class="flex border-0 items-center h-40 justify-end px-12"
                 aria-label="Toggle visibility of rows grouped under this one"
                 onClick={() => (this.collapseNestedRows = !this.collapseNestedRows)}
                 onMouseDown={e => e.preventDefault() /* Do not focus on click */}


### PR DESCRIPTION
- Fixed right side of table column contents sometimes getting clipped. ENG-144355
- Fixed subheader row children having crazy heights in Safari/iOS (basically the same bug as https://github.com/moxiworks/mds/pull/152, but for the new collapse/expand button instead of the indent element). ENG-144273