### PR TITLE
Fix generated icon list

### DIFF
--- a/vuepress/components/icons.md
+++ b/vuepress/components/icons.md
@@ -39,9 +39,9 @@ export default {
   },
   methods: {
     getIcons() {
-      document.styleSheets.forEach(stylesheet => {
+      [...document.styleSheets].forEach(stylesheet => {
         try {
-          stylesheet.rules.forEach(rule => {
+          [...stylesheet.cssRules].forEach(rule => {
             if (!rule || !rule.selectorText) return
             if (rule.selectorText.includes('.mds-') && !rule.selectorText.includes('::')) {
               const split = rule.selectorText.split('.')


### PR DESCRIPTION
This fixes the generated icon list (again).  The list worked fine when running `yarn dev`, but I'm really not sure how.  Neither [`StyleSheetList`](https://developer.mozilla.org/en-US/docs/Web/API/StyleSheetList) nor [`CCSRuleList`](https://developer.mozilla.org/en-US/docs/Web/API/CSSRuleList) support `forEach`, so they needed to be converted to arrays.

I also switched to using `CSSStyleSheet.cssRules` instead of `rules` because `rules` is deprecated apparently.

I built the docs and served them up locally to verify this fixes things.