### PR TITLE
OT-23 - Fix column count when first row is subheader

### DIFF
--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -462,7 +462,9 @@ export class MxTable {
       // If `columns` prop is missing or does not have enough defintions for all columns, add default columns
       const rows = this.getTableRows().filter(row => !row.subheader);
       if (rows.length) {
-        const cellCount = rows[0].querySelectorAll('mx-table-cell:not(mx-table-row mx-table-row mx-table-cell)').length;
+        const cellCount = rows[0].querySelectorAll(
+          'mx-table-cell:not(mx-table-row:not([subheader]) mx-table-row mx-table-cell)',
+        ).length;
         if (cellCount !== cols.length) {
           cols = cols.concat(new Array(cellCount).fill({})).slice(0, cellCount);
         }


### PR DESCRIPTION
This is an additional fix for [OT-23](https://moxiworks.atlassian.net/browse/OT-23).  I previously changed the query for the first row's table cells to `mx-table-cell:not(mx-table-row mx-table-row mx-table-cell)` to avoid counting cells that are in a nested row.  However, this broke the counting of cells inside a subheader row, so this fixes that by adding a `:not([subheader])`.

This change should fix the admin Programs table in nucleus in the current `release-candidate` branch.
![image](https://user-images.githubusercontent.com/3342530/210431658-102293b2-efdb-4bca-95ae-e6e6888ef3fd.png)
