### PR TITLE
Add better handling for missing or invalid `columns` prop

### DIFF
--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -445,7 +445,7 @@ export class MxTable {
     // Emit paginated rows right away.
     this.onVisibleRowsChange();
     if (!this.columns.length) console.warn('No "columns" prop was provided.');
-    if (this.columns.length !== this.cols.length)
+    else if (this.columns.length !== this.cols.length)
       console.warn(`The number of columns in the "columns" prop does not match the number of columns in the table.`);
   }
 

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -460,7 +460,7 @@ export class MxTable {
       return Object.keys(this.rows[0]).map(property => ({ property, heading: capitalize(property), sortable: true }));
     } else if (this.hasDefaultSlot) {
       // If `columns` prop is missing or does not have enough defintions for all columns, add default columns
-      const rows = this.getTableRows();
+      const rows = this.getTableRows().filter(row => !row.subheader);
       if (rows.length) {
         const cellCount = rows[0].querySelectorAll('mx-table-cell').length;
         if (cellCount !== cols.length) {


### PR DESCRIPTION
This adds better handling and warnings for these `mx-table` scenarios:
- **The `columns` prop is not provided for a custom templated table**: Instead of throwing an exception, the header row will now consist of only empty cells, and a warning will be shown in the console.
- **The `columns` prop does not have enough definitions for all the columns in the template**:  The extra columns will now have empty cells in the header row, and a different warning will be shown in the console.
- **Some (but not all) rows have more cells than are defined**:  An error will be shown in the console.

![image](https://user-images.githubusercontent.com/3342530/175380066-abedcfb1-e8f3-4502-8651-2032a9e21701.png)
![image](https://user-images.githubusercontent.com/3342530/175380120-cfe5de10-1558-4432-bb9c-b82f5d88ad6f.png)
![image](https://user-images.githubusercontent.com/3342530/175383573-25d93c30-6341-407b-8a96-f99fe9df23ae.png)
