### PR TITLE
Add Mercury selection controls

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -108,6 +108,44 @@ export namespace Components {
         "name": string;
         "value": string;
     }
+    interface McRange {
+        "disabled": boolean;
+        /**
+          * Set to `true` to prevent the value from being shown to the right of the slider
+         */
+        "hideValue": boolean;
+        /**
+          * The `id` attribute for the `input` element
+         */
+        "inputId": string;
+        "label": string;
+        /**
+          * The maximum value for the slider
+         */
+        "max": number;
+        /**
+          * The minimum value for the slider
+         */
+        "min": number;
+        "name": string;
+        /**
+          * The increment by which the value is changed when adjusting the slider
+         */
+        "step": number;
+        "value": number;
+        /**
+          * Additional CSS classes to apply to the value text
+         */
+        "valueClass": string;
+        /**
+          * A prefix for the displayed value (e.g. "$")
+         */
+        "valuePrefix": string;
+        /**
+          * A suffix for the displayed value (e.g. "%")
+         */
+        "valueSuffix": string;
+    }
     interface McToggle {
         "checked": boolean;
         "disabled": boolean;
@@ -1268,6 +1306,12 @@ declare global {
         prototype: HTMLMcRadioElement;
         new (): HTMLMcRadioElement;
     };
+    interface HTMLMcRangeElement extends Components.McRange, HTMLStencilElement {
+    }
+    var HTMLMcRangeElement: {
+        prototype: HTMLMcRangeElement;
+        new (): HTMLMcRangeElement;
+    };
     interface HTMLMcToggleElement extends Components.McToggle, HTMLStencilElement {
     }
     var HTMLMcToggleElement: {
@@ -1507,6 +1551,7 @@ declare global {
         "mc-checkbox": HTMLMcCheckboxElement;
         "mc-input": HTMLMcInputElement;
         "mc-radio": HTMLMcRadioElement;
+        "mc-range": HTMLMcRangeElement;
         "mc-toggle": HTMLMcToggleElement;
         "mx-badge": HTMLMxBadgeElement;
         "mx-banner": HTMLMxBannerElement;
@@ -1634,6 +1679,44 @@ declare namespace LocalJSX {
         "labelName"?: string;
         "name"?: string;
         "value"?: string;
+    }
+    interface McRange {
+        "disabled"?: boolean;
+        /**
+          * Set to `true` to prevent the value from being shown to the right of the slider
+         */
+        "hideValue"?: boolean;
+        /**
+          * The `id` attribute for the `input` element
+         */
+        "inputId"?: string;
+        "label"?: string;
+        /**
+          * The maximum value for the slider
+         */
+        "max"?: number;
+        /**
+          * The minimum value for the slider
+         */
+        "min"?: number;
+        "name"?: string;
+        /**
+          * The increment by which the value is changed when adjusting the slider
+         */
+        "step"?: number;
+        "value"?: number;
+        /**
+          * Additional CSS classes to apply to the value text
+         */
+        "valueClass"?: string;
+        /**
+          * A prefix for the displayed value (e.g. "$")
+         */
+        "valuePrefix"?: string;
+        /**
+          * A suffix for the displayed value (e.g. "%")
+         */
+        "valueSuffix"?: string;
     }
     interface McToggle {
         "checked"?: boolean;
@@ -2736,6 +2819,7 @@ declare namespace LocalJSX {
         "mc-checkbox": McCheckbox;
         "mc-input": McInput;
         "mc-radio": McRadio;
+        "mc-range": McRange;
         "mc-toggle": McToggle;
         "mx-badge": MxBadge;
         "mx-banner": MxBanner;
@@ -2785,6 +2869,7 @@ declare module "@stencil/core" {
             "mc-checkbox": LocalJSX.McCheckbox & JSXBase.HTMLAttributes<HTMLMcCheckboxElement>;
             "mc-input": LocalJSX.McInput & JSXBase.HTMLAttributes<HTMLMcInputElement>;
             "mc-radio": LocalJSX.McRadio & JSXBase.HTMLAttributes<HTMLMcRadioElement>;
+            "mc-range": LocalJSX.McRange & JSXBase.HTMLAttributes<HTMLMcRangeElement>;
             "mc-toggle": LocalJSX.McToggle & JSXBase.HTMLAttributes<HTMLMcToggleElement>;
             "mx-badge": LocalJSX.MxBadge & JSXBase.HTMLAttributes<HTMLMxBadgeElement>;
             "mx-banner": LocalJSX.MxBanner & JSXBase.HTMLAttributes<HTMLMxBannerElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -108,6 +108,14 @@ export namespace Components {
         "name": string;
         "value": string;
     }
+    interface McToggle {
+        "checked": boolean;
+        "disabled": boolean;
+        "labelClass": string;
+        "labelName": string;
+        "name": string;
+        "value": string;
+    }
     interface MxBadge {
         /**
           * Additional classes to add to the badge itself
@@ -1260,6 +1268,12 @@ declare global {
         prototype: HTMLMcRadioElement;
         new (): HTMLMcRadioElement;
     };
+    interface HTMLMcToggleElement extends Components.McToggle, HTMLStencilElement {
+    }
+    var HTMLMcToggleElement: {
+        prototype: HTMLMcToggleElement;
+        new (): HTMLMcToggleElement;
+    };
     interface HTMLMxBadgeElement extends Components.MxBadge, HTMLStencilElement {
     }
     var HTMLMxBadgeElement: {
@@ -1493,6 +1507,7 @@ declare global {
         "mc-checkbox": HTMLMcCheckboxElement;
         "mc-input": HTMLMcInputElement;
         "mc-radio": HTMLMcRadioElement;
+        "mc-toggle": HTMLMcToggleElement;
         "mx-badge": HTMLMxBadgeElement;
         "mx-banner": HTMLMxBannerElement;
         "mx-button": HTMLMxButtonElement;
@@ -1613,6 +1628,14 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     interface McRadio {
+        "checked"?: boolean;
+        "disabled"?: boolean;
+        "labelClass"?: string;
+        "labelName"?: string;
+        "name"?: string;
+        "value"?: string;
+    }
+    interface McToggle {
         "checked"?: boolean;
         "disabled"?: boolean;
         "labelClass"?: string;
@@ -2713,6 +2736,7 @@ declare namespace LocalJSX {
         "mc-checkbox": McCheckbox;
         "mc-input": McInput;
         "mc-radio": McRadio;
+        "mc-toggle": McToggle;
         "mx-badge": MxBadge;
         "mx-banner": MxBanner;
         "mx-button": MxButton;
@@ -2761,6 +2785,7 @@ declare module "@stencil/core" {
             "mc-checkbox": LocalJSX.McCheckbox & JSXBase.HTMLAttributes<HTMLMcCheckboxElement>;
             "mc-input": LocalJSX.McInput & JSXBase.HTMLAttributes<HTMLMcInputElement>;
             "mc-radio": LocalJSX.McRadio & JSXBase.HTMLAttributes<HTMLMcRadioElement>;
+            "mc-toggle": LocalJSX.McToggle & JSXBase.HTMLAttributes<HTMLMcToggleElement>;
             "mx-badge": LocalJSX.MxBadge & JSXBase.HTMLAttributes<HTMLMxBadgeElement>;
             "mx-banner": LocalJSX.MxBanner & JSXBase.HTMLAttributes<HTMLMxBannerElement>;
             "mx-button": LocalJSX.MxButton & JSXBase.HTMLAttributes<HTMLMxButtonElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -100,6 +100,14 @@ export namespace Components {
         "type": McInputType;
         "value": string;
     }
+    interface McRadio {
+        "checked": boolean;
+        "disabled": boolean;
+        "labelClass": string;
+        "labelName": string;
+        "name": string;
+        "value": string;
+    }
     interface MxBadge {
         /**
           * Additional classes to add to the badge itself
@@ -1246,6 +1254,12 @@ declare global {
         prototype: HTMLMcInputElement;
         new (): HTMLMcInputElement;
     };
+    interface HTMLMcRadioElement extends Components.McRadio, HTMLStencilElement {
+    }
+    var HTMLMcRadioElement: {
+        prototype: HTMLMcRadioElement;
+        new (): HTMLMcRadioElement;
+    };
     interface HTMLMxBadgeElement extends Components.MxBadge, HTMLStencilElement {
     }
     var HTMLMxBadgeElement: {
@@ -1478,6 +1492,7 @@ declare global {
         "mc-button": HTMLMcButtonElement;
         "mc-checkbox": HTMLMcCheckboxElement;
         "mc-input": HTMLMcInputElement;
+        "mc-radio": HTMLMcRadioElement;
         "mx-badge": HTMLMxBadgeElement;
         "mx-banner": HTMLMxBannerElement;
         "mx-button": HTMLMxButtonElement;
@@ -1595,6 +1610,14 @@ declare namespace LocalJSX {
         "searchLabel"?: string;
         "showCancelIcon"?: boolean;
         "type"?: McInputType;
+        "value"?: string;
+    }
+    interface McRadio {
+        "checked"?: boolean;
+        "disabled"?: boolean;
+        "labelClass"?: string;
+        "labelName"?: string;
+        "name"?: string;
         "value"?: string;
     }
     interface MxBadge {
@@ -2689,6 +2712,7 @@ declare namespace LocalJSX {
         "mc-button": McButton;
         "mc-checkbox": McCheckbox;
         "mc-input": McInput;
+        "mc-radio": McRadio;
         "mx-badge": MxBadge;
         "mx-banner": MxBanner;
         "mx-button": MxButton;
@@ -2736,6 +2760,7 @@ declare module "@stencil/core" {
             "mc-button": LocalJSX.McButton & JSXBase.HTMLAttributes<HTMLMcButtonElement>;
             "mc-checkbox": LocalJSX.McCheckbox & JSXBase.HTMLAttributes<HTMLMcCheckboxElement>;
             "mc-input": LocalJSX.McInput & JSXBase.HTMLAttributes<HTMLMcInputElement>;
+            "mc-radio": LocalJSX.McRadio & JSXBase.HTMLAttributes<HTMLMcRadioElement>;
             "mx-badge": LocalJSX.MxBadge & JSXBase.HTMLAttributes<HTMLMxBadgeElement>;
             "mx-banner": LocalJSX.MxBanner & JSXBase.HTMLAttributes<HTMLMxBannerElement>;
             "mx-button": LocalJSX.MxButton & JSXBase.HTMLAttributes<HTMLMxButtonElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -63,6 +63,24 @@ export namespace Components {
         "type": ButtonTypeAttribute;
         "value": string;
     }
+    interface McCheckbox {
+        "checked": boolean;
+        "disabled": boolean;
+        /**
+          * The aria-label attribute for the inner input element.
+         */
+        "elAriaLabel": string;
+        /**
+          * Hide the label text visually, but still make it accessible for screen readers
+         */
+        "hideLabel": boolean;
+        "indeterminate": boolean;
+        "labelClass": string;
+        "labelLeft": boolean;
+        "labelName": string;
+        "name": string;
+        "value": string;
+    }
     interface McInput {
         "disabled": boolean;
         "elAriaLabel": string;
@@ -1216,6 +1234,12 @@ declare global {
         prototype: HTMLMcButtonElement;
         new (): HTMLMcButtonElement;
     };
+    interface HTMLMcCheckboxElement extends Components.McCheckbox, HTMLStencilElement {
+    }
+    var HTMLMcCheckboxElement: {
+        prototype: HTMLMcCheckboxElement;
+        new (): HTMLMcCheckboxElement;
+    };
     interface HTMLMcInputElement extends Components.McInput, HTMLStencilElement {
     }
     var HTMLMcInputElement: {
@@ -1452,6 +1476,7 @@ declare global {
     };
     interface HTMLElementTagNameMap {
         "mc-button": HTMLMcButtonElement;
+        "mc-checkbox": HTMLMcCheckboxElement;
         "mc-input": HTMLMcInputElement;
         "mx-badge": HTMLMxBadgeElement;
         "mx-banner": HTMLMxBannerElement;
@@ -1533,6 +1558,24 @@ declare namespace LocalJSX {
          */
         "target"?: string;
         "type"?: ButtonTypeAttribute;
+        "value"?: string;
+    }
+    interface McCheckbox {
+        "checked"?: boolean;
+        "disabled"?: boolean;
+        /**
+          * The aria-label attribute for the inner input element.
+         */
+        "elAriaLabel"?: string;
+        /**
+          * Hide the label text visually, but still make it accessible for screen readers
+         */
+        "hideLabel"?: boolean;
+        "indeterminate"?: boolean;
+        "labelClass"?: string;
+        "labelLeft"?: boolean;
+        "labelName"?: string;
+        "name"?: string;
         "value"?: string;
     }
     interface McInput {
@@ -2644,6 +2687,7 @@ declare namespace LocalJSX {
     }
     interface IntrinsicElements {
         "mc-button": McButton;
+        "mc-checkbox": McCheckbox;
         "mc-input": McInput;
         "mx-badge": MxBadge;
         "mx-banner": MxBanner;
@@ -2690,6 +2734,7 @@ declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
             "mc-button": LocalJSX.McButton & JSXBase.HTMLAttributes<HTMLMcButtonElement>;
+            "mc-checkbox": LocalJSX.McCheckbox & JSXBase.HTMLAttributes<HTMLMcCheckboxElement>;
             "mc-input": LocalJSX.McInput & JSXBase.HTMLAttributes<HTMLMcInputElement>;
             "mx-badge": LocalJSX.MxBadge & JSXBase.HTMLAttributes<HTMLMxBadgeElement>;
             "mx-banner": LocalJSX.MxBanner & JSXBase.HTMLAttributes<HTMLMxBannerElement>;

--- a/src/components/mc-button/mc-button.tsx
+++ b/src/components/mc-button/mc-button.tsx
@@ -111,7 +111,7 @@ export class McButton implements IMcButtonProps {
         {this.showLeft && (
           <span class="flex items-center justify-self-start mr-10" data-testid="left-content">
             <slot name="left" />
-            {this.iconLeft && <i class={'text-subtitle ' + this.iconLeft}></i>}
+            {this.iconLeft && <i class={'text-16 ' + this.iconLeft}></i>}
           </span>
         )}
         <span class="slot-content truncate">
@@ -122,7 +122,7 @@ export class McButton implements IMcButtonProps {
             {(this.iconRight || this.dropdown) && (
               <i
                 data-testid="dropdown-icon"
-                class={`text-subtitle ${this.dropdown ? 'mds-caret-down-fill' : this.iconRight}`}
+                class={`text-16 ${this.dropdown ? 'mds-caret-down-fill' : this.iconRight}`}
               ></i>
             )}
             <slot name="right" />

--- a/src/components/mc-checkbox/mc-checkbox.scss
+++ b/src/components/mc-checkbox/mc-checkbox.scss
@@ -1,0 +1,34 @@
+mc-checkbox {
+  color: var(--mc-text-checkbox);
+  input[type='checkbox'] {
+    background-color: var(--mc-bg-checkbox);
+    border-color: var(--mc-border-checkbox);
+    &:disabled {
+      background-color: var(--mc-bg-checkbox-disabled);
+      border-color: var(--mc-border-checkbox-disabled);
+    }
+    &:focus {
+      filter: drop-shadow(0px 0px 0.3125rem var(--mc-shadow-checkbox));
+    }
+    &:checked,
+    &.indeterminate {
+      background-color: var(--mc-bg-checkbox-checked);
+      border-color: var(--mc-border-checkbox-checked);
+      &:disabled {
+        background-color: var(--mc-bg-checkbox-disabled-checked);
+        border-color: var(--mc-border-checkbox-disabled-checked);
+      }
+      &::after {
+        @apply absolute -top-1 -left-1 w-20 h-20;
+        content: '';
+        background-color: var(--mc-bg-checkbox-tick);
+      }
+    }
+    &:checked::after {
+      mask-image: url("data:image/svg+xml;charset=UTF-8,%3csvg width='100%' height='100%' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M12.718 6 14 7.45 9.094 13 6 9.5l1.281-1.449 1.813 2.05L12.718 6Z' fill='%23fff'/%3e%3c/svg%3e");
+    }
+    &.indeterminate::after {
+      mask-image: url("data:image/svg+xml;charset=UTF-8,%3csvg width='100%' height='100%' fill='none' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M6 10h8' stroke='%23fff' stroke-width='2' stroke-linecap='round'/%3e%3c/svg%3e");
+    }
+  }
+}

--- a/src/components/mc-checkbox/mc-checkbox.scss
+++ b/src/components/mc-checkbox/mc-checkbox.scss
@@ -3,6 +3,7 @@ mc-checkbox {
   input[type='checkbox'] {
     background-color: var(--mc-bg-checkbox);
     border-color: var(--mc-border-checkbox);
+    cursor: inherit;
     &:disabled {
       background-color: var(--mc-bg-checkbox-disabled);
       border-color: var(--mc-border-checkbox-disabled);

--- a/src/components/mc-checkbox/mc-checkbox.scss
+++ b/src/components/mc-checkbox/mc-checkbox.scss
@@ -10,6 +10,7 @@ mc-checkbox {
     }
     &:focus {
       filter: drop-shadow(0px 0px 0.3125rem var(--mc-shadow-checkbox));
+      border-color: var(--mc-border-checkbox-focus);
     }
     &:checked,
     &.indeterminate {

--- a/src/components/mc-checkbox/mc-checkbox.scss
+++ b/src/components/mc-checkbox/mc-checkbox.scss
@@ -1,5 +1,10 @@
 mc-checkbox {
   color: var(--mc-text-checkbox);
+  label:active input:not(:disabled),
+  label:focus-within input {
+    filter: drop-shadow(0px 0px 0.3125rem var(--mc-shadow-checkbox));
+    border-color: var(--mc-border-checkbox-focus);
+  }
   input[type='checkbox'] {
     background-color: var(--mc-bg-checkbox);
     border-color: var(--mc-border-checkbox);
@@ -7,10 +12,6 @@ mc-checkbox {
     &:disabled {
       background-color: var(--mc-bg-checkbox-disabled);
       border-color: var(--mc-border-checkbox-disabled);
-    }
-    &:focus {
-      filter: drop-shadow(0px 0px 0.3125rem var(--mc-shadow-checkbox));
-      border-color: var(--mc-border-checkbox-focus);
     }
     &:checked,
     &.indeterminate {

--- a/src/components/mc-checkbox/mc-checkbox.tsx
+++ b/src/components/mc-checkbox/mc-checkbox.tsx
@@ -54,7 +54,7 @@ export class McCheckbox {
       <Host class="inline-flex">
         <label
           class={[
-            'flex-1 inline-flex flex-nowrap text-14 leading-4' + (this.disabled ? '' : ' cursor-pointer'),
+            'inline-flex flex-nowrap text-14 leading-4' + (this.disabled ? '' : ' cursor-pointer'),
             this.labelClass,
           ].join(' ')}
         >

--- a/src/components/mc-checkbox/mc-checkbox.tsx
+++ b/src/components/mc-checkbox/mc-checkbox.tsx
@@ -37,7 +37,7 @@ export class McCheckbox {
   }
 
   get checkLabelClass(): string {
-    let str = 'inline-block';
+    let str = 'inline-block mt-2';
     if (this.hideLabel) str += ' sr-only';
     str += this.labelLeft ? ' order-1 flex-1' : ' order-2';
     if (!this.labelLeft && !this.hideLabel) str += ' ml-10';
@@ -70,7 +70,7 @@ export class McCheckbox {
             {...this.dataAttributes}
             onInput={this.onInput.bind(this)}
           />
-          <div class={this.checkLabelClass} style={{ marginTop: '0.125rem' }} data-testid="labelName">
+          <div class={this.checkLabelClass} data-testid="labelName">
             {this.labelName}
           </div>
         </label>

--- a/src/components/mc-checkbox/mc-checkbox.tsx
+++ b/src/components/mc-checkbox/mc-checkbox.tsx
@@ -1,0 +1,80 @@
+import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { propagateDataAttributes } from '../../utils/utils';
+
+export type McBtnType = 'normal' | 'alt' | 'ghost' | 'transparent' | 'action' | 'error' | 'warning';
+export type ButtonTypeAttribute = 'button' | 'submit' | 'reset';
+
+@Component({
+  tag: 'mc-checkbox',
+  shadow: false,
+})
+export class McCheckbox {
+  dataAttributes = {};
+
+  @Prop() name = '';
+  @Prop() value = '';
+  @Prop() labelLeft = false;
+  @Prop() labelName = '';
+  @Prop() labelClass = '';
+  /** Hide the label text visually, but still make it accessible for screen readers */
+  @Prop() hideLabel = false;
+  @Prop({ mutable: true }) checked = false;
+  @Prop() disabled = false;
+  @Prop() indeterminate = false;
+  /** The aria-label attribute for the inner input element. */
+  @Prop() elAriaLabel: string;
+
+  @Element() element: HTMLMxInputElement;
+
+  componentWillRender = propagateDataAttributes;
+
+  get checkClass(): string {
+    let str = 'relative transition-colors appearance-none flex-shrink-0 rounded border focus:outline-none h-20 w-20';
+    if (this.indeterminate) str += ' indeterminate';
+    str += this.labelLeft ? ' order-2' : ' order-1';
+    if (this.labelLeft && !this.hideLabel) str += ' ml-10';
+    return str;
+  }
+
+  get checkLabelClass(): string {
+    let str = 'inline-block';
+    if (this.hideLabel) str += ' sr-only';
+    str += this.labelLeft ? ' order-1 flex-1' : ' order-2';
+    if (!this.labelLeft && !this.hideLabel) str += ' ml-10';
+    return str;
+  }
+
+  /** Keep checked prop in sync with input element attribute */
+  onInput(e: InputEvent) {
+    this.checked = (e.target as HTMLInputElement).checked;
+  }
+
+  render() {
+    return (
+      <Host class="inline-flex">
+        <label
+          class={[
+            'flex-1 inline-flex flex-nowrap text-14 leading-4' + (this.disabled ? '' : ' cursor-pointer'),
+            this.labelClass,
+          ].join(' ')}
+        >
+          <input
+            class={this.checkClass}
+            type="checkbox"
+            aria-label={this.elAriaLabel}
+            name={this.name}
+            value={this.value}
+            checked={this.checked}
+            disabled={this.disabled}
+            indeterminate={this.indeterminate}
+            {...this.dataAttributes}
+            onInput={this.onInput.bind(this)}
+          />
+          <div class={this.checkLabelClass} style={{ marginTop: '0.125rem' }} data-testid="labelName">
+            {this.labelName}
+          </div>
+        </label>
+      </Host>
+    );
+  }
+}

--- a/src/components/mc-checkbox/test/mc-checkbox.spec.tsx
+++ b/src/components/mc-checkbox/test/mc-checkbox.spec.tsx
@@ -1,0 +1,59 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { McCheckbox } from '../mc-checkbox';
+
+describe('mc-checkbox', () => {
+  let page;
+  let root: HTMLMcCheckboxElement;
+  let input;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [McCheckbox],
+      html: `<mc-checkbox name="foo" label-name="Premier" checked="true" data-test="test" />`,
+    });
+    root = page.root;
+    input = root.querySelector('input');
+  });
+
+  it('is a checkbox', async () => {
+    expect(input.type).toBe('checkbox');
+  });
+
+  it('has the proper name and label', async () => {
+    const labelName = root.querySelector('[data-testid="labelName"]') as HTMLElement;
+    expect(input.getAttribute('name')).toBe('foo');
+    expect(labelName.innerText).toBe('Premier');
+  });
+
+  it('uses the elAriaLabel prop for the aria-label attribute', async () => {
+    root.elAriaLabel = 'aria label';
+    await page.waitForChanges();
+    expect(input.getAttribute('aria-label')).toBe('aria label');
+  });
+
+  it('is checked', async () => {
+    expect(input.checked).toBeTruthy();
+  });
+
+  it('disables the input when the disabled prop is set', async () => {
+    root.disabled = true;
+    await page.waitForChanges();
+    expect(input.disabled).toBeTruthy();
+  });
+
+  it('sets the indeterminate attribute on the input when the indeterminate prop is set', async () => {
+    root.indeterminate = true;
+    await page.waitForChanges();
+    expect(input.getAttribute('indeterminate')).not.toBeNull();
+  });
+
+  it('applies any data attributes to the input element', async () => {
+    expect(input.getAttribute('data-test')).toBe('test');
+  });
+
+  it('updates the checked prop when the checkbox is (un)checked', async () => {
+    input.checked = false;
+    input.dispatchEvent(new Event('input'));
+    await page.waitForChanges();
+    expect(root.checked).toBe(false);
+  });
+});

--- a/src/components/mc-radio/mc-radio.scss
+++ b/src/components/mc-radio/mc-radio.scss
@@ -1,5 +1,10 @@
 mc-radio {
   color: var(--mc-text-radio);
+  label:active input:not(:disabled),
+  label:focus-within input {
+    filter: drop-shadow(0px 0px 0.3125rem var(--mc-shadow-radio));
+    border-color: var(--mc-border-radio-focus);
+  }
   input[type='radio'] {
     background-color: var(--mc-bg-radio);
     border-color: var(--mc-border-radio);
@@ -7,10 +12,6 @@ mc-radio {
     &:disabled {
       background-color: var(--mc-bg-radio-disabled);
       border-color: var(--mc-border-radio-disabled);
-    }
-    &:focus {
-      filter: drop-shadow(0px 0px 0.3125rem var(--mc-shadow-radio));
-      border-color: var(--mc-border-radio-focus);
     }
     &:checked {
       background-color: var(--mc-bg-radio-checked);

--- a/src/components/mc-radio/mc-radio.scss
+++ b/src/components/mc-radio/mc-radio.scss
@@ -1,0 +1,29 @@
+mc-radio {
+  color: var(--mc-text-radio);
+  input[type='radio'] {
+    background-color: var(--mc-bg-radio);
+    border-color: var(--mc-border-radio);
+    cursor: inherit;
+    &:disabled {
+      background-color: var(--mc-bg-radio-disabled);
+      border-color: var(--mc-border-radio-disabled);
+    }
+    &:focus {
+      filter: drop-shadow(0px 0px 0.3125rem var(--mc-shadow-radio));
+    }
+    &:checked {
+      background-color: var(--mc-bg-radio-checked);
+      border-color: var(--mc-border-radio-checked);
+      &:disabled {
+        background-color: var(--mc-bg-radio-disabled-checked);
+        border-color: var(--mc-border-radio-disabled-checked);
+      }
+      &::after {
+        @apply absolute -top-1 -left-1 w-20 h-20;
+        content: '';
+        background-color: var(--mc-bg-radio-tick);
+        mask-image: url("data:image/svg+xml;charset=UTF-8,%3csvg width='100%' height='100%' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle fill-rule='evenodd' clip-rule='evenodd' cx='10' cy='10' r='7.5' stroke-width='2.5' stroke='%23fff' /%3e%3c/svg%3e");
+      }
+    }
+  }
+}

--- a/src/components/mc-radio/mc-radio.scss
+++ b/src/components/mc-radio/mc-radio.scss
@@ -10,6 +10,7 @@ mc-radio {
     }
     &:focus {
       filter: drop-shadow(0px 0px 0.3125rem var(--mc-shadow-radio));
+      border-color: var(--mc-border-radio-focus);
     }
     &:checked {
       background-color: var(--mc-bg-radio-checked);

--- a/src/components/mc-radio/mc-radio.tsx
+++ b/src/components/mc-radio/mc-radio.tsx
@@ -1,0 +1,55 @@
+import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { propagateDataAttributes } from '../../utils/utils';
+
+@Component({
+  tag: 'mc-radio',
+  shadow: false,
+})
+export class McRadio {
+  dataAttributes = {};
+
+  @Prop() name = '';
+  @Prop() value = '';
+  @Prop() labelClass = '';
+  @Prop() labelName = '';
+  @Prop({ mutable: true }) checked = false;
+  @Prop() disabled = false;
+
+  @Element() element: HTMLMcInputElement;
+
+  componentWillRender = propagateDataAttributes;
+
+  /** Keep checked prop in sync with input element attribute */
+  onInput(e: InputEvent) {
+    this.checked = (e.target as HTMLInputElement).checked;
+  }
+
+  get labelClassNames(): string {
+    let str = 'inline-flex flex-nowrap text-14 leading-4';
+    if (!this.disabled) str += ' cursor-pointer';
+    if (this.labelClass) str += ' ' + this.labelClass;
+    return str;
+  }
+
+  render() {
+    return (
+      <Host class="inline-flex">
+        <label class={this.labelClassNames}>
+          <input
+            class="relative transition-colors appearance-none flex-shrink-0 rounded-full border focus:outline-none h-20 w-20"
+            type="radio"
+            name={this.name}
+            value={this.value}
+            checked={this.checked}
+            disabled={this.disabled}
+            {...this.dataAttributes}
+            onInput={this.onInput.bind(this)}
+          />
+          <div class="ml-10 mt-2 inline-block" data-testid="labelName">
+            {this.labelName}
+          </div>
+        </label>
+      </Host>
+    );
+  }
+}

--- a/src/components/mc-radio/test/mc-radio.spec.tsx
+++ b/src/components/mc-radio/test/mc-radio.spec.tsx
@@ -1,0 +1,47 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { McRadio } from '../mc-radio';
+
+describe('mc-radio', () => {
+  let page;
+  let root;
+  let input;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [McRadio],
+      html: `<mc-radio name="foo" label-name="Premier" checked="true" data-test="test" />`,
+    });
+    root = page.root;
+    input = root.querySelector('input');
+  });
+
+  it('is a radio', async () => {
+    expect(input.type).toBe('radio');
+  });
+
+  it('has the proper name and label', async () => {
+    const labelName = root.querySelector('[data-testid="labelName"]');
+    expect(input.getAttribute('name')).toBe('foo');
+    expect(labelName.innerText).toBe('Premier');
+  });
+
+  it('is checked', async () => {
+    expect(input.checked).toBeTruthy();
+  });
+
+  it('disables the input when the disabled prop is set', async () => {
+    root.disabled = true;
+    await page.waitForChanges();
+    expect(input.disabled).toBeTruthy();
+  });
+
+  it('applies any data attributes to the input element', async () => {
+    expect(input.getAttribute('data-test')).toBe('test');
+  });
+
+  it('updates the checked prop when the radio is (un)checked', async () => {
+    input.checked = false;
+    input.dispatchEvent(new Event('input'));
+    await page.waitForChanges();
+    expect(root.checked).toBe(false);
+  });
+});

--- a/src/components/mc-range/mc-range.scss
+++ b/src/components/mc-range/mc-range.scss
@@ -1,0 +1,53 @@
+mc-range {
+  --mc-min-w-range-value: 1.875rem; /* Default value text's min-width to 30px, which is the width of "100%". */
+  color: var(--mc-text-range);
+  input {
+    /** --mc-bg-range will be changed to a linear gradient via JS in the component. */
+    --mc-bg-range: var(--mc-bg-range-track);
+    --mc-bg-range-1: var(--mc-bg-range-fill);
+    --mc-bg-range-2: var(--mc-bg-range-track);
+    --mc-h-range-track: 0.3125rem; /* 5px */
+    --mc-h-range-thumb: 0.875rem; /* 14px */
+    --mc-mt-range-thumb: -0.28125rem; /* -4.5px = (track height / 2) - (thumb height - 2) */
+    --mc-shadow-range-thumb: 0 0 0 0.25rem var(--mc-border-range-thumb); /* Thumb does not always support border, so we use a shadow instead. */
+    outline-offset: 0.25rem; /* 4px */
+    &:disabled {
+      --mc-bg-range-1: var(--mc-bg-range-fill-disabled);
+      --mc-bg-range-2: var(--mc-bg-range-track-disabled);
+      --mc-bg-range-thumb: var(--mc-bg-range-thumb-disabled);
+      --mc-bg-range-thumb-active: var(--mc-bg-range-thumb-disabled);
+    }
+    &:active {
+      --mc-bg-range-thumb: var(--mc-bg-range-thumb-active);
+    }
+    &::-webkit-slider-runnable-track {
+      @apply rounded-full;
+      background: var(--mc-bg-range);
+      height: var(--mc-h-range-track);
+    }
+    &::-moz-range-track {
+      @apply rounded-full;
+      background: var(--mc-bg-range);
+      height: var(--mc-h-range-track);
+    }
+    &::-webkit-slider-thumb {
+      @apply appearance-none rounded-full;
+      background-color: var(--mc-bg-range-thumb);
+      box-shadow: var(--mc-shadow-range-thumb);
+      height: var(--mc-h-range-thumb);
+      width: var(--mc-h-range-thumb);
+      margin-top: var(--mc-mt-range-thumb);
+    }
+    &::-moz-range-thumb {
+      @apply appearance-none border-0 rounded-full;
+      background-color: var(--mc-bg-range-thumb);
+      box-shadow: var(--mc-shadow-range-thumb);
+      height: var(--mc-h-range-thumb);
+      width: var(--mc-h-range-thumb);
+      margin-top: var(--mc-mt-range-thumb);
+    }
+  }
+  input + span {
+    min-width: var(--mc-min-w-range-value);
+  }
+}

--- a/src/components/mc-range/mc-range.tsx
+++ b/src/components/mc-range/mc-range.tsx
@@ -1,0 +1,94 @@
+import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { propagateDataAttributes } from '../../utils/utils';
+import { uuidv4 } from '../../utils/utils';
+
+@Component({
+  tag: 'mc-range',
+  shadow: false,
+})
+export class McRadio {
+  inputEl!: HTMLInputElement;
+  dataAttributes = {};
+
+  @Prop() disabled = false;
+  /** Set to `true` to prevent the value from being shown to the right of the slider */
+  @Prop() hideValue = false;
+  /** The `id` attribute for the `input` element */
+  @Prop() inputId: string = uuidv4();
+  @Prop() label = '';
+  /** The maximum value for the slider */
+  @Prop() max = 100;
+  @Prop() name = '';
+  /** The minimum value for the slider */
+  @Prop() min = 0;
+  /** The increment by which the value is changed when adjusting the slider */
+  @Prop() step = 1;
+  @Prop({ mutable: true }) value = 0;
+  /** Additional CSS classes to apply to the value text */
+  @Prop() valueClass = '';
+  /** A prefix for the displayed value (e.g. "$") */
+  @Prop() valuePrefix = '';
+  /** A suffix for the displayed value (e.g. "%") */
+  @Prop() valueSuffix = '';
+
+  @Element() element: HTMLMcInputElement;
+
+  componentWillRender = propagateDataAttributes;
+
+  get inputClass(): string {
+    let str = 'appearance-none bg-transparent flex-1 h-14';
+    if (!this.disabled) str += ' cursor-pointer';
+    return str;
+  }
+
+  onInput(e: InputEvent) {
+    this.value = +(e.target as HTMLInputElement).value;
+    this.updateTrackFill();
+  }
+
+  updateTrackFill() {
+    // Webkit browsers do not have a pseudo-element for the "filled" portion of the slider, so this
+    // updates a linear gradient to achieve the same effect.
+    const percent = ((this.value - this.min) / (this.max - this.min)) * 100;
+    const linearGradient = `linear-gradient(to right, var(--mc-bg-range-1) 0%, var(--mc-bg-range-1) ${percent}%,
+      var(--mc-bg-range-2) ${percent}%, var(--mc-bg-range-2) 100%)`;
+    this.inputEl.style.setProperty('--mc-bg-range', linearGradient);
+  }
+
+  componentDidLoad() {
+    this.updateTrackFill();
+  }
+
+  render() {
+    return (
+      <Host class="inline-block">
+        <label htmlFor={this.inputId} class="block text-label uppercase">
+          {this.label}
+        </label>
+        <div class="flex items-center mt-10 space-x-10">
+          <input
+            ref={el => (this.inputEl = el)}
+            class={this.inputClass}
+            type="range"
+            id={this.inputId}
+            name={this.name}
+            min={this.min}
+            max={this.max}
+            step={this.step}
+            value={this.value}
+            disabled={this.disabled}
+            {...this.dataAttributes}
+            onInput={this.onInput.bind(this)}
+          />
+          {!this.hideValue && (
+            <span class={`text-body2 font-bold ${this.valueClass}`}>
+              {this.valuePrefix}
+              {this.value}
+              {this.valueSuffix}
+            </span>
+          )}
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/mc-range/mc-range.tsx
+++ b/src/components/mc-range/mc-range.tsx
@@ -6,7 +6,7 @@ import { uuidv4 } from '../../utils/utils';
   tag: 'mc-range',
   shadow: false,
 })
-export class McRadio {
+export class McRange {
   inputEl!: HTMLInputElement;
   dataAttributes = {};
 

--- a/src/components/mc-range/test/mc-range.spec.tsx
+++ b/src/components/mc-range/test/mc-range.spec.tsx
@@ -1,0 +1,81 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { McRange } from '../mc-range';
+
+describe('mc-range', () => {
+  let page;
+  let root: HTMLMcRangeElement;
+  let input: HTMLInputElement;
+
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [McRange],
+      html: `
+        <mc-range
+          name="foo"
+          value="50"
+          min="10"
+          max="100"
+          step="5"
+          input-id="bloop"
+          label="Label"
+          value-prefix="$"
+          value-suffix="USD"
+          value-class="test-class"
+        />
+      `,
+    });
+    root = page.root;
+    input = root.querySelector('input');
+  });
+
+  it('renders', async () => {
+    const elems = document.getElementsByTagName('mc-range');
+    expect(elems.length).toBe(1);
+  });
+
+  it('has the right name, id, value, min, max, and step', async () => {
+    expect(input.getAttribute('name')).toBe('foo');
+    expect(input.getAttribute('id')).toBe('bloop');
+    expect(input.value).toBe('50');
+    expect(input.min).toBe('10');
+    expect(input.max).toBe('100');
+    expect(input.step).toBe('5');
+  });
+
+  it('sets the label properly', async () => {
+    const label = root.querySelector('label');
+    expect(label.textContent).toBe('Label');
+  });
+
+  it('renders the value-prefix and value-suffix', async () => {
+    expect(root.textContent).toContain('$50USD');
+  });
+
+  it('applies the value-class to the value', async () => {
+    const value = root.querySelector('input + span');
+    expect(value.classList.contains('test-class')).toBe(true);
+  });
+
+  it('does not render the value text if hide-value is set', async () => {
+    let valueEl = root.querySelector('input + span');
+    expect(valueEl).not.toBeNull();
+    root.hideValue = true;
+    await page.waitForChanges();
+    valueEl = root.querySelector('input + span');
+    expect(valueEl).toBe(null);
+  });
+
+  it('updates the value prop when the input value is changed', async () => {
+    input.value = '25';
+    input.dispatchEvent(new Event('input'));
+    await page.waitForChanges();
+    expect(root.value).toBe(25);
+  });
+
+  it('disables the input based on the disabled prop', async () => {
+    expect(input.getAttribute('disabled')).toBeNull();
+    root.disabled = true;
+    await page.waitForChanges();
+    expect(input.getAttribute('disabled')).not.toBeNull();
+  });
+});

--- a/src/components/mc-toggle/mc-toggle.scss
+++ b/src/components/mc-toggle/mc-toggle.scss
@@ -1,5 +1,13 @@
 mc-toggle {
   color: var(--mc-text-toggle);
+  label:active input:not(:disabled),
+  label:focus-within input {
+    filter: drop-shadow(0px 0px 0.3125rem var(--mc-shadow-toggle));
+    border-color: var(--mc-border-toggle-focus);
+    &:not(:checked)::after {
+      background-color: var(--mc-bg-toggle-handle-focus);
+    }
+  }
   input[type='checkbox'] {
     background-color: var(--mc-bg-toggle);
     border-color: var(--mc-border-toggle);
@@ -15,13 +23,6 @@ mc-toggle {
       border-color: var(--mc-border-toggle-disabled);
       &::after {
         background-color: var(--mc-bg-toggle-handle-disabled);
-      }
-    }
-    &:focus {
-      filter: drop-shadow(0px 0px 0.3125rem var(--mc-shadow-toggle));
-      border-color: var(--mc-border-toggle-focus);
-      &::after {
-        background-color: var(--mc-bg-toggle-handle-focus);
       }
     }
     &:checked {

--- a/src/components/mc-toggle/mc-toggle.scss
+++ b/src/components/mc-toggle/mc-toggle.scss
@@ -1,0 +1,40 @@
+mc-toggle {
+  color: var(--mc-text-toggle);
+  input[type='checkbox'] {
+    background-color: var(--mc-bg-toggle);
+    border-color: var(--mc-border-toggle);
+    cursor: inherit;
+    &::after {
+      @apply absolute -top-1 left-0 w-40 h-20 transform -translate-x-20 transition-all duration-200;
+      content: '';
+      background-color: var(--mc-bg-toggle-handle);
+      mask-image: url("data:image/svg+xml;charset=UTF-8,%3csvg width='100%' height='100%' viewBox='0 0 40 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M14 8.45 12.719 7l-3.625 4.1L7.28 9.05 6 10.5 9.094 14 14 8.45ZM30 17a7 7 0 1 0 0-14 7 7 0 0 0 0 14Z' fill='%23fff'/%3e%3c/svg%3e");
+    }
+    &:disabled {
+      background-color: var(--mc-bg-toggle-disabled);
+      border-color: var(--mc-border-toggle-disabled);
+      &::after {
+        background-color: var(--mc-bg-toggle-handle-disabled);
+      }
+    }
+    &:focus {
+      filter: drop-shadow(0px 0px 0.3125rem var(--mc-shadow-toggle));
+      border-color: var(--mc-border-toggle-focus);
+      &::after {
+        background-color: var(--mc-bg-toggle-handle-focus);
+      }
+    }
+    &:checked {
+      background-color: var(--mc-bg-toggle-checked);
+      border-color: var(--mc-border-toggle-checked);
+      &:disabled {
+        background-color: var(--mc-bg-toggle-disabled-checked);
+        border-color: var(--mc-border-toggle-disabled-checked);
+      }
+      &::after {
+        @apply transform -translate-x-1;
+        background-color: var(--mc-bg-toggle-handle-checked);
+      }
+    }
+  }
+}

--- a/src/components/mc-toggle/mc-toggle.tsx
+++ b/src/components/mc-toggle/mc-toggle.tsx
@@ -1,0 +1,56 @@
+import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { propagateDataAttributes } from '../../utils/utils';
+
+@Component({
+  tag: 'mc-toggle',
+  shadow: false,
+})
+export class McRadio {
+  dataAttributes = {};
+
+  @Prop() name = '';
+  @Prop() value = '';
+  @Prop() labelClass = '';
+  @Prop() labelName = '';
+  @Prop({ mutable: true }) checked = false;
+  @Prop() disabled = false;
+
+  @Element() element: HTMLMcInputElement;
+
+  componentWillRender = propagateDataAttributes;
+
+  /** Keep checked prop in sync with input element attribute */
+  onInput(e: InputEvent) {
+    this.checked = (e.target as HTMLInputElement).checked;
+  }
+
+  get labelClassNames(): string {
+    let str = 'inline-flex flex-nowrap text-14 leading-4';
+    if (!this.disabled) str += ' cursor-pointer';
+    if (this.labelClass) str += ' ' + this.labelClass;
+    return str;
+  }
+
+  render() {
+    return (
+      <Host class="inline-flex">
+        <label class={this.labelClassNames}>
+          <input
+            class="relative overflow-hidden transition-colors duration-200 appearance-none flex-shrink-0 rounded-full border focus:outline-none h-20 w-40"
+            type="checkbox"
+            role="switch"
+            name={this.name}
+            value={this.value}
+            checked={this.checked}
+            disabled={this.disabled}
+            {...this.dataAttributes}
+            onInput={this.onInput.bind(this)}
+          />
+          <div class="ml-10 mt-2 inline-block" data-testid="labelName">
+            {this.labelName}
+          </div>
+        </label>
+      </Host>
+    );
+  }
+}

--- a/src/components/mc-toggle/mc-toggle.tsx
+++ b/src/components/mc-toggle/mc-toggle.tsx
@@ -5,7 +5,7 @@ import { propagateDataAttributes } from '../../utils/utils';
   tag: 'mc-toggle',
   shadow: false,
 })
-export class McRadio {
+export class McToggle {
   dataAttributes = {};
 
   @Prop() name = '';

--- a/src/components/mc-toggle/test/mc-toggle.spec.tsx
+++ b/src/components/mc-toggle/test/mc-toggle.spec.tsx
@@ -1,0 +1,48 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { McToggle } from '../mc-toggle';
+
+describe('mc-toggle', () => {
+  let page;
+  let root;
+  let input;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [McToggle],
+      html: `<mc-toggle name="foo" label-name="Premier" value="dog" checked="true" data-test="test" />`,
+    });
+    root = page.root;
+    input = root.querySelector('input');
+  });
+
+  it('is a checkbox', async () => {
+    expect(input.type).toBe('checkbox');
+  });
+
+  it('has the proper name, value, and label', async () => {
+    const labelName = root.querySelector('[data-testid="labelName"]');
+    expect(input.getAttribute('name')).toBe('foo');
+    expect(input.getAttribute('value')).toBe('dog');
+    expect(labelName.innerText).toBe('Premier');
+  });
+
+  it('is checked', async () => {
+    expect(input.checked).toBeTruthy();
+  });
+
+  it('disables the input when the disabled prop is set', async () => {
+    root.disabled = true;
+    await page.waitForChanges();
+    expect(input.disabled).toBeTruthy();
+  });
+
+  it('applies any data attributes to the input element', async () => {
+    expect(input.getAttribute('data-test')).toBe('test');
+  });
+
+  it('updates the checked prop when the checkbox is (un)checked', async () => {
+    input.checked = false;
+    input.dispatchEvent(new Event('input'));
+    await page.waitForChanges();
+    expect(root.checked).toBe(false);
+  });
+});

--- a/src/tailwind/styles.scss
+++ b/src/tailwind/styles.scss
@@ -21,6 +21,7 @@
 @import '../components/mc-button/mc-button.scss';
 @import '../components/mc-input/mc-input.scss';
 @import '../components/mc-checkbox/mc-checkbox.scss';
+@import '../components/mc-radio/mc-radio.scss';
 
 /***************************
 * Import Component CSS

--- a/src/tailwind/styles.scss
+++ b/src/tailwind/styles.scss
@@ -20,6 +20,7 @@
 ***************************/
 @import '../components/mc-button/mc-button.scss';
 @import '../components/mc-input/mc-input.scss';
+@import '../components/mc-checkbox/mc-checkbox.scss';
 
 /***************************
 * Import Component CSS

--- a/src/tailwind/styles.scss
+++ b/src/tailwind/styles.scss
@@ -22,6 +22,7 @@
 @import '../components/mc-input/mc-input.scss';
 @import '../components/mc-checkbox/mc-checkbox.scss';
 @import '../components/mc-radio/mc-radio.scss';
+@import '../components/mc-toggle/mc-toggle.scss';
 
 /***************************
 * Import Component CSS

--- a/src/tailwind/styles.scss
+++ b/src/tailwind/styles.scss
@@ -23,6 +23,7 @@
 @import '../components/mc-checkbox/mc-checkbox.scss';
 @import '../components/mc-radio/mc-radio.scss';
 @import '../components/mc-toggle/mc-toggle.scss';
+@import '../components/mc-range/mc-range.scss';
 
 /***************************
 * Import Component CSS

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -131,6 +131,20 @@
   --mc-text-checkbox: var(--mc-secondary);
   /* #endregion mc-checkbox */
 
+  /* #region mc-radio */
+  --mc-bg-radio-checked: var(--mc-primary);
+  --mc-bg-radio-disabled-checked: var(--mc-secondary-light);
+  --mc-bg-radio-disabled: var(--mc-secondary-ultra-light);
+  --mc-bg-radio-tick: var(--mc-white);
+  --mc-bg-radio: var(--mc-white);
+  --mc-border-radio-disabled-checked: var(--mc-secondary-light);
+  --mc-border-radio-disabled: var(--mc-secondary);
+  --mc-border-radio-checked: var(--mc-primary);
+  --mc-border-radio: var(--mc-secondary);
+  --mc-shadow-radio: var(--mc-primary-shadow);
+  --mc-text-radio: var(--mc-secondary);
+  /* #endregion mc-radio */
+
   /* #region buttons */
   /* Contained Buttons */
   --mds-bg-btn-contained-active: #0457af;

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -165,6 +165,18 @@
   --mc-text-toggle: var(--mc-secondary);
   /* #endregion mc-toggle */
 
+  /* #region mc-range */
+  --mc-bg-range-fill-disabled: var(--mc-secondary-light);
+  --mc-bg-range-fill: var(--mc-primary);
+  --mc-bg-range-thumb-active: var(--mc-tertiary);
+  --mc-bg-range-thumb-disabled: var(--mc-secondary-light);
+  --mc-bg-range-thumb: var(--mc-primary);
+  --mc-bg-range-track-disabled: var(--mc-secondary-ultra-light);
+  --mc-bg-range-track: var(--mc-secondary-light);
+  --mc-border-range-thumb: var(--mc-white);
+  --mc-text-range: var(--mc-secondary);
+  /* #endregion mc-range */
+
   /* #region buttons */
   /* Contained Buttons */
   --mds-bg-btn-contained-active: #0457af;

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -4,6 +4,7 @@
   --mc-primary-dark-alt: #243c5a;
   --mc-primary-dark: #003b76;
   --mc-primary-hover: #4096ec;
+  --mc-primary-shadow: rgba(0, 115, 230, 0.5);
   --mc-primary: #0073e6;
   --mc-secondary-light: #ced8dc;
   --mc-secondary-medium: #9bb2c9;
@@ -115,6 +116,20 @@
   --mc-text-btn-warning-hover: var(--mc-white);
   --mc-text-btn-warning: var(--mc-white);
   /* #endregion mc-button */
+
+  /* #region mc-checkbox */
+  --mc-bg-checkbox-checked: var(--mc-primary);
+  --mc-bg-checkbox-disabled-checked: var(--mc-secondary-light);
+  --mc-bg-checkbox-disabled: var(--mc-secondary-ultra-light);
+  --mc-bg-checkbox-tick: var(--mc-white);
+  --mc-bg-checkbox: var(--mc-white);
+  --mc-border-checkbox-disabled-checked: var(--mc-secondary-light);
+  --mc-border-checkbox-disabled: var(--mc-secondary);
+  --mc-border-checkbox-checked: var(--mc-primary);
+  --mc-border-checkbox: var(--mc-secondary);
+  --mc-shadow-checkbox: var(--mc-primary-shadow);
+  --mc-text-checkbox: var(--mc-secondary);
+  /* #endregion mc-checkbox */
 
   /* #region buttons */
   /* Contained Buttons */

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -123,9 +123,10 @@
   --mc-bg-checkbox-disabled: var(--mc-secondary-ultra-light);
   --mc-bg-checkbox-tick: var(--mc-white);
   --mc-bg-checkbox: var(--mc-white);
+  --mc-border-checkbox-checked: var(--mc-primary);
   --mc-border-checkbox-disabled-checked: var(--mc-secondary-light);
   --mc-border-checkbox-disabled: var(--mc-secondary);
-  --mc-border-checkbox-checked: var(--mc-primary);
+  --mc-border-checkbox-focus: var(--mc-primary);
   --mc-border-checkbox: var(--mc-secondary);
   --mc-shadow-checkbox: var(--mc-primary-shadow);
   --mc-text-checkbox: var(--mc-secondary);
@@ -137,13 +138,32 @@
   --mc-bg-radio-disabled: var(--mc-secondary-ultra-light);
   --mc-bg-radio-tick: var(--mc-white);
   --mc-bg-radio: var(--mc-white);
+  --mc-border-radio-checked: var(--mc-primary);
   --mc-border-radio-disabled-checked: var(--mc-secondary-light);
   --mc-border-radio-disabled: var(--mc-secondary);
-  --mc-border-radio-checked: var(--mc-primary);
+  --mc-border-radio-focus: var(--mc-primary);
   --mc-border-radio: var(--mc-secondary);
   --mc-shadow-radio: var(--mc-primary-shadow);
   --mc-text-radio: var(--mc-secondary);
   /* #endregion mc-radio */
+
+  /* #region mc-toggle */
+  --mc-bg-toggle-checked: var(--mc-primary);
+  --mc-bg-toggle-disabled-checked: var(--mc-secondary-light);
+  --mc-bg-toggle-disabled: var(--mc-white);
+  --mc-bg-toggle-handle-checked: var(--mc-white);
+  --mc-bg-toggle-handle-disabled: var(--mc-secondary-light);
+  --mc-bg-toggle-handle-focus: var(--mc-primary);
+  --mc-bg-toggle-handle: var(--mc-secondary);
+  --mc-bg-toggle: var(--mc-white);
+  --mc-border-toggle-checked: var(--mc-primary);
+  --mc-border-toggle-disabled-checked: var(--mc-secondary-light);
+  --mc-border-toggle-disabled: var(--mc-secondary);
+  --mc-border-toggle-focus: var(--mc-primary);
+  --mc-border-toggle: var(--mc-secondary);
+  --mc-shadow-toggle: var(--mc-primary-shadow);
+  --mc-text-toggle: var(--mc-secondary);
+  /* #endregion mc-toggle */
 
   /* #region buttons */
   /* Contained Buttons */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,7 @@ const config = {
     },
     fontSize: {
       14: '0.875rem',
+      16: '1rem',
     },
     letterSpacing: {
       '0': '0rem',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,9 @@ const config = {
       16: '0px 16px 24px rgba(0, 0, 0, 0.04), 0px 6px 30px rgba(0, 0, 0, 0.02), 0px 8px 10px rgba(0, 0, 0, 0.06)',
       24: '0px 24px 38px rgba(0, 0, 0, 0.04), 0px 9px 46px rgba(0, 0, 0, 0.02), 0px 11px 15px rgba(0, 0, 0, 0.06)',
     },
+    fontSize: {
+      14: '0.875rem',
+    },
     letterSpacing: {
       '0': '0rem',
       '0-1': '0.006rem',

--- a/vuepress/.vuepress/components/ComponentReadme.vue
+++ b/vuepress/.vuepress/components/ComponentReadme.vue
@@ -17,7 +17,8 @@ export default {
 </script>
 
 <style>
-.component-readme h1 {
+.component-readme h1,
+.component-readme h2:first-of-type {
   display: none; /* Hide the element heading that Stencil adds to its readme files. */
 }
 </style>

--- a/vuepress/components/mc-checkbox/readme.md
+++ b/vuepress/components/mc-checkbox/readme.md
@@ -1,0 +1,26 @@
+# mc-checkbox
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property        | Attribute       | Description                                                                   | Type      | Default     |
+| --------------- | --------------- | ----------------------------------------------------------------------------- | --------- | ----------- |
+| `checked`       | `checked`       |                                                                               | `boolean` | `false`     |
+| `disabled`      | `disabled`      |                                                                               | `boolean` | `false`     |
+| `elAriaLabel`   | `el-aria-label` | The aria-label attribute for the inner input element.                         | `string`  | `undefined` |
+| `hideLabel`     | `hide-label`    | Hide the label text visually, but still make it accessible for screen readers | `boolean` | `false`     |
+| `indeterminate` | `indeterminate` |                                                                               | `boolean` | `false`     |
+| `labelClass`    | `label-class`   |                                                                               | `string`  | `''`        |
+| `labelLeft`     | `label-left`    |                                                                               | `boolean` | `false`     |
+| `labelName`     | `label-name`    |                                                                               | `string`  | `''`        |
+| `name`          | `name`          |                                                                               | `string`  | `''`        |
+| `value`         | `value`         |                                                                               | `string`  | `''`        |
+
+
+----------------------------------------------
+
+

--- a/vuepress/components/mc-radio/readme.md
+++ b/vuepress/components/mc-radio/readme.md
@@ -1,0 +1,22 @@
+# mc-radio
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property     | Attribute     | Description | Type      | Default |
+| ------------ | ------------- | ----------- | --------- | ------- |
+| `checked`    | `checked`     |             | `boolean` | `false` |
+| `disabled`   | `disabled`    |             | `boolean` | `false` |
+| `labelClass` | `label-class` |             | `string`  | `''`    |
+| `labelName`  | `label-name`  |             | `string`  | `''`    |
+| `name`       | `name`        |             | `string`  | `''`    |
+| `value`      | `value`       |             | `string`  | `''`    |
+
+
+----------------------------------------------
+
+

--- a/vuepress/components/mc-range/readme.md
+++ b/vuepress/components/mc-range/readme.md
@@ -1,0 +1,28 @@
+# mc-range
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property      | Attribute      | Description                                                                    | Type      | Default    |
+| ------------- | -------------- | ------------------------------------------------------------------------------ | --------- | ---------- |
+| `disabled`    | `disabled`     |                                                                                | `boolean` | `false`    |
+| `hideValue`   | `hide-value`   | Set to `true` to prevent the value from being shown to the right of the slider | `boolean` | `false`    |
+| `inputId`     | `input-id`     | The `id` attribute for the `input` element                                     | `string`  | `uuidv4()` |
+| `label`       | `label`        |                                                                                | `string`  | `''`       |
+| `max`         | `max`          | The maximum value for the slider                                               | `number`  | `100`      |
+| `min`         | `min`          | The minimum value for the slider                                               | `number`  | `0`        |
+| `name`        | `name`         |                                                                                | `string`  | `''`       |
+| `step`        | `step`         | The increment by which the value is changed when adjusting the slider          | `number`  | `1`        |
+| `value`       | `value`        |                                                                                | `number`  | `0`        |
+| `valueClass`  | `value-class`  | Additional CSS classes to apply to the value text                              | `string`  | `''`       |
+| `valuePrefix` | `value-prefix` | A prefix for the displayed value (e.g. "$")                                    | `string`  | `''`       |
+| `valueSuffix` | `value-suffix` | A suffix for the displayed value (e.g. "%")                                    | `string`  | `''`       |
+
+
+----------------------------------------------
+
+

--- a/vuepress/components/mc-toggle/readme.md
+++ b/vuepress/components/mc-toggle/readme.md
@@ -1,0 +1,22 @@
+# mc-toggle
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property     | Attribute     | Description | Type      | Default |
+| ------------ | ------------- | ----------- | --------- | ------- |
+| `checked`    | `checked`     |             | `boolean` | `false` |
+| `disabled`   | `disabled`    |             | `boolean` | `false` |
+| `labelClass` | `label-class` |             | `string`  | `''`    |
+| `labelName`  | `label-name`  |             | `string`  | `''`    |
+| `name`       | `name`        |             | `string`  | `''`    |
+| `value`      | `value`       |             | `string`  | `''`    |
+
+
+----------------------------------------------
+
+

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -106,7 +106,7 @@ Selection controls consist of checkboxes, radios, toggles, and range selectors.
 </div>
 <!-- #endregion checkboxes-dep -->
 
-<<< @/vuepress/components/selection-controls.md#checkboxes
+<<< @/vuepress/components/selection-controls.md#checkboxes-dep
 
 #### Checkbox Properties
 
@@ -138,7 +138,7 @@ Selection controls consist of checkboxes, radios, toggles, and range selectors.
 </div>
 <!-- #endregion radio-buttons-dep -->
 
-<<< @/vuepress/components/selection-controls.md#radio-buttons
+<<< @/vuepress/components/selection-controls.md#radio-buttons-dep
 
 #### Radio Button Properties
 
@@ -166,7 +166,7 @@ Selection controls consist of checkboxes, radios, toggles, and range selectors.
 </div>
 <!-- #endregion switches-dep -->
 
-<<< @/vuepress/components/selection-controls.md#switches
+<<< @/vuepress/components/selection-controls.md#switches-dep
 
 #### Switch Properties
 

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -64,6 +64,29 @@ Selection controls consist of checkboxes, radios, toggles, and range selectors.
 
 <ComponentReadme component="mc-toggle" />
 
+## Range Selectors
+
+<section class="mds">
+  <div class="my-12 grid grid-flow-row grid-cols-2 gap-32">
+    <!-- #region range-selectors -->
+    <mc-range label="Label" value="50" />
+    <mc-range label="Label" value="50" disabled />
+    <mc-range label="Label" value="500" min="0" max="1000" step="100" />
+    <mc-range label="Label" value="2" min="2" max="8" />
+    <mc-range label="Label" value="50" value-suffix="%" />
+    <mc-range label="Label" value="50" value-prefix="$" />
+    <mc-range label="Label" value="50" hide-value />
+    <mc-range label="Label" value="50" value-class="text-status-error" />
+    <!-- #endregion range-selectors -->
+  </div>
+</section>
+
+<<<@/vuepress/components/selection-controls.md#range-selectors
+
+## mc-range Properties
+
+<ComponentReadme component="mc-range" />
+
 ## Deprecated components ⚠️
 
 ### Checkboxes

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -24,6 +24,26 @@ Selection controls consist of checkboxes, radios, toggles, and range selectors.
 
 <ComponentReadme component="mc-checkbox" />
 
+## Radio Buttons
+
+<section class="mds">
+  <div class="max-w-sm my-12 grid grid-flow-row grid-cols-2 gap-12">
+    <!-- #region radio-buttons -->
+    <mc-radio name="rad" label-name="Label" checked />
+    <mc-radio name="rad" label-name="Label" />
+    <mc-radio label-name="Disabled" disabled />
+    <mc-radio label-name="Disabled" checked disabled />
+    <mc-radio name="rad" label-name="Text label that wraps multiple lines" />
+    <!-- #endregion radio-buttons -->
+  </div>
+</section>
+
+<<<@/vuepress/components/selection-controls.md#radio-buttons
+
+## mc-radio Properties
+
+<ComponentReadme component="mc-radio" />
+
 ## Deprecated components ⚠️
 
 ### Checkboxes

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -67,7 +67,7 @@ Selection controls consist of checkboxes, radios, toggles, and range selectors.
 ## Range Selectors
 
 <section class="mds">
-  <div class="my-12 grid grid-flow-row grid-cols-2 gap-32">
+  <div class="my-12 grid grid-flow-row grid-cols-1 sm:grid-cols-2 gap-32">
     <!-- #region range-selectors -->
     <mc-range label="Label" value="50" />
     <mc-range label="Label" value="50" disabled />

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -1,10 +1,34 @@
 # Selection Controls
 
-Selection controls consist of checkboxes, radios, and switches. Also see [Toggle Buttons](/components/buttons.html#toggle-buttons) and [Toggle Button Groups](/components/buttons.html#toggle-button-groups).
+Selection controls consist of checkboxes, radios, toggles, and range selectors.
 
 ## Checkboxes
 
-<!-- #region checkboxes -->
+<section class="mds">
+  <div class="max-w-sm my-12 grid grid-flow-row grid-cols-2 gap-12">
+    <!-- #region checkboxes -->
+    <mc-checkbox label-name="Label" checked />
+    <mc-checkbox label-name="Label" />
+    <mc-checkbox label-name="Disabled" disabled />
+    <mc-checkbox label-name="Disabled" checked disabled />
+    <mc-checkbox label-name="Indeterminate" indeterminate />
+    <mc-checkbox label-name="Indeterminate" indeterminate disabled />
+    <mc-checkbox label-name="Text label that wraps multiple lines" />
+    <!-- #endregion checkboxes -->
+  </div>
+</section>
+
+<<<@/vuepress/components/selection-controls.md#checkboxes
+
+## mc-checkbox Properties
+
+<ComponentReadme component="mc-checkbox" />
+
+## Deprecated components ⚠️
+
+### Checkboxes
+
+<!-- #region checkboxes-dep -->
 <div class="mds">
   <div class="my-12 grid grid-flow-row grid-cols-2 gap-4">
     <div><mx-checkbox name="foo" label-name="Premier" checked /></div>
@@ -17,11 +41,11 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
     <div><mx-checkbox name="foo" indeterminate disabled label-name="Indeterminate" /></div>
   </div>
 </div>
-<!-- #endregion checkboxes -->
+<!-- #endregion checkboxes-dep -->
 
 <<< @/vuepress/components/selection-controls.md#checkboxes
 
-### Checkbox Properties
+#### Checkbox Properties
 
 | Property        | Attribute       | Description                                                                   | Type      | Default     |
 | --------------- | --------------- | ----------------------------------------------------------------------------- | --------- | ----------- |
@@ -36,9 +60,9 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
 | `name`          | `name`          |                                                                               | `string`  | `''`        |
 | `value`         | `value`         |                                                                               | `string`  | `''`        |
 
-## Radio Buttons
+### Radio Buttons
 
-<!-- #region radio-buttons -->
+<!-- #region radio-buttons-dep -->
 <div class="mds">
   <div class="my-12 grid grid-flow-row grid-cols-2 gap-4">
     <div><mx-radio name="foo" label-name="Premier" /></div>
@@ -49,11 +73,11 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
     <div><mx-radio name="foo" disabled checked label-name="Disabled" /></div>
   </div>
 </div>
-<!-- #endregion radio-buttons -->
+<!-- #endregion radio-buttons-dep -->
 
 <<< @/vuepress/components/selection-controls.md#radio-buttons
 
-### Radio Button Properties
+#### Radio Button Properties
 
 | Property     | Attribute     | Description | Type      | Default |
 | ------------ | ------------- | ----------- | --------- | ------- |
@@ -64,9 +88,9 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
 | `name`       | `name`        |             | `string`  | `''`    |
 | `value`      | `value`       |             | `string`  | `''`    |
 
-## Switches
+### Switches
 
-<!-- #region switches -->
+<!-- #region switches-dep -->
 <div class="mds">
   <div class="my-12 grid grid-flow-row grid-cols-2 gap-4">
     <div><mx-switch name="foo" label-name="Premier" /></div>
@@ -77,11 +101,11 @@ Selection controls consist of checkboxes, radios, and switches. Also see [Toggle
     <div><mx-switch name="foo" disabled checked label-name="Disabled" /></div>
   </div>
 </div>
-<!-- #endregion switches -->
+<!-- #endregion switches-dep -->
 
 <<< @/vuepress/components/selection-controls.md#switches
 
-### Switch Properties
+#### Switch Properties
 
 | Property     | Attribute     | Description | Type      | Default |
 | ------------ | ------------- | ----------- | --------- | ------- |

--- a/vuepress/components/selection-controls.md
+++ b/vuepress/components/selection-controls.md
@@ -44,6 +44,26 @@ Selection controls consist of checkboxes, radios, toggles, and range selectors.
 
 <ComponentReadme component="mc-radio" />
 
+## Toggles
+
+<section class="mds">
+  <div class="max-w-sm my-12 grid grid-flow-row grid-cols-2 gap-12">
+    <!-- #region toggles -->
+    <mc-toggle label-name="Label" checked />
+    <mc-toggle label-name="Label" />
+    <mc-toggle label-name="Disabled" disabled />
+    <mc-toggle label-name="Disabled" checked disabled />
+    <mc-toggle label-name="Text label that wraps multiple lines" />
+    <!-- #endregion toggles -->
+  </div>
+</section>
+
+<<<@/vuepress/components/selection-controls.md#toggles
+
+## mc-toggle Properties
+
+<ComponentReadme component="mc-toggle" />
+
 ## Deprecated components ⚠️
 
 ### Checkboxes

--- a/vuepress/css-documentation/typography.md
+++ b/vuepress/css-documentation/typography.md
@@ -54,6 +54,15 @@ headings, subtitles, body text, and more.
   </table>
 </section>
 
+## Font Size
+
+These classes should only be used when the font size needs to be applied without the additional properties of the above type scale classes.
+
+| Class     | Properties             |
+| --------- | ---------------------- |
+| `text-14` | `font-size: 0.875rem;` |
+| `text-16` | `font-size: 1rem;`     |
+
 ## Font Style
 
 | Class        | Properties            |
@@ -451,6 +460,7 @@ There are currently 5 subtitle variants available via special classes.
           [...stylesheet.cssRules].forEach(rule => {
             if (!rule || !rule.selectorText || !rule.selectorText.startsWith('.mds .text-')) return
             if (!rule.style.fontSize || rule.style[0] === '--deprecated') return
+            if (/text\-[0-9]+$/g.test(rule.selectorText)) return // Exclude text-16, etc.
             const getPxAndRem = val => val ? `${parseFloat(val) * 16}px / ${val}` : ''
             const utility = {
               className: rule.selectorText.replace('.mds ', ''),


### PR DESCRIPTION
This adds the Mercury checkboxes, radio buttons, toggle switches, and range selectors for #215.

![image](https://user-images.githubusercontent.com/3342530/203159119-b7e8aa8b-97be-480d-a348-a7746023fa29.png)
![image](https://user-images.githubusercontent.com/3342530/203159163-41b9a1f6-3471-4914-b43f-6595dd2460f9.png)
![image](https://user-images.githubusercontent.com/3342530/203159203-ce528b65-d4f3-4a13-b8d9-b855b36c1edb.png)
![image](https://user-images.githubusercontent.com/3342530/203159233-6513da11-cc0f-4caa-9d71-e90206cbc3ad.png)

Per my comment in the typography PR, I've already run into a need for an arbitrary 14px font-size utility for the checkbox/radio/toggle labels, so I added a `.text-14` class to the tailwind config.  I also added a `.text-16` for the icons used in the `mc-button` component since `.text-subtitle` did not really feel appropriate even though it technically looked okay.  @iamjpg Let me know if you hate these `.text-16` and `.text-14` classes.  I'm hoping we won't need too many of these, and I think I like `.text-14` better than something like `.text-sm` since you can tell immediately what the pixel size is and it's similar to how we have `.h-14`, `.w-14`, etc.

![image](https://user-images.githubusercontent.com/3342530/203162349-e8ee49f2-8581-4179-8e88-13f5c08dd3ca.png)

I also updated the `ComponentReadme` component to hide the redundant "Properties" heading since we have already been putting something like `## mc-radio Properties` above it.
