### PR TITLE
ENG-166245 - Fixed the prepublish script

### DIFF
--- a/packages/mds-angular/package.json
+++ b/packages/mds-angular/package.json
@@ -21,8 +21,7 @@
   },
   "scripts": {
     "build": "ng build",
-    "prepublish": "sh scripts/delete-output.sh",
-    "prepack": "sh scripts/delete-output.sh"
+    "prepublish": "sh scripts/delete-output.sh"
   },
   "dependencies": {
     "@angular/core": "^16.1.0",

--- a/packages/mds-angular/scripts/delete-output.sh
+++ b/packages/mds-angular/scripts/delete-output.sh
@@ -5,5 +5,5 @@ set -eu
 # ng-packagr outputs a custom package.json and README.md.
 # Since we are using lerna workspaces, I want to use my own customised package.json.
 # I can't stop ng from creating one, so I just delete the file
-rm dist/package.json
-rm dist/README.md
+rm -f dist/package.json
+rm -f dist/README.md


### PR DESCRIPTION
`ng`, the angular cli, builds a package.json into dist. I've chosen to ignore it and delete the file.

I did this incorrectly though as prepublish and prepack both run on publish. So by the time the 2nd ran, the file was deleted and it'd error.

So now the -f flag is used to ignore deleted files, and I removed the prepack cause it's not necessary