### PR TITLE
Fix disabled toggle button group still emitting `mxInput` events; Fix double bullets in docs

### DIFF
--- a/src/components/mx-toggle-button-group/mx-toggle-button-group.tsx
+++ b/src/components/mx-toggle-button-group/mx-toggle-button-group.tsx
@@ -26,7 +26,7 @@ export class MxToggleButtonGroup {
   @Listen('click')
   onToggleButtonClick(e: MouseEvent) {
     const toggleButton: HTMLMxToggleButtonElement = (e.target as HTMLElement).closest('mx-toggle-button');
-    if (!toggleButton) return;
+    if (!toggleButton || toggleButton.disabled) return;
     this.toggleValue(toggleButton.value);
     this.mxInput.emit(this.value);
   }

--- a/vuepress/components/buttons.md
+++ b/vuepress/components/buttons.md
@@ -190,9 +190,9 @@ Pill shaped buttons that can also have a leading or trailing icon. These are low
 
 Icon buttons are round buttons that only contain an icon. The icon can be set three different ways:
 
-- &bull; the class name of an icon in the icon font library (i.e. [Phosphor Icons](/getting-started.html#phosphor-icons)) via the `icon` prop,
-- &bull; an SVG passed into the default slot,
-- &bull; or one of the built-in elevated chevron icons via the `chevron-dropdown`, `chevron-left`, and `chevron-right` props.
+- the class name of an icon in the icon font library (i.e. [Phosphor Icons](/getting-started.html#phosphor-icons)) via the `icon` prop,
+- an SVG passed into the default slot,
+- or one of the built-in elevated chevron icons via the `chevron-dropdown`, `chevron-left`, and `chevron-right` props.
 
 <!-- #region icon-buttons -->
 <section class="mds">

--- a/vuepress/components/inputs.md
+++ b/vuepress/components/inputs.md
@@ -118,9 +118,9 @@ Icons that are embedded in the design system are also available.
 
 The `mx-confirm-input` component wraps the `mx-input` component, and provides additional edit-in-place behaviors.
 
-- &bull; If a `value` is present, the input has no border or background color when not hovered or focused.
-- &bull; If <kbd>Escape</kbd> is pressed, or if the <i class="mds-x"></i> icon is clicked, then changes inside the input are discarded.
-- &bull; If <kbd>Enter</kbd> is pressed, or if the <i class="mds-check"></i> icon is clicked, then the `value` is updated and an `input` event is fired.
+- If a `value` is present, the input has no border or background color when not hovered or focused.
+- If <kbd>Escape</kbd> is pressed, or if the <i class="mds-x"></i> icon is clicked, then changes inside the input are discarded.
+- If <kbd>Enter</kbd> is pressed, or if the <i class="mds-check"></i> icon is clicked, then the `value` is updated and an `input` event is fired.
 
 <section class="mds">
   <div class="space-y-20 my-40">

--- a/vuepress/components/menus.md
+++ b/vuepress/components/menus.md
@@ -101,10 +101,10 @@ additional behaviors to allow the menu to function as an autocomplete or suggest
 
 These additional behaviors include:
 
-- &bull; The menu stretches the entire width of the `anchorEl`.
-- &bull; Typing into the input opens the menu.
-- &bull; Typing while a menu item is focused restores focus to the input.
-- &bull; The input's `autocomplete` attribute is set to `off` to disable the browser's native autocomplete menu.
+- The menu stretches the entire width of the `anchorEl`.
+- Typing into the input opens the menu.
+- Typing while a menu item is focused restores focus to the input.
+- The input's `autocomplete` attribute is set to `off` to disable the browser's native autocomplete menu.
 
 Setting the `autocompleteOnly` prop to `true` causes the top menu item to always be selected by default,
 and pressing <kbd>Enter</kbd> inside the input will effectively click that item. Leave this set to `false` to

--- a/vuepress/components/modals.md
+++ b/vuepress/components/modals.md
@@ -6,14 +6,14 @@ To open or close a modal, set its `isOpen` prop to `true` or `false`. The modal 
 
 The modal component uses a [Page Header](/page-headers.html) internally. The `previousPageUrl`, `previousPageTitle`, and `buttons` props are passed to that Page Header. Additionally, the `mx-modal` component has eight slots for content:
 
-- &bull; The default, unnamed slot is for the main modal content.
-- &bull; `card` - This content will appear in a card-like container with rounded corners.
-- &bull; `header-left` - Place heading text in this slot.
-- &bull; `header-center` - This content appears to the right of the heading text.
-- &bull; `header-right` - This contains a Close button unless overridden.
-- &bull; `header-bottom` - This slot is for content that should appear below the header text, such as tabs.
-- &bull; `footer-left` - This slot contains the previous page link (if the `previousPageUrl` prop is provided).
-- &bull; `footer-right` - If the `buttons` prop is provided, this slot contains those buttons by default.
+- The default, unnamed slot is for the main modal content.
+- `card` - This content will appear in a card-like container with rounded corners.
+- `header-left` - Place heading text in this slot.
+- `header-center` - This content appears to the right of the heading text.
+- `header-right` - This contains a Close button unless overridden.
+- `header-bottom` - This slot is for content that should appear below the header text, such as tabs.
+- `footer-left` - This slot contains the previous page link (if the `previousPageUrl` prop is provided).
+- `footer-right` - If the `buttons` prop is provided, this slot contains those buttons by default.
 
 On small screens, the modal will fill the screen, except for a 24-px margin at the top. On larger screens, the max dimensions are based on whether the `large` prop is set. If `large` is `true`, the modal will stretch to nearly fill the entire page (with a 40px margin) up to 1200px; otherwise, the max dimensions are 800x600px.
 

--- a/vuepress/components/page-headers.md
+++ b/vuepress/components/page-headers.md
@@ -2,9 +2,9 @@
 
 The Page Header component displays the heading text of a page, and may also contain:
 
-- &bull; a link to the previous page,
-- &bull; primary, secondary, and tertiary [buttons](/components/buttons.html),
-- &bull; and [tabs](/components/tabs.html).
+- a link to the previous page,
+- primary, secondary, and tertiary [buttons](/components/buttons.html),
+- and [tabs](/components/tabs.html).
 
 On smaller screens, the size of the text and buttons will be reduced. Additionally, if there is not enough room on small screens for the tertiary button, it will be converted into a small menu button.
 

--- a/vuepress/components/tables.md
+++ b/vuepress/components/tables.md
@@ -2,8 +2,8 @@
 
 The `mx-table` component can be used one of two ways:
 
-- &bull; by providing an array of data via the `rows` prop, allowing the table to automatically generate rows and cells
-- &bull; by templating the rows and cells manually using `mx-table-row` and `mx-table-cell` components
+- by providing an array of data via the `rows` prop, allowing the table to automatically generate rows and cells
+- by templating the rows and cells manually using `mx-table-row` and `mx-table-cell` components
 
 On smaller, mobile-sized screens, the Data Table component shows one column of data at a time for each row, though rows may be expanded to reveal the remaining data.
 


### PR DESCRIPTION
- Fixed `mx-toggle-button-group` emitting `mxInput` even when a disabled toggle button is clicked.
- Removed all the `&bull;` bullets in the docs that were previously added when the tailwind reset was applied globally.