### PR TITLE
Fix icon list; Fix a11y issue with empty menus

### DIFF
--- a/src/components/mx-menu/mx-menu.tsx
+++ b/src/components/mx-menu/mx-menu.tsx
@@ -183,8 +183,10 @@ export class MxMenu {
 
   componentDidLoad() {
     this.setInputEl();
-    const role = !!this.element.querySelector('[role="option"]') ? 'listbox' : 'menu';
-    this.scrollElem.setAttribute('role', role);
+    if (this.menuItems.length) {
+      const role = !!this.element.querySelector('[role="option"]') ? 'listbox' : 'menu';
+      this.scrollElem.setAttribute('role', role);
+    }
     this.setTriggerElAttributes();
   }
 

--- a/vuepress/components/icons.md
+++ b/vuepress/components/icons.md
@@ -43,8 +43,9 @@ export default {
         try {
           stylesheet.rules.forEach(rule => {
             if (!rule || !rule.selectorText) return
-            if (rule.selectorText.startsWith('.mds-') && !rule.selectorText.includes('::')) {
-              this.icons.push(rule.selectorText.slice(1))
+            if (rule.selectorText.includes('.mds-') && !rule.selectorText.includes('::')) {
+              const split = rule.selectorText.split('.')
+              this.icons.push(split[split.length - 1])
             }
           })
         } catch (err) {


### PR DESCRIPTION
A couple small fixes:
- The `role="menu"` attribute is now only added if a menu actually has child menu items.  This applies to autocomplete menus that can become empty when there are no matching items, for example.
- Fixed the auto-generated icon list on the Icon documentation page.  This broke when all the icon classes were scoped to the `.mds` container in a previous PR.