### PR TITLE
ENG-144581 - Truncate buttons; Prevent table filter overflow

### DIFF
--- a/src/components/mx-button/mx-button.tsx
+++ b/src/components/mx-button/mx-button.tsx
@@ -102,9 +102,9 @@ export class MxButton implements IMxButtonProps {
 
   render() {
     const buttonContent = (
-      <div class="flex justify-center items-center content-center relative whitespace-nowrap">
+      <div class="flex justify-center items-center content-center relative overflow-hidden whitespace-nowrap">
         {this.icon && <i class={'mr-8 text-3 ' + this.icon}></i>}
-        <span class="slot-content">
+        <span class="slot-content truncate">
           <slot />
         </span>
         {this.dropdown && this.btnType === 'text' && <span class="separator inline-block w-1 ml-4 -my-4 h-24"></span>}

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -561,7 +561,7 @@ export class MxTable {
   }
 
   get filterClass(): string {
-    let str = 'flex items-center flex-wrap row-start-2 sm:row-start-auto sm:col-span-1 ';
+    let str = 'flex items-center overflow-hidden flex-wrap row-start-2 sm:row-start-auto sm:col-span-1 ';
     // Move to second column if using search-on-top layout and check-all checkbox is in first column
     str += this.mobileSearchOnTop && this.checkable && this.showCheckAll ? 'col-start-2' : 'col-span-full';
     return str;

--- a/src/tailwind/mx-table/index.scss
+++ b/src/tailwind/mx-table/index.scss
@@ -7,6 +7,13 @@
     }
   }
 
+  [slot='filter'] {
+    @apply max-w-full;
+    & > * {
+      @apply max-w-full;
+    }
+  }
+
   .table-grid > *:not(.hidden) {
     /* Only place table cell elements into the grid (not row elements). */
     @apply contents;


### PR DESCRIPTION
This fixes overflow issues that surfaced in nucleus with filter menu buttons.

Before:

![image](https://user-images.githubusercontent.com/3342530/159927192-9f2b6c42-c8bb-446e-b515-1e0ae190887d.png)


After:

![image](https://user-images.githubusercontent.com/3342530/159926785-efc2f8b5-3f56-427f-814a-076fe442c9a2.png)
