### PR TITLE
Allow modals to be initially open

### DIFF
--- a/src/components/mx-modal/mx-modal.tsx
+++ b/src/components/mx-modal/mx-modal.tsx
@@ -118,6 +118,10 @@ export class MxModal {
     unlockBodyScroll(this.element);
   }
 
+  componentDidLoad() {
+    if (this.isOpen) this.openModal();
+  }
+
   async openModal() {
     moveToPortal(this.element);
     lockBodyScroll(this.element);


### PR DESCRIPTION
Currently, if the `isOpen` prop is initially set to `true`, the modal will not open once the component loads.  This fixes that.