### PR TITLE
Do not combine `.overflow-hidden` with `.contents`

### DIFF
--- a/src/components/mx-table-row/mx-table-row.tsx
+++ b/src/components/mx-table-row/mx-table-row.tsx
@@ -414,8 +414,8 @@ export class MxTableRow {
   }
 
   get rowClass(): string {
-    let str = 'table-row overflow-hidden';
-    str += this.minWidths.sm ? ' contents' : ' grid';
+    let str = 'table-row';
+    str += this.minWidths.sm ? ' contents' : ' grid overflow-hidden';
     if (this.checkable) str += ' checkable-row';
     if (this.checkable && this.checkOnRowClick) str += ' cursor-pointer';
     if (!this.minWidths.sm && !this.isMobileExpanded) str += ' mobile-collapsed';


### PR DESCRIPTION
This addresses #227. Cypress mistakenly thinks some elements are not visible because we have combined `overflow: hidden` with `display: contents` on a parent element, which is admittedly unusual.