### PR TITLE
Remove overflow rule that breaks layout

### DIFF
--- a/vuepress/.vuepress/styles/index.styl
+++ b/vuepress/.vuepress/styles/index.styl
@@ -1,7 +1,6 @@
 html, body, #app, .theme-container.no-sidebar
   height: 100%;
   min-height: 100%;
-  overflow: auto;
 
 *
   box-sizing: border-box;


### PR DESCRIPTION
This line was previously added when the tailwind preflight was scoped under `.mds`, but this was causing a weird double scrollbar issue on some pages, which in turn would sometimes cause the table row dragging to break.