### PR TITLE
feat: initial block input components

### DIFF
--- a/packages/mds/src/components.d.ts
+++ b/packages/mds/src/components.d.ts
@@ -65,6 +65,23 @@ export namespace Components {
          */
         "sticky": boolean;
     }
+    interface MxBlockInput {
+        "assistiveText": string;
+        "colspan": number;
+        "disabled": boolean;
+        "error": boolean;
+        "inputId": string;
+        "label": string;
+        "maxlength": number;
+        "name": string;
+        "placeholder": string;
+        "readonly": boolean;
+        "type": string;
+        "value": string;
+    }
+    interface MxBlockWrapper {
+        "columns": number;
+    }
     interface MxButton {
         "btnType": BtnType;
         "disabled": boolean;
@@ -1165,6 +1182,18 @@ declare global {
         prototype: HTMLMxBannerElement;
         new (): HTMLMxBannerElement;
     };
+    interface HTMLMxBlockInputElement extends Components.MxBlockInput, HTMLStencilElement {
+    }
+    var HTMLMxBlockInputElement: {
+        prototype: HTMLMxBlockInputElement;
+        new (): HTMLMxBlockInputElement;
+    };
+    interface HTMLMxBlockWrapperElement extends Components.MxBlockWrapper, HTMLStencilElement {
+    }
+    var HTMLMxBlockWrapperElement: {
+        prototype: HTMLMxBlockWrapperElement;
+        new (): HTMLMxBlockWrapperElement;
+    };
     interface HTMLMxButtonElement extends Components.MxButton, HTMLStencilElement {
     }
     var HTMLMxButtonElement: {
@@ -1384,6 +1413,8 @@ declare global {
     interface HTMLElementTagNameMap {
         "mx-badge": HTMLMxBadgeElement;
         "mx-banner": HTMLMxBannerElement;
+        "mx-block-input": HTMLMxBlockInputElement;
+        "mx-block-wrapper": HTMLMxBlockWrapperElement;
         "mx-button": HTMLMxButtonElement;
         "mx-chart": HTMLMxChartElement;
         "mx-checkbox": HTMLMxCheckboxElement;
@@ -1467,6 +1498,23 @@ declare namespace LocalJSX {
           * When set, `position: sticky` will be applied to the banner.
          */
         "sticky"?: boolean;
+    }
+    interface MxBlockInput {
+        "assistiveText"?: string;
+        "colspan"?: number;
+        "disabled"?: boolean;
+        "error"?: boolean;
+        "inputId"?: string;
+        "label"?: string;
+        "maxlength"?: number;
+        "name"?: string;
+        "placeholder"?: string;
+        "readonly"?: boolean;
+        "type"?: string;
+        "value"?: string;
+    }
+    interface MxBlockWrapper {
+        "columns"?: number;
     }
     interface MxButton {
         "btnType"?: BtnType;
@@ -2519,6 +2567,8 @@ declare namespace LocalJSX {
     interface IntrinsicElements {
         "mx-badge": MxBadge;
         "mx-banner": MxBanner;
+        "mx-block-input": MxBlockInput;
+        "mx-block-wrapper": MxBlockWrapper;
         "mx-button": MxButton;
         "mx-chart": MxChart;
         "mx-checkbox": MxCheckbox;
@@ -2563,6 +2613,8 @@ declare module "@stencil/core" {
         interface IntrinsicElements {
             "mx-badge": LocalJSX.MxBadge & JSXBase.HTMLAttributes<HTMLMxBadgeElement>;
             "mx-banner": LocalJSX.MxBanner & JSXBase.HTMLAttributes<HTMLMxBannerElement>;
+            "mx-block-input": LocalJSX.MxBlockInput & JSXBase.HTMLAttributes<HTMLMxBlockInputElement>;
+            "mx-block-wrapper": LocalJSX.MxBlockWrapper & JSXBase.HTMLAttributes<HTMLMxBlockWrapperElement>;
             "mx-button": LocalJSX.MxButton & JSXBase.HTMLAttributes<HTMLMxButtonElement>;
             "mx-chart": LocalJSX.MxChart & JSXBase.HTMLAttributes<HTMLMxChartElement>;
             "mx-checkbox": LocalJSX.MxCheckbox & JSXBase.HTMLAttributes<HTMLMxCheckboxElement>;

--- a/packages/mds/src/components/mx-block-input/mx-block-input.tsx
+++ b/packages/mds/src/components/mx-block-input/mx-block-input.tsx
@@ -92,6 +92,7 @@ export class MxBlockInput implements IMxBlockInputProps {
 
   get containerClass() {
     let str = 'mx-block-input-container';
+    if (this.disabled) str += ' disabled';
     if (this.error) str += ' error';
     return str;
   }

--- a/packages/mds/src/components/mx-block-input/mx-block-input.tsx
+++ b/packages/mds/src/components/mx-block-input/mx-block-input.tsx
@@ -100,11 +100,12 @@ export class MxBlockInput implements IMxBlockInputProps {
     return (
       <Host class={this.hostClass}>
         <div class={this.containerClass} onClick={this.onContainerClick.bind(this)}>
-          <label>
+          <label htmlFor={this.inputId || this.uuid}>
             {this.label}
-            {this.assistiveText && <span>{this.assistiveText}</span>}
+            {this.assistiveText && <span id={this.inputId || this.uuid + '-assistive'}>{this.assistiveText}</span>}
           </label>
           <input
+            aria-describedby={this.assistiveText ? this.inputId || this.uuid + '-assistive' : null}
             disabled={this.disabled}
             id={this.inputId || this.uuid}
             maxlength={this.maxlength}

--- a/packages/mds/src/components/mx-block-input/mx-block-input.tsx
+++ b/packages/mds/src/components/mx-block-input/mx-block-input.tsx
@@ -106,7 +106,7 @@ export class MxBlockInput implements IMxBlockInputProps {
             {this.assistiveText && <span id={this.inputId || this.uuid + '-assistive'}>{this.assistiveText}</span>}
           </label>
           <input
-            aria-describedby={this.assistiveText ? this.inputId || this.uuid + '-assistive' : null}
+            aria-describedby={this.assistiveText ? (this.inputId || this.uuid) + '-assistive' : null}
             disabled={this.disabled}
             id={this.inputId || this.uuid}
             maxlength={this.maxlength}

--- a/packages/mds/src/components/mx-block-input/mx-block-input.tsx
+++ b/packages/mds/src/components/mx-block-input/mx-block-input.tsx
@@ -1,0 +1,126 @@
+import { Component, Host, h, Prop, State, Watch, Element } from '@stencil/core';
+import { uuidv4, propagateDataAttributes } from '../../utils/utils';
+
+export interface IMxBlockInputProps {
+  assistiveText: string;
+  colspan: number;
+  disabled: boolean;
+  error: boolean;
+  inputId: string;
+  label: string;
+  maxlength: number;
+  name: string;
+  placeholder: string;
+  readonly: boolean;
+  type: string;
+  value: string;
+}
+
+@Component({
+  tag: 'mx-block-input',
+  shadow: false,
+})
+export class MxBlockInput implements IMxBlockInputProps {
+  dataAttributes = {};
+  textInput!: HTMLInputElement;
+  textArea!: HTMLTextAreaElement;
+  uuid: string = uuidv4();
+
+  @Prop() assistiveText: string;
+  @Prop() colspan: number;
+  @Prop() disabled = false;
+  @Prop({ mutable: true, reflect: true }) error = false;
+  @Prop() inputId: string;
+  @Prop() label: string;
+  @Prop() maxlength: number;
+  @Prop() name: string;
+  @Prop() placeholder: string;
+  @Prop() readonly = false;
+  @Prop() type = 'text';
+  @Prop({ mutable: true }) value: string;
+
+  @State() isFocused = false;
+  @State() characterCount = 0;
+
+  @Element() element: HTMLMxBlockInputElement;
+
+  componentWillRender = propagateDataAttributes;
+
+  componentDidLoad() {
+    this.updateValue();
+  }
+
+  @Watch('value')
+  onValueChange() {
+    this.updateValue();
+  }
+
+  updateValue() {
+    this.textInput.value = this.hasValue ? this.value : '';
+  }
+
+  onFocus() {
+    this.isFocused = true;
+    this.error = false;
+  }
+
+  onBlur() {
+    this.isFocused = false;
+  }
+
+  onContainerClick() {
+    if (!this.disabled && !this.readonly) this.textInput.focus();
+  }
+
+  onInput(e: InputEvent) {
+    this.characterCount = (e.target as HTMLInputElement).value.length;
+    this.value = (e.target as HTMLInputElement).value;
+  }
+
+  get hasValue() {
+    return this.value !== null && this.value !== '' && this.value !== undefined;
+  }
+
+  get hostClass() {
+    let str = 'mx-block-input';
+    // for now we want to allow up to 6 columns
+    if (this.colspan > 0 && this.colspan < 7) {
+      str += ' col-span-' + this.colspan;
+    }
+    return str;
+  }
+
+  get containerClass() {
+    let str = 'mx-block-input-container';
+    if (this.error) str += ' error';
+    return str;
+  }
+
+  render() {
+    return (
+      <Host class={this.hostClass}>
+        <div class={this.containerClass} onClick={this.onContainerClick.bind(this)}>
+          <label>
+            {this.label}
+            {this.assistiveText && <span>{this.assistiveText}</span>}
+          </label>
+          <input
+            disabled={this.disabled}
+            id={this.inputId || this.uuid}
+            maxlength={this.maxlength}
+            name={this.name}
+            onBlur={this.onBlur.bind(this)}
+            onFocus={this.onFocus.bind(this)}
+            onInput={this.onInput.bind(this)}
+            placeholder={this.placeholder}
+            readonly={this.readonly}
+            ref={el => (this.textInput = el as HTMLInputElement)}
+            type={this.type}
+            value={this.value}
+            {...this.dataAttributes}
+          />
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/mds/src/components/mx-block-input/test/mx-block-input.spec.tsx
+++ b/packages/mds/src/components/mx-block-input/test/mx-block-input.spec.tsx
@@ -1,0 +1,75 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { MxBlockInput } from '../mx-block-input';
+
+describe('mx-block-input', () => {
+  let page;
+  let root: HTMLMxBlockInputElement;
+  let input: HTMLInputElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxBlockInput],
+      html: `
+        <mx-block-input
+          assistive-text="testAssistiveText"
+          colspan="2"
+          inputId="testId"
+          label="testLabel"
+          maxlength="10"
+          name="testName"
+          placeholder="testPlaceholder"
+          type="email"
+          value="testValue"
+          data-test="testData"
+        />
+      `,
+    });
+    root = page.root;
+    input = root.querySelector('input');
+  });
+
+  it('assigns proper value for label', async () => {
+    const placeholder = root.querySelector('label');
+    expect(placeholder.textContent).toContain('testLabel');
+  });
+
+  it('has the right name, value, placeholder and type', async () => {
+    expect(input.getAttribute('name')).toBe('testName');
+    expect(input.value).toBe('testValue');
+    expect(input.placeholder).toBe('testPlaceholder');
+    expect(input.getAttribute('type')).toBe('email');
+  });
+
+  it('updates the value prop when the input value is changed', async () => {
+    input.value = 'bar';
+    input.dispatchEvent(new Event('input'));
+    await page.waitForChanges();
+    expect(root.value).toBe('bar');
+  });
+
+  it('should have proper assistive text', async () => {
+    const assitive = root.querySelector('label span');
+    expect(assitive.textContent).toBe('testAssistiveText');
+  });
+
+  it('disables the input based on the disabled prop', async () => {
+    expect(input.getAttribute('disabled')).toBeNull();
+    root.disabled = true;
+    await page.waitForChanges();
+    expect(input.getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('sets the inputs to read-only if the readonly prop is set', async () => {
+    expect(input.getAttribute('readonly')).toBeNull();
+    root.readonly = true;
+    await page.waitForChanges();
+    expect(input.getAttribute('readonly')).not.toBeNull();
+  });
+
+  it('sets the maxlength attribute on the input', async () => {
+    expect(input.getAttribute('maxlength')).toBe('10');
+  });
+
+  it('applies any data attributes to the input element', async () => {
+    expect(input.getAttribute('data-test')).toBe('testData');
+  });
+});

--- a/packages/mds/src/components/mx-block-input/test/mx-block-input.spec.tsx
+++ b/packages/mds/src/components/mx-block-input/test/mx-block-input.spec.tsx
@@ -5,6 +5,7 @@ describe('mx-block-input', () => {
   let page;
   let root: HTMLMxBlockInputElement;
   let input: HTMLInputElement;
+  let label: HTMLLabelElement;
   beforeEach(async () => {
     page = await newSpecPage({
       components: [MxBlockInput],
@@ -25,11 +26,16 @@ describe('mx-block-input', () => {
     });
     root = page.root;
     input = root.querySelector('input');
+    label = root.querySelector('label');
   });
 
   it('assigns proper value for label', async () => {
     const placeholder = root.querySelector('label');
     expect(placeholder.textContent).toContain('testLabel');
+  });
+
+  it('associates the label with the input', async () => {
+    expect(label.getAttribute('htmlFor')).toBe(input.getAttribute('id'));
   });
 
   it('has the right name, value, placeholder and type', async () => {
@@ -47,7 +53,7 @@ describe('mx-block-input', () => {
   });
 
   it('should have proper assistive text', async () => {
-    const assitive = root.querySelector('label span');
+    const assitive = label.querySelector('span');
     expect(assitive.textContent).toBe('testAssistiveText');
   });
 
@@ -71,5 +77,9 @@ describe('mx-block-input', () => {
 
   it('applies any data attributes to the input element', async () => {
     expect(input.getAttribute('data-test')).toBe('testData');
+  });
+
+  it('associates assistive text to the aria-describedby attribute', async () => {
+    expect(input.getAttribute('aria-describedby')).toBe(label.querySelector('span').getAttribute('id'));
   });
 });

--- a/packages/mds/src/components/mx-block-wrapper/mx-block-wrapper.tsx
+++ b/packages/mds/src/components/mx-block-wrapper/mx-block-wrapper.tsx
@@ -1,0 +1,39 @@
+import { Component, Host, h, Prop, Element } from '@stencil/core';
+import { propagateDataAttributes } from '../../utils/utils';
+
+export interface IMxBlockWrapperProps {
+  columns: number;
+}
+
+@Component({
+  tag: 'mx-block-wrapper',
+  shadow: false,
+})
+export class MxBlockWrapper implements IMxBlockWrapperProps {
+  @Prop() columns: number;
+
+  @Element() element: HTMLMxBlockWrapperElement;
+
+  componentWillRender = propagateDataAttributes;
+
+  get containerClass() {
+    let str = 'mx-block-wrapper-container';
+    // for now we want to allow up to 6 columns
+    if (this.columns > 0 && this.columns < 7) {
+      str += ' md:grid-cols-' + this.columns;
+    } else {
+      str += ' md:grid-cols-none';
+    }
+    return str;
+  }
+
+  render() {
+    return (
+      <Host class={'mx-block-wrapper'}>
+        <div class={this.containerClass}>
+          <slot></slot>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/mds/src/components/mx-block-wrapper/test/mx-block-wrapper.spec.tsx
+++ b/packages/mds/src/components/mx-block-wrapper/test/mx-block-wrapper.spec.tsx
@@ -1,0 +1,23 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { MxBlockWrapper } from '../mx-block-wrapper';
+
+describe('mx-block-wrapper', () => {
+  let page;
+  let root: HTMLMxBlockInputElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [MxBlockWrapper],
+      html: `
+        <mx-block-wrapper
+          columns="2"
+        />
+      `,
+    });
+    root = page.root;
+  });
+
+  it('assigns proper class for columns', async () => {
+    const div = root.querySelector('div');
+    expect(div.className).toContain('md:grid-cols-2');
+  });
+});

--- a/packages/mds/src/tailwind/mx-block-input/index.scss
+++ b/packages/mds/src/tailwind/mx-block-input/index.scss
@@ -17,6 +17,10 @@
       border: 1px solid var(--mds-color-secondary-light);
     }
     
+    &.disabled:before {
+      background-color: var(--mds-color-secondary-light);
+    }
+    
     &:after {
       display: none;
       position: absolute;

--- a/packages/mds/src/tailwind/mx-block-input/index.scss
+++ b/packages/mds/src/tailwind/mx-block-input/index.scss
@@ -1,0 +1,97 @@
+.mx-block-input {
+  .mx-block-input-container {
+    margin-right: -1px;
+    margin-bottom: -1px;
+    position: relative;
+    border: 1px solid transparent;
+
+    &:before {
+      display: block;
+      position: absolute;
+      z-index: -1;
+      bottom: -1px;
+      left: -1px;
+      top: -1px;
+      right: -1px;
+      content: "";
+      border: 1px solid var(--mds-color-secondary-light);
+    }
+    
+    &:after {
+      display: none;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      top: 0;
+      width: 0;
+      content: "";
+      border: none;
+      background-color: var(--mds-color-primary);
+    }
+
+    &:focus-within {
+      border: 1px solid var(--mds-color-primary);
+    }
+
+    &.error:before {
+      border-color: var(--mds-color-error);
+    }
+    &.error:after {
+      background-color: var(--mds-color-error);
+    }
+    &.error label {
+      color: var(--mds-color-error);
+    }
+
+    &:focus-within:after {
+      display: block;
+      animation: slideIn var(--mds-animation-speed-quick) var(--mds-animation-ease-bounce) forwards;
+    }
+
+    label {
+      @apply text-small font-bold uppercase;
+      color: var(--mds-color-secondary);
+      height: 40px;
+      width: 100%;
+      display: block;
+      padding: 20px 20px 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    /* assistive Text wrapper */
+    label span {
+      @apply font-normal normal-case pl-4;
+    }
+
+    input {
+      @apply text-body;
+      color: var(--mds-color-secondary);
+      background-color: transparent;
+      appearance: none;
+      width: 100%;
+      height: 40px;
+      padding: 0 20px 20px;
+      display: block;
+      border: none;
+      outline: none;
+    }
+
+    input::placeholder {
+      color: var(--mds-color-secondary);
+      opacity: 0.5;
+      font-size: 14px;
+    }
+
+    @keyframes slideIn {
+      0% {
+        width: 0;
+      }
+
+      100% {
+        width: 4px;
+      }
+    }
+  }
+}

--- a/packages/mds/src/tailwind/mx-block-wrapper/index.scss
+++ b/packages/mds/src/tailwind/mx-block-wrapper/index.scss
@@ -1,0 +1,8 @@
+.mx-block-wrapper {
+  .mx-block-wrapper-container {
+    @apply grid gap-0;
+    z-index: 0;
+    position: relative;
+    background-color: var(--mds-color-white);
+  }
+}

--- a/packages/mds/src/tailwind/mx-block-wrapper/index.scss
+++ b/packages/mds/src/tailwind/mx-block-wrapper/index.scss
@@ -2,6 +2,7 @@
   .mx-block-wrapper-container {
     @apply grid gap-0;
     z-index: 0;
+    padding: 0 1px 1px 0;
     position: relative;
     background-color: var(--mds-color-white);
   }

--- a/packages/mds/src/tailwind/styles.css
+++ b/packages/mds/src/tailwind/styles.css
@@ -18,36 +18,38 @@
 /***************************
 * Import Component CSS
 ***************************/
-@import './mx-input/index.scss';
-@import './mx-confirm-input/index.scss';
-@import './mx-search/index.scss';
-@import './mx-button/index.scss';
-@import './mx-icon-button/index.scss';
-@import './mx-toggle-button/index.scss';
-@import './mx-chip/index.scss';
-@import './mx-fab/index.scss';
-@import './mx-checkbox/index.scss';
-@import './mx-radio/index.scss';
-@import './mx-switch/index.scss';
-@import './mx-tooltip/index.scss';
-@import './mx-circular-progress/index.scss';
-@import './mx-linear-progress/index.scss';
-@import './mx-tab/index.scss';
-@import './mx-select/index.scss';
-@import './mx-dropdown-menu/index.scss';
-@import './mx-menu/index.scss';
-@import './mx-menu-item/index.scss';
-@import './mx-date-picker/index.scss';
-@import './mx-time-picker/index.scss';
-@import './mx-page-header/index.scss';
 @import './mx-banner/index.scss';
-@import './mx-dialog/index.scss';
-@import './mx-modal/index.scss';
-@import './mx-table/index.scss';
-@import './mx-pagination/index.scss';
-@import './mx-snackbar/index.scss';
-@import './mx-image-upload/index.scss';
+@import './mx-block-input/index.scss';
+@import './mx-block-wrapper/index.scss';
+@import './mx-button/index.scss';
+@import './mx-checkbox/index.scss';
+@import './mx-chip/index.scss';
+@import './mx-circular-progress/index.scss';
 @import './mx-code/index.scss';
+@import './mx-confirm-input/index.scss';
+@import './mx-date-picker/index.scss';
+@import './mx-dialog/index.scss';
+@import './mx-dropdown-menu/index.scss';
+@import './mx-fab/index.scss';
+@import './mx-icon-button/index.scss';
+@import './mx-image-upload/index.scss';
+@import './mx-input/index.scss';
+@import './mx-linear-progress/index.scss';
+@import './mx-menu-item/index.scss';
+@import './mx-menu/index.scss';
+@import './mx-modal/index.scss';
+@import './mx-page-header/index.scss';
+@import './mx-pagination/index.scss';
+@import './mx-radio/index.scss';
+@import './mx-search/index.scss';
+@import './mx-select/index.scss';
+@import './mx-snackbar/index.scss';
+@import './mx-switch/index.scss';
+@import './mx-tab/index.scss';
+@import './mx-table/index.scss';
+@import './mx-time-picker/index.scss';
+@import './mx-toggle-button/index.scss';
+@import './mx-tooltip/index.scss';
 
 @import './icons.scss';
 @import './ripple.scss';
@@ -111,6 +113,17 @@
       &:not(.my-0) {
         @apply mb-24;
       }
+    }
+    .text-small {
+      font-size: 0.75rem;
+      letter-spacing: 0;
+      line-height: 0.875rem;
+    }
+    .text-tooltip {
+      font-size: 0.6875rem;
+      letter-spacing: 0.1px;
+      font-weight: 700;
+      line-height: 0.875rem;
     }
     .text-h1 {
       font-size: 2.5rem;
@@ -249,16 +262,5 @@
       font-size: 0.75rem;
       @apply tracking-1-5 leading-4 font-normal uppercase;
     }
-  }
-  .text-small {
-    font-size: 0.75rem;
-    letter-spacing: 0;
-    line-height: 0.875rem;
-  }
-  .text-tooltip {
-    font-size: 0.6875rem;
-    letter-spacing: 0.1px;
-    font-weight: 700;
-    line-height: 0.875rem;
   }
 }

--- a/packages/mds/vuepress/.vuepress/config.js
+++ b/packages/mds/vuepress/.vuepress/config.js
@@ -7,10 +7,7 @@ module.exports = {
   description: description,
   base: '/mds/',
   dest: './docs',
-  extraWatchFiles: [
-    '.vuepress/public/components/*',
-    '.vuepress/public/styles/*',
-  ],
+  extraWatchFiles: ['.vuepress/public/components/*', '.vuepress/public/styles/*'],
   head: [
     ['meta', { name: 'theme-color', content: '#0457af' }],
     ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
@@ -149,6 +146,7 @@ module.exports = {
       '/components/': [
         'badges',
         'banners',
+        'block-inputs',
         'buttons',
         'charts',
         'chips',

--- a/packages/mds/vuepress/components/block-inputs.md
+++ b/packages/mds/vuepress/components/block-inputs.md
@@ -1,0 +1,69 @@
+# Block Inputs
+
+## Block Wrapper
+
+Block inputs should always be contained within the `mx-block-wrapper` component.
+
+Block Wrappers have a single attribute of `columns`
+
+## Block Input (text)
+
+The `mx-block-input` component...
+
+<br />
+<section class="mds">
+  <!-- #region block-inputs -->
+  <div class="grid grid-cols-1 gap-40">
+    <div>
+      <strong>Regular in 2 columns</strong>
+      <div class="my-20">
+        <mx-block-wrapper columns="2">
+          <mx-block-input label="Label" placeholder="Placeholder" />
+          <mx-block-input label="Label" placeholder="Placeholder" />
+        </mx-block-wrapper>
+      </div>
+      <strong>Regular in 3 columns</strong>
+      <div class="my-20">
+        <mx-block-wrapper columns="3">
+          <mx-block-input label="Label" placeholder="Placeholder" />
+          <mx-block-input label="Label" placeholder="Placeholder" />
+          <mx-block-input label="Label" placeholder="Placeholder" />
+          <mx-block-input label="Label" colspan="2" placeholder="Placeholder" />
+          <mx-block-input label="Label" placeholder="Placeholder" />
+        </mx-block-wrapper>
+      </div>
+      <strong>Disabled with assistive text</strong>
+      <div class="my-20">
+        <mx-block-wrapper>
+          <mx-block-input label="Label" assistive-text="Helpful text about input" disabled placeholder="Placeholder" />
+        </mx-block-wrapper>
+      </div>
+      <strong>Error</strong>
+      <div class="my-20">
+        <mx-block-wrapper>
+          <mx-block-input label="Label" assistive-text="Reason goes here" error placeholder="Placeholder" />
+        </mx-block-wrapper>
+      </div>
+    </div>
+  </div>
+  <!-- #endregion block-inputs -->
+</section>
+
+<<< @/vuepress/components/block-inputs.md#block-inputs
+
+### Properties
+
+| Property        | Attribute        | Description                                                                       | Type      | Default     |
+| --------------- | ---------------- | --------------------------------------------------------------------------------- | --------- | ----------- |
+| `assistiveText` | `assistive-text` |                                                                                   | `string`  | `undefined` |
+| `colspan`       | `colspan`        | Used to define the number of columns to span in the parent wrapper if more than 1 | `number`  | `undefined` |
+| `disabled`      | `disabled`       |                                                                                   | `boolean` | `false`     |
+| `error`         | `error`          |                                                                                   | `boolean` | `false`     |
+| `inputId`       | `input-id`       | The `id` attribute for the text input                                             | `string`  | `undefined` |
+| `label`         | `label`          | Text for the label element                                                        | `string`  | `undefined` |
+| `maxlength`     | `maxlength`      |                                                                                   | `number`  | `undefined` |
+| `name`          | `name`           | The `name` attribute for the text input                                           | `string`  | `undefined` |
+| `placeholder`   | `placeholder`    | Placeholder text for the input.                                                   | `string`  | `undefined` |
+| `readonly`      | `readonly`       |                                                                                   | `boolean` | `false`     |
+| `type`          | `type`           | The `type` attribute for the text input                                           | `string`  | `'text'`    |
+| `value`         | `value`          |                                                                                   | `string`  | `undefined` |

--- a/packages/mds/vuepress/components/block-inputs.md
+++ b/packages/mds/vuepress/components/block-inputs.md
@@ -4,11 +4,13 @@
 
 Block inputs should always be contained within the `mx-block-wrapper` component.
 
-Block Wrappers have a single attribute of `columns`
+Block Wrappers have a single (optional) attribute of `columns` which is used to define the number of grid columns to utilise in the layout. Note: these collapse on mobile viewport sizes.
 
 ## Block Input (text)
 
-The `mx-block-input` component...
+The `mx-block-input` component is used for standard `<input>` fields in the Mercury block input designs.
+
+It utilises a similar interface to the [`mx-input` component](/components/inputs.html) but also adds the optional `colspan` attribute to define the number of columns in the block wrapper to span if a value other than 1 is required.
 
 <br />
 <section class="mds">

--- a/packages/mds/vuepress/components/block-inputs.md
+++ b/packages/mds/vuepress/components/block-inputs.md
@@ -37,7 +37,7 @@ It utilises a similar interface to the [`mx-input` component](/components/inputs
       <strong>Disabled with assistive text</strong>
       <div class="my-20">
         <mx-block-wrapper>
-          <mx-block-input label="Label" assistive-text="Helpful text about input" disabled placeholder="Placeholder" />
+          <mx-block-input label="Label" assistive-text="Helpful text about input" disabled placeholder="Placeholder" value="This is the value" />
         </mx-block-wrapper>
       </div>
       <strong>Error</strong>


### PR DESCRIPTION
Initial commit for block input component.

Currently this implements the Block Wrapper (a basic styled grid utility used to contain block input components) and the basic input (think: `<input>` replacement)

Will look at how we can re-use as much of the key pieces for other input types (selects, etc) and keep things dry but wanted to get some feedback on this one first.

![image](https://github.com/moxiworks/mds/assets/1267217/905bc755-9f8c-4261-8f0e-9f1c398fde02)
