### PR TITLE
ENG-144356 - Fix intermittent wrong collapsed row height

### DIFF
--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -73,7 +73,7 @@ export class MxTableRow {
 
   @Watch('minWidths')
   async onMinWidthsChange() {
-    this.resetResizeObserver();
+    // this.resetResizeObserver();
     if (!this.collapseNestedRows) return;
     // Ensure that collapsed, nested rows are hidden after switching to/from mobile UI
     await new Promise(requestAnimationFrame);


### PR DESCRIPTION
This adds a `ResizeObserver` to `mx-table-row` that sets the appropriate `max-height` values when the row is collapsed on mobile.  Without the observer, the calculated height was not always correct if the row content happened to wrap after the initial render tick.


Before (2nd row's height does not grow when text wraps):

![Apr-04-2022 14-15-02](https://user-images.githubusercontent.com/3342530/161606263-01daaec1-f196-44f1-8b9a-345c26e1895f.gif)

After:

![Apr-04-2022 14-15-37](https://user-images.githubusercontent.com/3342530/161606276-0819b456-bc81-4c1c-9c70-e0dd77ea9428.gif)
