### PR TITLE
Add `target` prop to icon buttons

### DIFF
--- a/src/components/mx-icon-button/mx-icon-button.tsx
+++ b/src/components/mx-icon-button/mx-icon-button.tsx
@@ -16,6 +16,8 @@ export class MxIconButton {
   @Prop() value: string;
   /** Create button as link */
   @Prop() href: string;
+  /** Only for link buttons */
+  @Prop() target: string;
   @Prop({ reflect: true }) disabled: boolean = false;
   /** The aria-label attribute for the inner button element. */
   @Prop() elAriaLabel: string;
@@ -74,6 +76,7 @@ export class MxIconButton {
           formaction={this.formaction}
           value={this.value}
           href={this.href}
+          target={this.href ? this.target : null}
           class="flex text-current appearance-none items-center w-48 h-48 rounded-full justify-center relative overflow-hidden cursor-pointer disabled:pointer-events-none disabled:cursor-auto"
           ref={el => (this.btnElem = el as HTMLButtonElement)}
           disabled={this.disabled}

--- a/src/components/mx-icon-button/test/mx-icon-button.spec.tsx
+++ b/src/components/mx-icon-button/test/mx-icon-button.spec.tsx
@@ -106,4 +106,10 @@ describe('mx-icon-button (as link)', () => {
     expect(button.getAttribute('class')).toContain('h-48');
     expect(button.getAttribute('class')).toContain('rounded-full');
   });
+
+  it('uses the target prop as the target attribute on the link', async () => {
+    root.target = '_blank';
+    await page.waitForChanges();
+    expect(button.getAttribute('target')).toBe('_blank');
+  });
 });

--- a/vuepress/components/buttons.md
+++ b/vuepress/components/buttons.md
@@ -4,7 +4,7 @@ Buttons are used to indicate calls to actions (CTAs) that the user can take (e.g
 
 ## Primary Buttons
 
-Contained buttons using the primary brandable color as a fill. Other than FAB, they have the highest level of emphasis. Commonly used at the top of page headers, within modals, and empty states. These are usually for the main action on a page. Avoid grouping multiple primary buttons together or using them for less important actions. 
+Contained buttons using the primary brandable color as a fill. Other than FAB, they have the highest level of emphasis. Commonly used at the top of page headers, within modals, and empty states. These are usually for the main action on a page. Avoid grouping multiple primary buttons together or using them for less important actions.
 
 <!-- #region primary-buttons -->
 <section class="mds">
@@ -168,8 +168,6 @@ Pill shaped buttons that can also have a leading or trailing icon. These are low
 
 <<< @/vuepress/components/buttons.md#simple-buttons
 
-
-
 ### Button Properties
 
 | Property      | Attribute       | Description                                            | Type                                                          | Default       |
@@ -247,6 +245,7 @@ Icon buttons are round buttons that only contain an icon. The icon can be set th
 | `formaction`   | `formaction`    |                                                        | `string`                          | `undefined` |
 | `href`         | `href`          | Create button as link                                  | `string`                          | `undefined` |
 | `icon`         | `icon`          | Class name of icon (for icon font)                     | `string`                          | `undefined` |
+| `target`       | `target`        | Only for link buttons                                  | `string`                          | `undefined` |
 | `type`         | `type`          |                                                        | `"button" \| "reset" \| "submit"` | `'button'`  |
 | `value`        | `value`         |                                                        | `string`                          | `undefined` |
 


### PR DESCRIPTION
This updates `mx-icon-button` to have a `target` prop just like `mx-button` already has.

Once this change is in nucleus, the arrow button for a Quick Action will open the link in a new tab (matching the behavior of the text links).