### PR TITLE
OT-76 / OT-85 - Fix isDateObject exceptions when a table cell value is null/undefined

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -17,6 +17,7 @@ export function capitalize(str: string): string {
 }
 
 export function isDateObject(val: any): boolean {
+  if (val == null) return false; // null or undefined
   if (typeof val !== 'object') return false;
   return 'getTime' in val && !isNaN(val.getTime()); // "Invalid Date" objects return NaN for getTime()
 }


### PR DESCRIPTION
If a table is given a `null` cell value via the `rows` prop, the `isDateObject` helper blows up.  The `typeof val !== 'object'` check I already had wasn't enough since `typeof null` returns `'object'` (JavaScript, you so crazy).

The bad nucleus association data in QA has some null `boardname` values, which caused a table to not render at all.  I will also do another PR in nucleus to filter those null associations out.