### PR TITLE
OT-94 - Fix table sorting when a column has both string and number values

### DIFF
--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -622,7 +622,7 @@ export class MxTable {
         const valueA = this.getCellSortableValue(a, sortByColumn);
         const valueB = this.getCellSortableValue(b, sortByColumn);
         if (typeof valueA === 'number' && typeof valueB === 'number') return valueA - valueB;
-        return (valueA as string).localeCompare(valueB as string);
+        return valueA.toString().localeCompare(valueB.toString());
       };
     }
     rows.sort(sortCompare);

--- a/src/components/mx-table/mx-table.tsx
+++ b/src/components/mx-table/mx-table.tsx
@@ -634,6 +634,7 @@ export class MxTable {
     const val = row[col.property];
     if (['date', 'dateTime'].includes(col.type) || isDateObject(val)) return -new Date(val).getTime();
     if (col.type === 'boolean') return val ? 1 : 0;
+    if (val == null) return '';
     return val;
   }
 


### PR DESCRIPTION
If a column has values that are a mix of numbers and strings like `30` and `'100'`, the table will effectively try to call `(30).localeCompare('100')`, which results in a `localeCompare is not a function` exception.

This PR prevents the exception by always converting values to strings once it is determined that they are not both numbers.  

For OT-94, I'm also [making a change to the affected table in nucleus](https://github.com/moxiworks/nucleus/pull/721) to use a custom `sortCompare`, which will avoid the exception AND sort the rows as expected.