### PR TITLE
ENG-144396 - Add bold+italic font style

### DIFF
--- a/src/tailwind/styles.css
+++ b/src/tailwind/styles.css
@@ -6,7 +6,7 @@
 /***************************
 * Import Font
 ***************************/
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;0,800;1,400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;0,800;1,400;1,700&display=swap');
 
 /***************************
 * Import Tailwind helpers


### PR DESCRIPTION
You cannot use bold and italic together in the ckeditor in nucleus because we are not loading that style for Open Sans from Google Fonts.