### PR TITLE
Fix tab width on Safari

### DIFF
--- a/src/components/mx-tab/mx-tab.tsx
+++ b/src/components/mx-tab/mx-tab.tsx
@@ -41,7 +41,7 @@ export class MxTab implements IMxTabProps {
   }
 
   get tabClass() {
-    let str = 'mx-tab relative inline-flex items-center justify-center min-w-full';
+    let str = 'mx-tab relative inline-flex items-center justify-center min-w-0';
     str += this.label && this.icon ? ' h-72' : ' h-48';
     return str;
   }


### PR DESCRIPTION
Something must have changed in Safari recently because the tabs went crazy.  In my testing, a `.min-w-full` class on the tab can be safely replaced with `.min-w-0` to address the issue.

## Before 🤪
![image](https://user-images.githubusercontent.com/3342530/224129717-554df9c3-cc70-42aa-85d3-2d77e42e250f.png)

## After
![image](https://user-images.githubusercontent.com/3342530/224129685-187f3901-8db4-49bc-b453-e054539c07ea.png)
