### PR TITLE
Fix React exports not working with typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,16 @@
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
   "types": "dist/custom-elements/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "dist/custom-elements/index.d.ts": [
+        "dist/custom-elements/index.d.ts"
+      ],
+      "react": [
+        "react/dist/components.d.ts"
+      ]
+    }
+  },
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/mds-components/mds-components.esm.js",


### PR DESCRIPTION
This should hopefully address #206.  We needed to add `typesVersions` to the `package.json` to ensure there were typings for the `react` exports.
