### PR TITLE
ENG-144889 - Keep error attribute in sync with error property

### DIFF
--- a/src/components/mx-confirm-input/mx-confirm-input.tsx
+++ b/src/components/mx-confirm-input/mx-confirm-input.tsx
@@ -25,7 +25,7 @@ export class MxConfirmInput implements IMxInputProps {
   @Prop() suffix: string;
   @Prop() outerContainerClass: string = '';
   @Prop({ mutable: true }) labelClass: string = '';
-  @Prop({ mutable: true }) error: boolean = false;
+  @Prop({ mutable: true, reflect: true }) error: boolean = false;
   @Prop() assistiveText: string;
   @Prop() floatLabel: boolean = false;
   @Prop() textarea: boolean = false;

--- a/src/components/mx-date-picker/mx-date-picker.tsx
+++ b/src/components/mx-date-picker/mx-date-picker.tsx
@@ -32,7 +32,7 @@ export class MxDatePicker {
   @Prop() disabled: boolean = false;
   /** The aria-label attribute for the inner input element. */
   @Prop() elAriaLabel: string;
-  @Prop({ mutable: true }) error: boolean = false;
+  @Prop({ mutable: true, reflect: true }) error: boolean = false;
   @Prop() floatLabel: boolean = false;
   /** The `id` attribute for the internal input element */
   @Prop() inputId: string;

--- a/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
+++ b/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
@@ -28,7 +28,7 @@ export class MxDropdownMenu {
   @Prop() suffix: string;
   @Prop({ mutable: true }) value: any;
 
-  @Prop({ mutable: true }) error: boolean;
+  @Prop({ mutable: true, reflect: true }) error: boolean;
   @Prop() assistiveText: string;
 
   @State() isFocused: boolean = false;

--- a/src/components/mx-input/mx-input.tsx
+++ b/src/components/mx-input/mx-input.tsx
@@ -68,7 +68,7 @@ export class MxInput implements IMxInputProps {
   @Prop() suffix: string;
   @Prop() outerContainerClass: string = '';
   @Prop({ mutable: true }) labelClass: string = '';
-  @Prop({ mutable: true }) error: boolean = false;
+  @Prop({ mutable: true, reflect: true }) error: boolean = false;
   @Prop() assistiveText: string;
   @Prop() floatLabel: boolean = false;
   /** Display a multi-line `textarea` instead of an `input` */

--- a/src/components/mx-select/mx-select.tsx
+++ b/src/components/mx-select/mx-select.tsx
@@ -30,7 +30,7 @@ export class MxSelect {
   @Prop() name: string;
   /** Text shown to the left of the arrow */
   @Prop() suffix: string;
-  @Prop({ mutable: true }) error: boolean = false;
+  @Prop({ mutable: true, reflect: true }) error: boolean = false;
   /** Additional classes for the label */
   @Prop({ mutable: true }) labelClass: string = '';
   @Prop({ mutable: true }) value: any;

--- a/src/components/mx-time-picker/mx-time-picker.tsx
+++ b/src/components/mx-time-picker/mx-time-picker.tsx
@@ -27,7 +27,7 @@ export class MxTimePicker {
   @Prop() disabled: boolean = false;
   /** The aria-label attribute for the inner input element. */
   @Prop() elAriaLabel: string;
-  @Prop({ mutable: true }) error: boolean = false;
+  @Prop({ mutable: true, reflect: true }) error: boolean = false;
   @Prop() floatLabel: boolean = false;
   /** The `id` attribute for the internal input element */
   @Prop() inputId: string;


### PR DESCRIPTION
Keeping the `error` attribute for form components in sync with the prop ensures we can do things like `HTMLFormElement.querySelectorAll('[error]')` reliably.