### PR TITLE
Add `chevron-up` icon and `chevronUp` icon button

### DIFF
--- a/src/components/mx-icon-button/mx-icon-button.tsx
+++ b/src/components/mx-icon-button/mx-icon-button.tsx
@@ -27,6 +27,8 @@ export class MxIconButton {
   @Prop() chevronLeft = false;
   /** Show right-pointing chevron icon */
   @Prop() chevronRight = false;
+  /** Show upward chevron icon */
+  @Prop() chevronUp = false;
   /** Class name of icon (for icon font) */
   @Prop() icon: string;
 
@@ -43,7 +45,7 @@ export class MxIconButton {
   }
 
   get isChevron() {
-    return this.chevronDown || this.chevronLeft || this.chevronRight;
+    return this.chevronDown || this.chevronLeft || this.chevronRight || this.chevronUp;
   }
 
   render() {
@@ -60,7 +62,13 @@ export class MxIconButton {
             <i
               data-testid="chevron"
               class={
-                this.chevronLeft ? 'mds-chevron-left' : this.chevronRight ? 'mds-chevron-right' : 'mds-chevron-down'
+                this.chevronLeft
+                  ? 'mds-chevron-left'
+                  : this.chevronRight
+                  ? 'mds-chevron-right'
+                  : this.chevronUp
+                  ? 'mds-chevron-up'
+                  : 'mds-chevron-down'
               }
             ></i>
           </span>

--- a/src/tailwind/icons.scss
+++ b/src/tailwind/icons.scss
@@ -60,6 +60,10 @@
   .mds-chevron-right {
     mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.58997 16.59L13.17 12L8.58997 7.41L9.99997 6L16 12L9.99997 18L8.58997 16.59Z' fill='currentColor'/%3E%3C/svg%3E");
   }
+  .mds-chevron-up {
+    transform: rotate(180deg);
+    mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16.8849 9L12.2949 13.58L7.70492 9L6.29492 10.41L12.2949 16.41L18.2949 10.41L16.8849 9Z' fill='currentColor' fill-opacity='0.88'/%3E%3C/svg%3E");
+  }
   .mds-clock {
     mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 3.75C7.44365 3.75 3.75 7.44365 3.75 12C3.75 16.5563 7.44365 20.25 12 20.25C16.5563 20.25 20.25 16.5563 20.25 12C20.25 7.44365 16.5563 3.75 12 3.75ZM2.25 12C2.25 6.61522 6.61522 2.25 12 2.25C17.3848 2.25 21.75 6.61522 21.75 12C21.75 17.3848 17.3848 21.75 12 21.75C6.61522 21.75 2.25 17.3848 2.25 12Z' fill='currentColor' fill-opacity='0.87' /%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 6C12.4142 6 12.75 6.33579 12.75 6.75V11.25H17.25C17.6642 11.25 18 11.5858 18 12C18 12.4142 17.6642 12.75 17.25 12.75H12C11.5858 12.75 11.25 12.4142 11.25 12V6.75C11.25 6.33579 11.5858 6 12 6Z' fill='currentColor' fill-opacity='0.87'/%3E%3C/svg%3E");
   }

--- a/vuepress/components/buttons.md
+++ b/vuepress/components/buttons.md
@@ -208,6 +208,7 @@ Icon buttons are round buttons that only contain an icon. The icon can be set th
         <mx-icon-button chevron-down el-aria-label="Down" />
         <mx-icon-button chevron-left el-aria-label="Left" />
         <mx-icon-button chevron-right el-aria-label="Right" />
+        <mx-icon-button chevron-up el-aria-label="Up" />
         <mx-icon-button icon="ph-link" href="/" el-aria-label="Link" />
       </div>
     </div>
@@ -223,6 +224,7 @@ Icon buttons are round buttons that only contain an icon. The icon can be set th
         <mx-icon-button chevron-down disabled el-aria-label="Down" />
         <mx-icon-button chevron-left disabled el-aria-label="Left" />
         <mx-icon-button chevron-right disabled el-aria-label="Right" />
+        <mx-icon-button chevron-up disabled el-aria-label="Up" />
         <mx-icon-button icon="ph-link" href="/" disabled el-aria-label="Link" />
       </div>
     </div>
@@ -239,6 +241,7 @@ Icon buttons are round buttons that only contain an icon. The icon can be set th
 | `chevronDown`  | `chevron-down`  | Show downward chevron icon                             | `boolean`                         | `false`     |
 | `chevronLeft`  | `chevron-left`  | Show left-pointing chevron icon                        | `boolean`                         | `false`     |
 | `chevronRight` | `chevron-right` | Show right-pointing chevron icon                       | `boolean`                         | `false`     |
+| `chevronUp`    | `chevron-up`    | Show upward chevron icon                               | `boolean`                         | `false`     |
 | `disabled`     | `disabled`      |                                                        | `boolean`                         | `false`     |
 | `elAriaLabel`  | `el-aria-label` | The aria-label attribute for the inner button element. | `string`                          | `undefined` |
 | `form`         | `form`          |                                                        | `string`                          | `undefined` |


### PR DESCRIPTION
An upward-pointing chevron icon button is needed for the notifications feature in nucleus.