### PR TITLE
Fix wrong snippet shown for modal example

### DIFF
--- a/vuepress/components/modals.md
+++ b/vuepress/components/modals.md
@@ -174,7 +174,7 @@ If `fromLeft` or `fromRight` are set, then the modal will appear fixed to one si
 </section>
 <!-- #endregion modals-4 -->
 
-<<< @/vuepress/components/modals.md#modals-5
+<<< @/vuepress/components/modals.md#modals-4
 
 ### Modal that opens from the right on larger screens
 


### PR DESCRIPTION
The fourth modal example was showing the code snippet for the fifth example.