### PR TITLE
Add `simulateProgressDuration` prop to progress indicators (#204)

### DIFF
--- a/src/components/mx-circular-progress/mx-circular-progress.tsx
+++ b/src/components/mx-circular-progress/mx-circular-progress.tsx
@@ -29,6 +29,7 @@ export class MxCircularProgress {
     clearInterval(this.simulateProgressInterval);
     if (!this.simulateProgressDuration) return;
     this.simulateProgressInterval = setInterval(() => {
+      if (this.value === 100) return;
       this.value = Math.min((this.value || 0) + 1, 99);
     }, this.simulateProgressDuration / 100);
   }

--- a/src/components/mx-circular-progress/mx-circular-progress.tsx
+++ b/src/components/mx-circular-progress/mx-circular-progress.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { Component, Host, h, Prop, Element, Watch } from '@stencil/core';
 
 const DIAMETER = 44;
 const THICKNESS = 3.6;
@@ -11,17 +11,30 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 })
 export class MxCircularProgress {
   delayTimeout;
+  simulateProgressInterval;
 
   /** The progress percentage from 0 to 100. If not provided (or set to `null`), an indeterminate progress indicator will be displayed. */
-  @Prop() value: number = null;
+  @Prop({ mutable: true }) value: number = null;
   /** The value to use for the width and height */
   @Prop() size = '3rem';
+  /** If provided, the indicator will simulate progress toward 99% over the given duration (milliseconds). */
+  @Prop() simulateProgressDuration: number = null;
   /** Delay the appearance of the indicator for this many milliseconds */
   @Prop() appearDelay = 0;
 
   @Element() element: HTMLMxLinearProgressElement;
 
+  @Watch('simulateProgressDuration')
+  simulateProgress() {
+    clearInterval(this.simulateProgressInterval);
+    if (!this.simulateProgressDuration) return;
+    this.simulateProgressInterval = setInterval(() => {
+      this.value = Math.min((this.value || 0) + 1, 99);
+    }, this.simulateProgressDuration / 100);
+  }
+
   connectedCallback() {
+    this.simulateProgress();
     if (!this.appearDelay) return;
     // Hide indicator until appearDelay duration has passed
     this.element.classList.remove('block');

--- a/src/components/mx-linear-progress/mx-linear-progress.tsx
+++ b/src/components/mx-linear-progress/mx-linear-progress.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { Component, Host, h, Prop, Element, Watch } from '@stencil/core';
 
 @Component({
   tag: 'mx-linear-progress',
@@ -6,15 +6,28 @@ import { Component, Host, h, Prop, Element } from '@stencil/core';
 })
 export class MxLinearProgress {
   delayTimeout;
+  simulateProgressInterval;
 
   /** The progress percentage from 0 to 100. If not provided (or set to `null`), an indeterminate progress indicator will be displayed. */
-  @Prop() value: number = null;
+  @Prop({ mutable: true }) value: number = null;
+  /** If provided, the indicator will simulate progress toward 99% over the given duration (milliseconds). */
+  @Prop() simulateProgressDuration: number = null;
   /** Delay the appearance of the indicator for this many milliseconds */
   @Prop() appearDelay = 0;
 
   @Element() element: HTMLMxLinearProgressElement;
 
+  @Watch('simulateProgressDuration')
+  simulateProgress() {
+    clearInterval(this.simulateProgressInterval);
+    if (!this.simulateProgressDuration) return;
+    this.simulateProgressInterval = setInterval(() => {
+      this.value = Math.min((this.value || 0) + 1, 99);
+    }, this.simulateProgressDuration / 100);
+  }
+
   connectedCallback() {
+    this.simulateProgress();
     if (!this.appearDelay) return;
     // Hide indicator until appearDelay duration has passed
     this.element.classList.remove('block');

--- a/src/components/mx-linear-progress/mx-linear-progress.tsx
+++ b/src/components/mx-linear-progress/mx-linear-progress.tsx
@@ -22,6 +22,7 @@ export class MxLinearProgress {
     clearInterval(this.simulateProgressInterval);
     if (!this.simulateProgressDuration) return;
     this.simulateProgressInterval = setInterval(() => {
+      if (this.value === 100) return;
       this.value = Math.min((this.value || 0) + 1, 99);
     }, this.simulateProgressDuration / 100);
   }

--- a/vuepress/components/progress.md
+++ b/vuepress/components/progress.md
@@ -1,5 +1,7 @@
 # Progress Indicators
 
+Two types of progress indicators are provided: circular and linear. They may be given a percentage `value` to display; otherwise, they will animate to indicate indeterminate progress. Additionally, a `simulateProgressDuration` may be provided in order to "fake" determinate progress over the specified time.
+
 ## Circular
 
 <section class="mds">
@@ -17,6 +19,10 @@
         <mx-circular-progress aria-label="Progress" value="100" />
         <mx-circular-progress aria-label="Progress" :value="progress" />
       </div>
+    </div>
+    <div class="flex flex-col space-y-20">
+      <strong>Simulated Progress (reaches 99% in 10 seconds)</strong>
+      <mx-circular-progress aria-label="Progress" simulate-progress-duration="10000" />
     </div>
     <div class="flex flex-col space-y-20">
       <strong>Custom Sizes</strong>
@@ -51,6 +57,10 @@
         <mx-linear-progress aria-label="Progress" :value="progress" />
       </div>
     </div>
+    <div class="flex flex-col space-y-20">
+      <strong>Simulated Progress (reaches 99% in 10 seconds)</strong>
+      <mx-linear-progress aria-label="Progress" simulate-progress-duration="10000" />
+    </div>
   </div>
 <!-- #endregion linear-progress -->
 </section>
@@ -78,18 +88,20 @@ If you only want to show a progress indicator when a task is taking longer to fi
 
 ### Circular Progress Properties
 
-| Property      | Attribute      | Description                                                                                                                       | Type     | Default  |
-| ------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- |
-| `appearDelay` | `appear-delay` | Delay the appearance of the indicator for this many milliseconds                                                                  | `number` | `0`      |
-| `size`        | `size`         | The value to use for the width and height                                                                                         | `string` | `'3rem'` |
-| `value`       | `value`        | The progress percentage from 0 to 100. If not provided (or set to `null`), an indeterminate progress indicator will be displayed. | `number` | `null`   |
+| Property                   | Attribute                    | Description                                                                                                                       | Type     | Default  |
+| -------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- |
+| `appearDelay`              | `appear-delay`               | Delay the appearance of the indicator for this many milliseconds                                                                  | `number` | `0`      |
+| `simulateProgressDuration` | `simulate-progress-duration` | If provided, the indicator will simulate progress toward 99% over the given duration (milliseconds).                              | `number` | `null`   |
+| `size`                     | `size`                       | The value to use for the width and height                                                                                         | `string` | `'3rem'` |
+| `value`                    | `value`                      | The progress percentage from 0 to 100. If not provided (or set to `null`), an indeterminate progress indicator will be displayed. | `number` | `null`   |
 
 ### Linear Progress Properties
 
-| Property      | Attribute      | Description                                                                                                                       | Type     | Default |
-| ------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| `appearDelay` | `appear-delay` | Delay the appearance of the indicator for this many milliseconds                                                                  | `number` | `0`     |
-| `value`       | `value`        | The progress percentage from 0 to 100. If not provided (or set to `null`), an indeterminate progress indicator will be displayed. | `number` | `null`  |
+| Property                   | Attribute                    | Description                                                                                                                       | Type     | Default |
+| -------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| `appearDelay`              | `appear-delay`               | Delay the appearance of the indicator for this many milliseconds                                                                  | `number` | `0`     |
+| `simulateProgressDuration` | `simulate-progress-duration` | If provided, the indicator will simulate progress toward 99% over the given duration (milliseconds).                              | `number` | `null`  |
+| `value`                    | `value`                      | The progress percentage from 0 to 100. If not provided (or set to `null`), an indeterminate progress indicator will be displayed. | `number` | `null`  |
 
 ### CSS Variables
 


### PR DESCRIPTION
This adds a `simulateProgressDuration` prop to the `mx-linear-progress` and `mx-circular-progress` components.

If given a duration of 500 milliseconds, for example, the component will artificially advance the progress 1% every 5ms, stopping at 99%.  The indicator will only show 100% once the `value` prop is set to `100`.

Addresses #204