### PR TITLE
OT-101 - Fix scollbar square corners overflowing menu

### DIFF
--- a/src/components/mx-menu/mx-menu.tsx
+++ b/src/components/mx-menu/mx-menu.tsx
@@ -238,7 +238,7 @@ export class MxMenu {
   render() {
     return (
       <Host class={this.hostClass}>
-        <div ref={el => (this.menuElem = el)} class="flex flex-col shadow-9 rounded-lg">
+        <div ref={el => (this.menuElem = el)} class="flex flex-col shadow-9 rounded-lg overflow-hidden">
           <div
             id={this.uuid}
             ref={el => (this.scrollElem = el)}


### PR DESCRIPTION
This adds `overflow: hidden` to the rounded menu element so that the inner scrollbar does not overflow, causing square corners on the right side of the menu.

https://moxiworks.atlassian.net/browse/OT-101

## Before

![image](https://user-images.githubusercontent.com/3342530/225051517-6a0ab09a-de60-4bbf-8829-525eb685b331.png)

## After

![image](https://user-images.githubusercontent.com/3342530/225051331-985e97a3-5961-435b-9438-f56b510e5e38.png)
