### PR TITLE
ENG-145350: Update snackbar button color, as well as documentation

### DIFF
--- a/src/components/mx-snackbar/mx-snackbar.tsx
+++ b/src/components/mx-snackbar/mx-snackbar.tsx
@@ -13,13 +13,16 @@ export class MxSnackbar {
   durationTimer: NodeJS.Timeout;
   queueItem: { resolve: Function; reject: Function };
 
+  /** The duration in milliseconds to show the snackbar before automatically closing. */
   @Prop() duration = 6000;
+  /** Toggles the visibility of the snackbar. */
   @Prop({ mutable: true, reflect: true }) isOpen = false;
 
   @State() isVisible = false;
 
   @Element() element: HTMLMxSnackbarElement;
 
+  /** Emitted after the snackbar closes (by any means). */
   @Event() mxClose: EventEmitter<void>;
 
   @Watch('isOpen')

--- a/src/tailwind/mx-snackbar/index.scss
+++ b/src/tailwind/mx-snackbar/index.scss
@@ -1,4 +1,7 @@
 .mx-snackbar-alert {
   background: var(--mds-bg-snackbar);
   color: var(--mds-text-snackbar);
+  button:not(:hover, :focus-within) {
+    --mds-text-btn-text: var(--mds-text-snackbar-btn);
+  }
 }

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -394,6 +394,7 @@
   /* Snackbars */
   --mds-bg-snackbar: #202020;
   --mds-text-snackbar: #fff;
+  --mds-text-snackbar-btn: #00b8ff;
   /* #endregion snackbars */
 
   /* #region uploads */

--- a/vuepress/components/snackbars.md
+++ b/vuepress/components/snackbars.md
@@ -36,16 +36,16 @@ If multiple snackbars are triggered, they will be queued and displayed consecuti
 
 ### Properties
 
-| Property   | Attribute  | Description | Type      | Default |
-| ---------- | ---------- | ----------- | --------- | ------- |
-| `duration` | `duration` |             | `number`  | `6000`  |
-| `isOpen`   | `is-open`  |             | `boolean` | `false` |
+| Property   | Attribute  | Description                                                                     | Type      | Default |
+| ---------- | ---------- | ------------------------------------------------------------------------------- | --------- | ------- |
+| `duration` | `duration` | The duration in milliseconds to show the snackbar before automatically closing. | `number`  | `6000`  |
+| `isOpen`   | `is-open`  | Toggles the visibility of the snackbar.                                         | `boolean` | `false` |
 
 ### Events
 
-| Event     | Description | Type                |
-| --------- | ----------- | ------------------- |
-| `mxClose` |             | `CustomEvent<void>` |
+| Event     | Description                                       | Type                |
+| --------- | ------------------------------------------------- | ------------------- |
+| `mxClose` | Emitted after the snackbar closes (by any means). | `CustomEvent<void>` |
 
 ### CSS Variables
 


### PR DESCRIPTION
This updates the default text color of action buttons inside snackbars to use a new `--mds-text-snackbar-btn` variable.  The default value is a lighter blue that meets WCAG contrast requirements when used against the dark snackbar background, unlike the default color for text buttons.

I also added descriptions to the prop and event tables in the snackbar documentation.

Before:

![MicrosoftTeams-image](https://user-images.githubusercontent.com/3342530/163006898-1fd66c51-4d55-4b75-9c31-e6f051c09e73.png)
![image](https://user-images.githubusercontent.com/3342530/163007934-4a15ded1-0848-4e0a-9684-0a8c3adf7587.png)


After:

![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/3342530/163006907-23358117-7a6c-49fc-8ec1-e8305173b3e7.png)
![image](https://user-images.githubusercontent.com/3342530/163007906-68f1a947-0b9c-4f76-93f5-866572fd7805.png)
