### PR TITLE
Add Mercury icon buttons

### DIFF
--- a/src/components/mc-icon-button/mc-icon-button.scss
+++ b/src/components/mc-icon-button/mc-icon-button.scss
@@ -1,0 +1,35 @@
+mc-icon-button {
+  color: var(--mc-text-icon-btn);
+  & > button,
+  & > a {
+    background-color: var(--mc-bg-icon-btn);
+    &.close-button {
+      background-color: var(--mc-bg-icon-btn-close);
+    }
+    &:hover {
+      background-color: var(--mc-bg-icon-btn-hover);
+      color: var(--mc-text-icon-btn-hover);
+      &.small-button {
+        color: var(--mc-text-icon-btn-small-hover);
+      }
+      &.close-button {
+        background-color: var(--mc-bg-icon-btn-close-hover);
+      }
+    }
+    &:active,
+    &:active.small-button,
+    &:active.close-button {
+      background-color: var(--mc-bg-icon-btn-active);
+      color: var(--mc-text-icon-btn-active);
+    }
+    &:disabled,
+    &[aria-disabled='true'] {
+      background-color: var(--mc-bg-icon-btn-disabled);
+      color: var(--mc-text-icon-btn-disabled);
+      &.small-button {
+        background-color: var(--mc-bg-icon-btn-small-disabled);
+        color: var(--mc-text-icon-btn-small-disabled);
+      }
+    }
+  }
+}

--- a/src/components/mc-icon-button/mc-icon-button.tsx
+++ b/src/components/mc-icon-button/mc-icon-button.tsx
@@ -1,0 +1,103 @@
+import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { propagateDataAttributes } from '../../utils/utils';
+
+export type McIconBtnType = 'normal' | 'small' | 'close';
+export type ButtonTypeAttribute = 'button' | 'submit' | 'reset';
+
+export interface IMcIconButtonProps {
+  btnType?: McIconBtnType;
+  disabled?: boolean;
+  /** The aria-label attribute for the inner button element. */
+  elAriaLabel?: string;
+  form?: string;
+  formaction?: string;
+  /** Create button as link */
+  href?: string;
+  /** Class name of icon */
+  icon?: string;
+  /** Only for link buttons */
+  target?: string;
+  type?: ButtonTypeAttribute;
+  value?: string;
+}
+
+@Component({
+  tag: 'mc-icon-button',
+  shadow: false,
+})
+export class McIconButton implements IMcIconButtonProps {
+  dataAttributes = {};
+
+  @Prop({ mutable: true }) btnType: McIconBtnType = 'normal';
+  @Prop() disabled = false;
+  @Prop() elAriaLabel: string;
+  @Prop() formaction: string;
+  @Prop() form: string;
+  @Prop() href: string;
+  @Prop() icon: string;
+  @Prop() target: string;
+  @Prop() type: ButtonTypeAttribute = 'button';
+  @Prop() value: string;
+
+  @Element() element: HTMLMcIconButtonElement;
+
+  componentWillRender = propagateDataAttributes;
+
+  onClick(e: MouseEvent) {
+    if (this.disabled) {
+      e.stopPropagation();
+      e.preventDefault();
+      return;
+    }
+  }
+
+  get buttonClass() {
+    let str = this.btnType + '-button'; // Sets color vars
+    str += ' flex items-center justify-center relative overflow-hidden appearance-none select-none';
+    str += ' cursor-pointer disabled:pointer-events-none disabled:cursor-auto hover:no-underline';
+    str += ' rounded-full text-16';
+    str += this.btnType === 'normal' ? ' h-40 w-40' : ' h-30 w-30';
+    return str;
+  }
+
+  render() {
+    const buttonContent = (
+      <span class="flex">
+        {this.btnType === 'close' && <i class="mds-x-close"></i>}
+        {this.icon && <i class={this.icon}></i>}
+        <slot />
+      </span>
+    );
+
+    return (
+      <Host class="inline-flex">
+        {this.href ? (
+          <a
+            href={this.href}
+            target={this.target}
+            aria-disabled={this.disabled ? 'true' : null}
+            class={this.buttonClass}
+            onClick={this.onClick.bind(this)}
+            {...this.dataAttributes}
+          >
+            {buttonContent}
+          </a>
+        ) : (
+          <button
+            type={this.type}
+            form={this.form}
+            formaction={this.formaction}
+            value={this.value}
+            disabled={this.disabled}
+            class={this.buttonClass}
+            onClick={this.onClick.bind(this)}
+            aria-label={this.elAriaLabel}
+            {...this.dataAttributes}
+          >
+            {buttonContent}
+          </button>
+        )}
+      </Host>
+    );
+  }
+}

--- a/src/components/mc-icon-button/test/mc-icon-button.spec.tsx
+++ b/src/components/mc-icon-button/test/mc-icon-button.spec.tsx
@@ -1,0 +1,112 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { McIconButton } from '../mc-icon-button';
+
+describe('mc-icon-button', () => {
+  let page;
+  let root: HTMLMcIconButtonElement;
+  let button: HTMLButtonElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [McIconButton],
+      html: `<mc-icon-button data-test="test"></mc-icon-button>`,
+    });
+    root = page.root;
+    button = root.querySelector('button');
+  });
+
+  it('renders a round 40px button by default', async () => {
+    expect(button).not.toBeNull();
+    expect(button.getAttribute('class')).toContain('w-40');
+    expect(button.getAttribute('class')).toContain('h-40');
+    expect(button.getAttribute('class')).toContain('rounded-full');
+  });
+
+  it('renders a 30px button is the btn-type is set to small', async () => {
+    root.btnType = 'small';
+    await page.waitForChanges();
+    expect(button.getAttribute('class')).toContain('w-30');
+    expect(button.getAttribute('class')).toContain('h-30');
+  });
+
+  it('uses the icon prop as a class name on an <i> element', async () => {
+    root.icon = 'ph-apple-logo';
+    await page.waitForChanges();
+    const icon = root.querySelector('i');
+    expect(icon.getAttribute('class')).toContain('ph-apple-logo');
+  });
+
+  it('renders a close icon if the btn-type is set to close', async () => {
+    root.btnType = 'close';
+    await page.waitForChanges();
+    const icon = root.querySelector('i');
+    expect(button.getAttribute('class')).toContain('w-30');
+    expect(button.getAttribute('class')).toContain('h-30');
+    expect(icon.getAttribute('class')).toContain('mds-x-close');
+  });
+
+  it('does not emit a click event when disabled is true', async () => {
+    const listener = jest.fn();
+    root.addEventListener('click', listener);
+    button.click();
+    expect(listener).toHaveBeenCalled();
+    listener.mockReset();
+    root.disabled = true;
+    await page.waitForChanges();
+    button.click();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('uses the elAriaLabel prop for the aria-label attribute on the button', async () => {
+    root.elAriaLabel = 'Open';
+    await page.waitForChanges();
+    expect(button.getAttribute('aria-label')).toBe('Open');
+  });
+
+  it('uses the value prop as an attribute on the button', async () => {
+    root.value = 'Open';
+    await page.waitForChanges();
+    expect(button.getAttribute('value')).toBe('Open');
+  });
+
+  it('uses the form and formaction props as attributes on the button', async () => {
+    root.form = 'the-form';
+    root.formaction = '/login';
+    await page.waitForChanges();
+    expect(button.getAttribute('form')).toBe('the-form');
+    expect(button.getAttribute('formaction')).toBe('/login');
+  });
+
+  it('uses the type prop as an attribute on the button', async () => {
+    root.type = 'submit';
+    await page.waitForChanges();
+    expect(button.getAttribute('type')).toBe('submit');
+  });
+
+  it('applies any data attributes to the button element', async () => {
+    expect(button.getAttribute('data-test')).toBe('test');
+  });
+});
+
+describe('mc-icon-button (as link)', () => {
+  let page;
+  let root: HTMLMcIconButtonElement;
+  let button: HTMLAnchorElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [McIconButton],
+      html: `<mc-icon-button href="/" icon="icon"></mc-icon-button>`,
+    });
+    root = page.root;
+    button = root.querySelector('a');
+  });
+
+  it('renders an <a>', async () => {
+    expect(button).not.toBeNull();
+  });
+
+  it('uses the target prop as the target attribute on the link', async () => {
+    root.target = '_blank';
+    await page.waitForChanges();
+    expect(button.getAttribute('target')).toBe('_blank');
+  });
+});

--- a/src/tailwind/icons.scss
+++ b/src/tailwind/icons.scss
@@ -118,4 +118,7 @@
   .mds-x {
     mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M19.2803 4.71967C19.5732 5.01256 19.5732 5.48744 19.2803 5.78033L5.78033 19.2803C5.48744 19.5732 5.01256 19.5732 4.71967 19.2803C4.42678 18.9874 4.42678 18.5126 4.71967 18.2197L18.2197 4.71967C18.5126 4.42678 18.9874 4.42678 19.2803 4.71967Z' fill='currentColor'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M4.71967 4.71967C5.01256 4.42678 5.48744 4.42678 5.78033 4.71967L19.2803 18.2197C19.5732 18.5126 19.5732 18.9874 19.2803 19.2803C18.9874 19.5732 18.5126 19.5732 18.2197 19.2803L4.71967 5.78033C4.42678 5.48744 4.42678 5.01256 4.71967 4.71967Z' fill='currentColor'/%3E%3C/svg%3E");
   }
+  .mds-x-close {
+    mask-image: url("data:image/svg+xml,%3csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M13.66 3.534a.844.844 0 0 0-1.194-1.193L8 6.807 3.534 2.34a.844.844 0 1 0-1.193 1.193L6.807 8 2.34 12.466a.844.844 0 1 0 1.193 1.193L8 9.193l4.466 4.466a.844.844 0 1 0 1.193-1.193L9.193 8l4.466-4.466Z' fill='currentColor'/%3e%3c/svg%3e");
+  }
 }

--- a/src/tailwind/styles.scss
+++ b/src/tailwind/styles.scss
@@ -19,6 +19,7 @@
 * Mercury components
 ***************************/
 @import '../components/mc-button/mc-button.scss';
+@import '../components/mc-icon-button/mc-icon-button.scss';
 @import '../components/mc-input/mc-input.scss';
 
 /***************************

--- a/src/tailwind/variables/index.scss
+++ b/src/tailwind/variables/index.scss
@@ -116,6 +116,22 @@
   --mc-text-btn-warning: var(--mc-white);
   /* #endregion mc-button */
 
+  /* #region mc-icon-button */
+  --mc-bg-icon-btn-active: var(--mc-primary);
+  --mc-bg-icon-btn-close: var(--mc-secondary-ultra-light);
+  --mc-bg-icon-btn-disabled: transparent;
+  --mc-bg-icon-btn-hover: var(--mc-secondary-ultra-light);
+  --mc-bg-icon-btn-close-hover: var(--mc-secondary-light);
+  --mc-bg-icon-btn-small-disabled: var(--mc-secondary-light);
+  --mc-bg-icon-btn: transparent;
+  --mc-text-icon-btn-active: var(--mc-white);
+  --mc-text-icon-btn-disabled: var(--mc-secondary-medium);
+  --mc-text-icon-btn-hover: var(--mc-secondary);
+  --mc-text-icon-btn-small-disabled: var(--mc-secondary);
+  --mc-text-icon-btn-small-hover: var(--mc-secondary-medium);
+  --mc-text-icon-btn: var(--mc-secondary);
+  /* #endregion mc-icon-button */
+
   /* #region buttons */
   /* Contained Buttons */
   --mds-bg-btn-contained-active: #0457af;

--- a/vuepress/components/buttons.md
+++ b/vuepress/components/buttons.md
@@ -10,56 +10,56 @@ The `btnType` prop can be used to change the button type, and the `small` prop c
   <div class="grid grid-cols-1 xl:grid-cols-2 gap-64 mb-64">
     <!-- #region mc-button-types -->
     <div>
-      <h2 class="text-h5">Normal</h2>
+      <h2 class="text-subtitle">Normal</h2>
       <div class="flex space-x-10">
         <mc-button>Enabled</mc-button>
         <mc-button disabled>Disabled</mc-button>
       </div>
     </div>
     <div>
-      <h2 class="text-h5">Small</h2>
+      <h2 class="text-subtitle">Small</h2>
       <div class="flex space-x-10">
         <mc-button small>Enabled</mc-button>
         <mc-button small disabled>Disabled</mc-button>
       </div>
     </div>
     <div>
-      <h2 class="text-h5">Alt Small</h2>
+      <h2 class="text-subtitle">Alt Small</h2>
       <div class="flex space-x-10">
         <mc-button btn-type="alt" small>Enabled</mc-button>
         <mc-button btn-type="alt" small disabled>Disabled</mc-button>
       </div>
     </div>
     <div>
-      <h2 class="text-h5">Ghost</h2>
+      <h2 class="text-subtitle">Ghost</h2>
       <div class="flex space-x-10">
         <mc-button btn-type="ghost">Enabled</mc-button>
         <mc-button btn-type="ghost" disabled>Disabled</mc-button>
       </div>
     </div>
     <div>
-      <h2 class="text-h5">Transparent</h2>
+      <h2 class="text-subtitle">Transparent</h2>
       <div class="flex space-x-10">
         <mc-button btn-type="transparent">Enabled</mc-button>
         <mc-button btn-type="transparent" disabled>Disabled</mc-button>
       </div>
     </div>
     <div>
-      <h2 class="text-h5">Action</h2>
+      <h2 class="text-subtitle">Action</h2>
       <div class="flex space-x-10">
         <mc-button btn-type="action">Enabled</mc-button>
         <mc-button btn-type="action" disabled>Disabled</mc-button>
       </div>
     </div>
     <div>
-      <h2 class="text-h5">Error</h2>
+      <h2 class="text-subtitle">Error</h2>
       <div class="flex space-x-10">
         <mc-button btn-type="error">Enabled</mc-button>
         <mc-button btn-type="error" disabled>Disabled</mc-button>
       </div>
     </div>
     <div>
-      <h2 class="text-h5">Warning</h2>
+      <h2 class="text-subtitle">Warning</h2>
       <div class="flex space-x-10">
         <mc-button btn-type="warning">Enabled</mc-button>
         <mc-button btn-type="warning" disabled>Disabled</mc-button>
@@ -88,28 +88,28 @@ This will ensure the button takes up the minimum space needed to display its con
   <div class="grid grid-cols-1 xl:grid-cols-2 gap-64 mb-64">
     <!-- #region mc-button-props -->
     <div>
-      <h2 class="text-h5">Button as Link</h2>
+      <h2 class="text-subtitle">Button as Link</h2>
       <div class="flex space-x-10">
         <mc-button href="#">Enabled</mc-button>
         <mc-button href="#" disabled>Disabled</mc-button>
       </div>
     </div>
     <div>
-      <h2 class="text-h5">Dropdown</h2>
+      <h2 class="text-subtitle">Dropdown</h2>
       <div class="flex space-x-10">
         <mc-button dropdown>Enabled</mc-button>
         <mc-button dropdown disabled>Disabled</mc-button>
       </div>
     </div>
     <div>
-      <h2 class="text-h5">Icons</h2>
+      <h2 class="text-subtitle">Icons</h2>
       <div class="flex space-x-10">
         <mc-button icon-left="ph-star-fill">Left</mc-button>
         <mc-button icon-right="ph-star-fill">Right</mc-button>
       </div>
     </div>
     <div>
-      <h2 class="text-h5">Slots</h2>
+      <h2 class="text-subtitle">Slots</h2>
       <div class="flex space-x-10">
         <mc-button>
           <svg slot="left" viewBox="0 0 16 16" width="16" height="16"><circle r="7" cx="8" cy="8" fill="currentColor"></circle></svg>
@@ -122,7 +122,7 @@ This will ensure the button takes up the minimum space needed to display its con
       </div>
     </div>
     <div>
-      <h2 class="text-h5">Hug</h2>
+      <h2 class="text-subtitle">Hug</h2>
       <div class="flex space-x-10 items-center">
         <mc-button hug>Hug</mc-button>
         <mc-button hug small>Hug</mc-button>
@@ -139,6 +139,59 @@ This will ensure the button takes up the minimum space needed to display its con
 ## mc-button Properties
 
 <ComponentReadme component="mc-button" />
+
+## `mc-icon-button`
+
+The `mc-icon-button` component is a button that only displays an icon.
+
+The icon may be set using the `icon` prop, which accepts a class name for an `<i>` element. Alternatively, the default slot can be used to render custom content, such as an inline SVG.
+
+The `btnType` can be set to `"normal"` (the default), `"small"`, or `"close"`. The `"small"` type affects both the size and colors. The `"close"` type is a small button with a close icon.
+
+<section class="mds">
+  <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-32 mb-32">
+    <!-- #region mc-icon-button -->
+    <div>
+      <h2 class="text-subtitle">Normal</h2>
+      <div class="flex space-x-10">
+        <mc-icon-button icon="ph-dots-three-outline-fill" />
+        <mc-icon-button icon="ph-dots-three-outline-fill" disabled />
+        <mc-icon-button>
+          <svg viewBox="0 0 16 16" width="16" height="16"><rect x="0" y="0" width="16" height="16" fill="currentColor"></rect></svg>
+        </mc-icon-button>
+        <mc-icon-button disabled>
+          <svg viewBox="0 0 16 16" width="16" height="16"><rect x="0" y="0" width="16" height="16" fill="currentColor"></rect></svg>
+        </mc-icon-button>
+      </div>
+    </div>
+    <div>
+      <h2 class="text-subtitle">Small</h2>
+      <div class="flex space-x-10">
+        <mc-icon-button btn-type="small" icon="ph-dots-three-outline-fill" />
+        <mc-icon-button btn-type="small" icon="ph-dots-three-outline-fill" disabled />
+        <mc-icon-button btn-type="small">
+          <svg viewBox="0 0 16 16" width="16" height="16"><rect x="0" y="0" width="16" height="16" fill="currentColor"></rect></svg>
+        </mc-icon-button>
+        <mc-icon-button btn-type="small" disabled>
+          <svg viewBox="0 0 16 16" width="16" height="16"><rect x="0" y="0" width="16" height="16" fill="currentColor"></rect></svg>
+        </mc-icon-button>
+      </div>
+    </div>
+    <div>
+      <h2 class="text-subtitle">Close</h2>
+      <div class="flex space-x-10">
+        <mc-icon-button btn-type="close" />
+      </div>
+    </div>
+    <!-- #endregion mc-icon-button -->
+  </div>
+</section>
+
+<<< @/vuepress/components/buttons.md#mc-icon-button
+
+## mc-icon-button Properties
+
+<ComponentReadme component="mc-icon-button" />
 
 ## Deprecated Buttons
 

--- a/vuepress/components/mc-icon-button/readme.md
+++ b/vuepress/components/mc-icon-button/readme.md
@@ -1,0 +1,26 @@
+# mc-icon-button
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property      | Attribute       | Description                                            | Type                              | Default     |
+| ------------- | --------------- | ------------------------------------------------------ | --------------------------------- | ----------- |
+| `btnType`     | `btn-type`      |                                                        | `"close" \| "normal" \| "small"`  | `'normal'`  |
+| `disabled`    | `disabled`      |                                                        | `boolean`                         | `false`     |
+| `elAriaLabel` | `el-aria-label` | The aria-label attribute for the inner button element. | `string`                          | `undefined` |
+| `form`        | `form`          |                                                        | `string`                          | `undefined` |
+| `formaction`  | `formaction`    |                                                        | `string`                          | `undefined` |
+| `href`        | `href`          | Create button as link                                  | `string`                          | `undefined` |
+| `icon`        | `icon`          | Class name of icon                                     | `string`                          | `undefined` |
+| `target`      | `target`        | Only for link buttons                                  | `string`                          | `undefined` |
+| `type`        | `type`          |                                                        | `"button" \| "reset" \| "submit"` | `'button'`  |
+| `value`       | `value`         |                                                        | `string`                          | `undefined` |
+
+
+----------------------------------------------
+
+


### PR DESCRIPTION
This adds the new `mc-icon-button` component.  The close button is needed to implement modals for #222.

![image](https://user-images.githubusercontent.com/3342530/203414119-6e61852e-d5c3-4ea0-b37e-b6a28b0deb62.png)
