### PR TITLE
OT-23 - Fix bad column count when first table row has nested rows

### DIFF
--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -386,7 +386,7 @@ export class MxTable {
     const rows = this.getTableRows();
     rows.forEach((row: HTMLMxTableRowElement) => {
       if (row.subheader) return;
-      const cells = row.querySelectorAll('mx-table-cell');
+      const cells = row.querySelectorAll('mx-table-cell:not(mx-table-row mx-table-row mx-table-cell)');
       let colIndex = 0;
       cells.forEach((cell: HTMLMxTableCellElement) => {
         cell.columnIndex = colIndex;
@@ -462,7 +462,7 @@ export class MxTable {
       // If `columns` prop is missing or does not have enough defintions for all columns, add default columns
       const rows = this.getTableRows().filter(row => !row.subheader);
       if (rows.length) {
-        const cellCount = rows[0].querySelectorAll('mx-table-cell').length;
+        const cellCount = rows[0].querySelectorAll('mx-table-cell:not(mx-table-row mx-table-row mx-table-cell)').length;
         if (cellCount !== cols.length) {
           cols = cols.concat(new Array(cellCount).fill({})).slice(0, cellCount);
         }


### PR DESCRIPTION
This problem showed up in nucleus not long after I went on parental leave.

![image](https://user-images.githubusercontent.com/3342530/208167341-95334aac-0ec1-4dfc-a175-6c94795517a0.png)

When you use the default slot of the `mx-table` component, it establishes a column count based on the number of `mx-table-cell` elements in the *first row*.  It uses this column count to create the CSS grid.

The problem would show up whenever you nested a row inside the *first row*, causing `rows[0].querySelectorAll('mx-table-cell')` to return both the top-level cells and the nested cells.

The fix is to simply change the selector to exclude cells that are inside nested rows.