### PR TITLE
fix: remove negative margins on focused inputs

### DIFF
--- a/packages/mds/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
+++ b/packages/mds/src/components/mx-dropdown-menu/mx-dropdown-menu.tsx
@@ -94,13 +94,11 @@ export class MxDropdownMenu {
   get inputClass() {
     let str =
       'absolute inset-0 w-full h-full pl-16 overflow-hidden outline-none appearance-none select-none bg-transparent cursor-pointer disabled:cursor-auto';
-    if (this.isFocused) str += ' -ml-1'; // prevent shifting due to border-width change
     return str;
   }
 
   get suffixClass() {
     let str = 'icon-suffix absolute flex items-center h-full right-12 space-x-8 pointer-events-none';
-    if (this.isFocused) str += ' -mr-1'; // prevent shifting due to border-width change
     return str;
   }
 

--- a/packages/mds/src/components/mx-input/mx-input.tsx
+++ b/packages/mds/src/components/mx-input/mx-input.tsx
@@ -166,7 +166,6 @@ export class MxInput implements IMxInputProps {
     } else {
       str += ' p-16 overflow-y-auto resize-none';
     }
-    if (this.isFocused || this.error) str += this.leftIcon ? ' -mr-1' : ' -m-1'; // prevent shifting due to border-width change
     return str;
   }
 
@@ -178,8 +177,6 @@ export class MxInput implements IMxInputProps {
       str += this.leftIcon && !this.textarea ? ' left-48 has-left-icon' : ' left-12';
       if (this.dense && !this.textarea) str += ' dense text-4';
       if (this.isFocused || this.characterCount > 0) str += ' floating';
-      if (this.isFocused || this.error) str += ' -ml-1'; // prevent shifting due to border-width change
-      if ((this.isFocused || this.error) && this.textarea) str += ' -mt-1';
     } else {
       str += ' subtitle2 mb-4';
     }
@@ -189,13 +186,11 @@ export class MxInput implements IMxInputProps {
 
   get leftIconWrapperClass() {
     let str = 'flex items-center h-full pl-16 space-x-16';
-    if (this.isFocused || this.error) str += ' -ml-1'; // prevent shifting due to border-width change
     return str;
   }
 
   get rightContentClass() {
     let str = 'icon-suffix flex items-center h-full pr-16 space-x-8';
-    if (this.isFocused || this.error) str += ' -mr-1'; // prevent shifting due to border-width change
     return str;
   }
 

--- a/packages/mds/src/components/mx-select/mx-select.tsx
+++ b/packages/mds/src/components/mx-select/mx-select.tsx
@@ -86,7 +86,6 @@ export class MxSelect {
   get selectElClass() {
     let str =
       'absolute inset-0 w-full pl-16 overflow-hidden outline-none appearance-none bg-transparent cursor-pointer disabled:cursor-auto';
-    if (this.isFocused) str += ' -m-1'; // prevent shifting due to border-width change
     return str;
   }
 
@@ -96,7 +95,6 @@ export class MxSelect {
       str += ' absolute mt-0 left-12 px-4';
       if (this.dense) str += ' dense text-4';
       if (this.isFocused || this.hasValue) str += ' floating';
-      if (this.isFocused) str += ' -ml-1'; // prevent shifting due to border-width change
     } else {
       str += ' subtitle2 mb-4';
     }
@@ -105,7 +103,6 @@ export class MxSelect {
 
   get iconSuffixClass() {
     let str = 'icon-suffix absolute flex items-center h-full right-12 space-x-8 pointer-events-none';
-    if (this.isFocused) str += ' -mr-1'; // prevent shifting due to border-width change
     return str;
   }
 


### PR DESCRIPTION
Previously, the `mx-dropdown-menu`, `mx-select`, and `mx-input` components had a 1px border width when not focused and a 2px border width when focused (or when in an error state).

https://github.com/moxiworks/mds/pull/246 removed this change in border width, so the negative margins that were previously added to prevent layout shifts need to also be removed.