### PR TITLE
ENG-144581 - Set operations bar columns to auto so they wrap

### DIFF
--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -525,7 +525,7 @@ export class MxTable {
     if (this.minWidths.sm) {
       // On larger screens, use a three-column grid
       return {
-        gridTemplateColumns: 'max-content 1fr max-content',
+        gridTemplateColumns: 'auto 1fr auto',
       };
     } else if (this.checkable && this.showCheckAll) {
       // If checkbox on mobile, use a two-column grid


### PR DESCRIPTION
Using `max-content` sets the column widths to the unwrapped widths, which causes the grid to overflow the container width.